### PR TITLE
stop brson, alercah from getting mail

### DIFF
--- a/people/alercah.toml
+++ b/people/alercah.toml
@@ -1,3 +1,5 @@
 name = "Alexis Hunt"
 github = "alercah"
-email = "alercah@gmail.com"
+# email = "alercah@gmail.com"
+email = false
+

--- a/people/brson.toml
+++ b/people/brson.toml
@@ -1,3 +1,5 @@
 name = "Brian Anderson"
 github = "brson"
-email = "andersrb@gmail.com"
+# email = "andersrb@gmail.com"
+email = false
+

--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -5,6 +5,7 @@ leads = []
 members = [
     "Gankro",
     "aatch",
+    "alercah",
     "arielb1",
     "bkoropoff",
     "booyaa",

--- a/teams/reference.toml
+++ b/teams/reference.toml
@@ -6,7 +6,6 @@ leads = ["Havvy"]
 members = [
     "Havvy",
     "matthewjasper",
-    "alercah",
 ]
 
 [website]


### PR DESCRIPTION
Per their requests, this should stop them from getting mail from the `all@` mailing list:

- clear the e-mail fields from their people files
- in the case of @alercah, move from reference to alumni (I believe this is correct)

(cc @brson, @alercah, @steveklabnik) 