### PR TITLE
Update and rename oe.toml to komaeda.toml

### DIFF
--- a/people/komaeda.toml
+++ b/people/komaeda.toml
@@ -1,0 +1,4 @@
+name = "Olivia Hugger"
+github = "komaeda"
+irc = "liv"
+email = "819880950@qq.com"

--- a/people/oe.toml
+++ b/people/oe.toml
@@ -1,4 +1,0 @@
-name = "Olivia Hugger"
-github = "oe"
-irc = "liv"
-email = "olivia@fastmail.com"


### PR DESCRIPTION
`oe` has been deleted and this is my account now. This was already on the website before the structure update, not sure why it got reverted?