### PR TITLE
Add Rust By Example

### DIFF
--- a/people/marioidival.toml
+++ b/people/marioidival.toml
@@ -1,0 +1,4 @@
+name = "Mário Idival"
+github = "marioidival"
+irc = "marioidival"
+email = "marioidival@gmail.com"

--- a/people/projektir.toml
+++ b/people/projektir.toml
@@ -1,0 +1,2 @@
+name = "projektir"
+github = "projektir"

--- a/people/projektir.toml
+++ b/people/projektir.toml
@@ -1,3 +1,0 @@
-name = "projektir"
-github = "projektir"
-email = false

--- a/people/projektir.toml
+++ b/people/projektir.toml
@@ -1,2 +1,3 @@
 name = "projektir"
 github = "projektir"
+email = false

--- a/teams/docs.toml
+++ b/teams/docs.toml
@@ -23,3 +23,7 @@ extra-teams = ["reference"]
 [[lists]]
 address = "doc-team@rust-lang.org"
 extra-teams = ["reference"]
+
+[[lists]]
+address = "doc-team@rust-lang.org"
+extra-teams = ["rust-by-example"]

--- a/teams/rust-by-example.toml
+++ b/teams/rust-by-example.toml
@@ -6,7 +6,6 @@ leads = ["steveklabnik"]
 members = [
     "steveklabnik",
     "marioidival",
-    "projektir",
 ]
 
 [website]

--- a/teams/rust-by-example.toml
+++ b/teams/rust-by-example.toml
@@ -10,4 +10,4 @@ members = [
 
 [website]
 name = "Rust by Example team"
-description = "working on the rust by example"
+description = "maintaining and updating Rust By Example"

--- a/teams/rust-by-example.toml
+++ b/teams/rust-by-example.toml
@@ -1,0 +1,14 @@
+name = "rust-by-example"
+subteam-of = "docs"
+
+[people]
+leads = ["steveklabnik"]
+members = [
+    "steveklabnik",
+    "marioidival",
+    "projektir",
+]
+
+[website]
+name = "Rust by Example team"
+description = "working on the rust by example"


### PR DESCRIPTION
Add missing information of Rust By Example on team references

[old site](https://prev.rust-lang.org/en-US/team.html#Documentation-peers)
https://github.com/rust-lang/rust/blob/master/src/tools/publish_toolstate.py#L24