### PR TITLE
Import bors permissions

### DIFF
--- a/people/Aaronepower.toml
+++ b/people/Aaronepower.toml
@@ -1,3 +1,6 @@
 name = "Aaron Power"
 github = "Aaronepower"
 email = "theaaronepower@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/Aatch.toml
+++ b/people/Aatch.toml
@@ -1,0 +1,6 @@
+name = "James Miller"
+github = "Aatch"
+email = "james@aatch.net"
+
+[permissions]
+bors.rust.review = true

--- a/people/Amanieu.toml
+++ b/people/Amanieu.toml
@@ -1,3 +1,6 @@
 name = "Amanieu d'Antras"
 github = "Amanieu"
 email = "amanieu@gmail.com"
+
+[permissions]
+bors.compiler_builtins.review = true

--- a/people/BurntSushi.toml
+++ b/people/BurntSushi.toml
@@ -2,3 +2,6 @@ name = "Andrew Gallant"
 github = "BurntSushi"
 irc = "burntsushi"
 email = "jamslam@gmail.com"
+
+[permissions]
+bors.regex.review = true

--- a/people/Diggsey.toml
+++ b/people/Diggsey.toml
@@ -1,0 +1,5 @@
+name = "Diggory Blake"
+github = "Diggsey"
+
+[permissions]
+bors.rustup_rs.review = true

--- a/people/Eh2406.toml
+++ b/people/Eh2406.toml
@@ -1,3 +1,3 @@
 name = "Jacob Finkelman"
-github = "eh2406"
+github = "Eh2406"
 email = "eh2406@wayne.edu"

--- a/people/Manishearth.toml
+++ b/people/Manishearth.toml
@@ -1,3 +1,6 @@
 name = "Manish Goregaokar"
 github = "Manishearth"
 email = "manishsmail@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/Mark-Simulacrum.toml
+++ b/people/Mark-Simulacrum.toml
@@ -2,3 +2,6 @@ name = "Mark Rousskov"
 github = "Mark-Simulacrum"
 irc = "simulacrum"
 email = "mark.simulacrum@gmail.com"
+
+[permissions]
+bors.cargo.review = true

--- a/people/RalfJung.toml
+++ b/people/RalfJung.toml
@@ -3,3 +3,4 @@ github = "RalfJung"
 
 [permissions]
 perf = true
+bors.rust.review = true

--- a/people/Xanewok.toml
+++ b/people/Xanewok.toml
@@ -4,3 +4,5 @@ email = "xanewok@gmail.com"
 
 [permissions]
 perf = true
+bors.rust.review = true
+bors.rls.review = true

--- a/people/aatch.toml
+++ b/people/aatch.toml
@@ -1,3 +1,0 @@
-name = "James Miller"
-github = "aatch"
-email = "james@aatch.net"

--- a/people/alexcrichton.toml
+++ b/people/alexcrichton.toml
@@ -2,3 +2,8 @@ name = "Alex Crichton"
 github = "alexcrichton"
 irc = "acrichto"
 email = "acrichton@mozilla.com"
+
+[permissions]
+bors.libc.review = true
+bors.rustup_rs.review = true
+bors.compiler_builtins.review = true

--- a/people/alexheretic.toml
+++ b/people/alexheretic.toml
@@ -1,3 +1,6 @@
 name = "Alex Butler"
 github = "alexheretic"
 email = "alexheretic@gmail.com"
+
+[permissions]
+bors.rls.review = true

--- a/people/alexreg.toml
+++ b/people/alexreg.toml
@@ -1,0 +1,5 @@
+name = "Alexander Regueiro"
+github = "alexreg"
+
+[permissions]
+bors.rust.review = true

--- a/people/apasel422.toml
+++ b/people/apasel422.toml
@@ -1,0 +1,5 @@
+name = "Andrew Paseltiner"
+github = "apasel422"
+
+[permissions]
+bors.rust.review = true

--- a/people/arielb1.toml
+++ b/people/arielb1.toml
@@ -1,3 +1,6 @@
 name = "Ariel Ben-Yehuda"
 github = "arielb1"
 email = "ariel.byd@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/birkenfeld.toml
+++ b/people/birkenfeld.toml
@@ -1,0 +1,5 @@
+name = "Georg Brandl"
+github = "birkenfeld"
+
+[permissions]
+bors.clippy.review = true

--- a/people/bkoropoff.toml
+++ b/people/bkoropoff.toml
@@ -1,3 +1,6 @@
 name = "Brian Koropoff"
 github = "bkoropoff"
 email = "bkoropoff@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/bluss.toml
+++ b/people/bluss.toml
@@ -1,0 +1,5 @@
+name = "bluss"
+github = "bluss"
+
+[permissions]
+bors.rust.review = true

--- a/people/bstrie.toml
+++ b/people/bstrie.toml
@@ -1,3 +1,6 @@
 name = "Ben Striegel"
 github = "bstrie"
 email = "ben.striegel@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/carols10cents.toml
+++ b/people/carols10cents.toml
@@ -1,3 +1,6 @@
 name = "Carol Nichols"
 github = "carols10cents"
 email = "carol.nichols@gmail.com"
+
+[permissions]
+bors.crates_io.review = true

--- a/people/cmr.toml
+++ b/people/cmr.toml
@@ -1,0 +1,5 @@
+name = "Corey Richardson"
+github = "cmr"
+
+[permissions]
+bors.rust.review = true

--- a/people/davidtwco.toml
+++ b/people/davidtwco.toml
@@ -2,4 +2,5 @@ name = "David Wood"
 github = "davidtwco"
 
 [permissions]
+bors.rust.review = true
 perf = true

--- a/people/dotdash.toml
+++ b/people/dotdash.toml
@@ -2,3 +2,6 @@ name = "Björn Steinbrink"
 github = "dotdash"
 irc = "doener"
 email = "bsteinbr@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/est31.toml
+++ b/people/est31.toml
@@ -1,0 +1,5 @@
+name = "est31"
+github = "est31"
+
+[permissions]
+bors.rust.try = true

--- a/people/fitzgen.toml
+++ b/people/fitzgen.toml
@@ -1,3 +1,6 @@
 name = "Nick Fitzgerald"
 github = "fitzgen"
 email = "nfitzgerald@mozilla.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/flaper87.toml
+++ b/people/flaper87.toml
@@ -1,0 +1,5 @@
+name = "Flavio Percoco"
+github = "flaper87"
+
+[permissions]
+bors.rust.review = true

--- a/people/flip1995.toml
+++ b/people/flip1995.toml
@@ -1,0 +1,5 @@
+name = "Philipp Krones"
+github = "flip1995"
+
+[permissions]
+bors.clippy.review = true

--- a/people/gnzlbg.toml
+++ b/people/gnzlbg.toml
@@ -1,0 +1,5 @@
+name = "gnzlbg"
+github = "gnzlbg"
+
+[permissions]
+bors.libc.review = true

--- a/people/huonw.toml
+++ b/people/huonw.toml
@@ -2,3 +2,6 @@ name = "Huon Wilson"
 github = "huonw"
 irc = "huon"
 email = "dbau.pp@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/japaric.toml
+++ b/people/japaric.toml
@@ -1,3 +1,7 @@
 name = "Jorge Aparicio"
 github = "japaric"
 email = "jorge@japaric.io"
+
+[permissions]
+bors.compiler_builtins.review = true
+bors.rust.review = true

--- a/people/jdm.toml
+++ b/people/jdm.toml
@@ -1,0 +1,5 @@
+name = "Josh Matthews"
+github = "jdm"
+
+[permissions]
+bors.rust.review = true

--- a/people/jonathandturner.toml
+++ b/people/jonathandturner.toml
@@ -2,3 +2,6 @@ name = "Jonathan Turner"
 github = "jonathandturner"
 irc = "jntrnr"
 email = "jonathan.d.turner@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/jroesch.toml
+++ b/people/jroesch.toml
@@ -1,0 +1,5 @@
+name = "Jared Roesch"
+github = "jroesch"
+
+[permissions]
+bors.rust.review = true

--- a/people/jseyfried.toml
+++ b/people/jseyfried.toml
@@ -2,3 +2,6 @@ name = "Jeffrey Seyfried"
 github = "jseyfried"
 irc = "jseyfried"
 email = "jeffrey.seyfried@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/jtgeibel.toml
+++ b/people/jtgeibel.toml
@@ -1,3 +1,6 @@
 name = "Justin Geibel"
 github = "jtgeibel"
 email = "jtgeibel@gmail.com"
+
+[permissions]
+bors.crates_io.review = true

--- a/people/killercup.toml
+++ b/people/killercup.toml
@@ -1,3 +1,6 @@
 name = "Pascal Hertleif"
 github = "killercup"
 email = "killercup@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/lilyball.toml
+++ b/people/lilyball.toml
@@ -1,0 +1,5 @@
+name = "Lily Ballard"
+github = "lilyball"
+
+[permissions]
+bors.rust.review = true

--- a/people/ljedrz.toml
+++ b/people/ljedrz.toml
@@ -1,0 +1,5 @@
+name = "ljedrz"
+github = "ljedrz"
+
+[permissions]
+bors.rust.try = true

--- a/people/luqmana.toml
+++ b/people/luqmana.toml
@@ -1,0 +1,5 @@
+name = "Luqman Aden"
+github = "luqmana"
+
+[permissions]
+bors.rust.review = true

--- a/people/malbarbo.toml
+++ b/people/malbarbo.toml
@@ -1,0 +1,5 @@
+name = "Marco A L Barbosa"
+github = "malbarbo"
+
+[permissions]
+bors.libc.review = true

--- a/people/matklad.toml
+++ b/people/matklad.toml
@@ -1,3 +1,6 @@
 name = "Aleksey Kladov"
 github = "matklad"
 email = "aleksey.kladov@gmail.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/matthewjasper.toml
+++ b/people/matthewjasper.toml
@@ -4,3 +4,4 @@ email = "mjjasper1@gmail.com"
 
 [permissions]
 crater = true
+bors.rust.review = true

--- a/people/matthiaskrgr.toml
+++ b/people/matthiaskrgr.toml
@@ -1,0 +1,5 @@
+name = "Matthias Krüger"
+github = "matthiaskrgr"
+
+[permissions]
+bors.clippy.review = true

--- a/people/mcarton.toml
+++ b/people/mcarton.toml
@@ -1,0 +1,5 @@
+name = "Martin Carton"
+github = "mcarton"
+
+[permissions]
+bors.clippy.review = true

--- a/people/mikerite.toml
+++ b/people/mikerite.toml
@@ -1,0 +1,5 @@
+name = "mikerite"
+github = "mikerite"
+
+[permissions]
+bors.clippy.review = true

--- a/people/nikic.toml
+++ b/people/nikic.toml
@@ -1,0 +1,5 @@
+name = "Nikita Popov"
+github = "nikic"
+
+[permissions]
+bors.rust.review = true

--- a/people/nnethercote.toml
+++ b/people/nnethercote.toml
@@ -3,3 +3,4 @@ github = "nnethercote"
 
 [permissions]
 perf = true
+bors.rust.review = true

--- a/people/nox.toml
+++ b/people/nox.toml
@@ -1,3 +1,6 @@
 name = "Anthony Ramine"
 github = "nox"
 email = "n.oxyde@gmail.com"
+
+[permissions]
+bors.rust.try = true

--- a/people/nrc.toml
+++ b/people/nrc.toml
@@ -1,3 +1,8 @@
 name = "Nick Cameron"
 github = "nrc"
 email = "nrc@ncameron.org"
+
+[permissions]
+bors.rust.review = true
+bors.rustup_rs.review = true
+bors.rls.review = true

--- a/people/pcwalton.toml
+++ b/people/pcwalton.toml
@@ -1,3 +1,6 @@
 name = "Patrick Walton"
 github = "pcwalton"
 email = "pcwalton@mimiga.net"
+
+[permissions]
+bors.rust.review = true

--- a/people/phansch.toml
+++ b/people/phansch.toml
@@ -1,0 +1,5 @@
+name = "Philipp Hansch"
+github = "phansch"
+
+[permissions]
+bors.clippy.review = true

--- a/people/rkruppe.toml
+++ b/people/rkruppe.toml
@@ -1,0 +1,5 @@
+name = "Robin Kruppe"
+github = "rkruppe"
+
+[permissions]
+bors.rust.review = true

--- a/people/sanxiyn.toml
+++ b/people/sanxiyn.toml
@@ -1,0 +1,5 @@
+name = "Seo Sanghyeon"
+github = "sanxiyn"
+
+[permissions]
+bors.rust.review = true

--- a/people/scalexm.toml
+++ b/people/scalexm.toml
@@ -1,0 +1,5 @@
+name = "Alexandre Martin"
+github = "scalexm"
+
+[permissions]
+bors.rust.review = true

--- a/people/sgrif.toml
+++ b/people/sgrif.toml
@@ -1,3 +1,6 @@
 name = "Sean Griffin"
 github = "sgrif"
 email = "sean@seantheprogrammer.com"
+
+[permissions]
+bors.crates_io.review = true

--- a/people/steveklabnik.toml
+++ b/people/steveklabnik.toml
@@ -1,3 +1,6 @@
 name = "Steve Klabnik"
 github = "steveklabnik"
 email = "steve@steveklabnik.com"
+
+[permissions]
+bors.cargo.review = true

--- a/people/tmandry.toml
+++ b/people/tmandry.toml
@@ -1,0 +1,5 @@
+name = "Tyler Mandry"
+github = "tmandry"
+
+[permissions]
+bors.rust.review = true

--- a/people/tomprince.toml
+++ b/people/tomprince.toml
@@ -1,3 +1,6 @@
 name = "Tom Prince"
 github = "tomprince"
 email = "tom.prince@twistedmatrix.com"
+
+[permissions]
+bors.rust.review = true

--- a/people/tromey.toml
+++ b/people/tromey.toml
@@ -1,0 +1,5 @@
+name = "Tom Tromey"
+github = "tromey"
+
+[permissions]
+bors.rust.review = true

--- a/people/vadimcn.toml
+++ b/people/vadimcn.toml
@@ -1,0 +1,5 @@
+name = "vadimcn"
+github = "vadimcn"
+
+[permissions]
+bors.rust.review = true

--- a/people/wesleywiser.toml
+++ b/people/wesleywiser.toml
@@ -1,0 +1,5 @@
+name = "Wesley Wiser"
+github = "wesleywiser"
+
+[permissions]
+bors.rust.review = true

--- a/people/zackmdavis.toml
+++ b/people/zackmdavis.toml
@@ -1,0 +1,5 @@
+name = "Zack M. Davis"
+github = "zackmdavis"
+
+[permissions]
+bors.rust.review = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,10 @@ fn run() -> Result<(), Error> {
             if !crate::schema::Permissions::AVAILABLE.contains(&name.as_str()) {
                 failure::bail!("unknown permission: {}", name);
             }
-            let allowed = crate::permissions::allowed_github_users(&data, name)?;
+            let mut allowed = crate::permissions::allowed_github_users(&data, name)?
+                .into_iter()
+                .collect::<Vec<_>>();
+            allowed.sort();
             for github_username in &allowed {
                 println!("{}", github_username);
             }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -74,6 +74,10 @@ macro_rules! permissions {
             ];
 
             pub(crate) fn has(&self, permission: &str) -> bool {
+                self.has_directly(permission) || self.has_indirectly(permission)
+            }
+
+            pub(crate) fn has_directly(&self, permission: &str) -> bool {
                 $(
                     if permission == stringify!($boolean) {
                         return self.$boolean;
@@ -83,10 +87,17 @@ macro_rules! permissions {
                     if permission == concat!("bors.", stringify!($bors), ".review") {
                         return self.bors.$bors.review;
                     }
+                    if permission == concat!("bors.", stringify!($bors), ".try") {
+                        return self.bors.$bors.try_
+                    }
                 )*
+                false
+            }
+
+            pub fn has_indirectly(&self, permission: &str) -> bool {
                 $(
                     if permission == concat!("bors.", stringify!($bors), ".try") {
-                        return self.bors.$bors.try_ || self.bors.$bors.review;
+                        return self.bors.$bors.review;
                     }
                 )*
                 false

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,5 +1,5 @@
 use crate::data::Data;
-use failure::{Error, bail};
+use failure::{bail, Error};
 use std::collections::HashSet;
 
 macro_rules! permissions {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,5 @@
 use crate::data::Data;
+pub(crate) use crate::permissions::Permissions;
 use failure::{bail, err_msg, Error};
 use std::collections::HashSet;
 
@@ -216,11 +217,6 @@ struct TeamPeople {
     #[serde(default = "default_false")]
     include_all_team_members: bool,
 }
-
-permissions!(pub(crate) struct Permissions {
-    perf,
-    crater,
-});
 
 pub(crate) struct DiscordInvite<'a> {
     pub(crate) url: &'a str,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -4,21 +4,28 @@ use failure::{bail, ensure, Error};
 use regex::Regex;
 use std::collections::HashSet;
 
+static CHECKS: &[fn(&Data, &mut Vec<String>)] = &[
+    validate_wg_names,
+    validate_subteam_of,
+    validate_team_leads,
+    validate_team_members,
+    validate_inactive_members,
+    validate_list_email_addresses,
+    validate_list_extra_people,
+    validate_list_extra_teams,
+    validate_list_addresses,
+    validate_people_addresses,
+    validate_discord_name,
+    validate_duplicate_permissions,
+    validate_permissions,
+];
+
 pub(crate) fn validate(data: &Data) -> Result<(), Error> {
     let mut errors = Vec::new();
 
-    validate_wg_names(data, &mut errors);
-    validate_subteam_of(data, &mut errors);
-    validate_team_leads(data, &mut errors);
-    validate_team_members(data, &mut errors);
-    validate_inactive_members(data, &mut errors);
-    validate_list_email_addresses(data, &mut errors);
-    validate_list_extra_people(data, &mut errors);
-    validate_list_extra_teams(data, &mut errors);
-    validate_list_addresses(data, &mut errors);
-    validate_people_addresses(data, &mut errors);
-    validate_discord_name(data, &mut errors);
-    validate_duplicate_permissions(data, &mut errors);
+    for check in CHECKS {
+        check(data, &mut errors);
+    }
 
     if !errors.is_empty() {
         errors.sort();
@@ -256,6 +263,18 @@ fn validate_duplicate_permissions(data: &Data, errors: &mut Vec<String>) {
             }
             Ok(())
         });
+        Ok(())
+    });
+}
+
+/// Ensure the permissions are valid
+fn validate_permissions(data: &Data, errors: &mut Vec<String>) {
+    wrapper(data.teams(), errors, |team, _| {
+        team.permissions().validate(format!("team `{}`", team.name()))?;
+        Ok(())
+    });
+    wrapper(data.people(), errors, |person, _| {
+        person.permissions().validate(format!("user `{}`", person.github()))?;
         Ok(())
     });
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -250,7 +250,9 @@ fn validate_duplicate_permissions(data: &Data, errors: &mut Vec<String>) {
         wrapper(team.members(&data)?.iter(), errors, |member, _| {
             if let Some(person) = data.person(member) {
                 for permission in Permissions::AVAILABLE {
-                    if team.permissions().has(permission) && person.permissions().has(permission) {
+                    if team.permissions().has(permission)
+                        && person.permissions().has_directly(permission)
+                    {
                         bail!(
                             "user `{}` has the permission `{}` both explicitly and through \
                              the `{}` team",

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -270,11 +270,14 @@ fn validate_duplicate_permissions(data: &Data, errors: &mut Vec<String>) {
 /// Ensure the permissions are valid
 fn validate_permissions(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, |team, _| {
-        team.permissions().validate(format!("team `{}`", team.name()))?;
+        team.permissions()
+            .validate(format!("team `{}`", team.name()))?;
         Ok(())
     });
     wrapper(data.people(), errors, |person, _| {
-        person.permissions().validate(format!("user `{}`", person.github()))?;
+        person
+            .permissions()
+            .validate(format!("user `{}`", person.github()))?;
         Ok(())
     });
 }

--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -4,7 +4,7 @@ name = "alumni"
 leads = []
 members = [
     "Gankro",
-    "aatch",
+    "Aatch",
     "alercah",
     "arielb1",
     "bkoropoff",

--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -6,13 +6,16 @@ leads = ["nrc"]
 members = [
     "alexcrichton",
     "dwijnand",
-    "eh2406",
+    "Eh2406",
     "ehuss",
     "joshtriplett",
     "nrc",
     "withoutboats",
     "wycats",
 ]
+
+[permissions]
+bors.cargo.review = true
 
 [website]
 name = "Cargo team"

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -10,6 +10,9 @@ members = [
     "oli-obk",
 ]
 
+[permissions]
+bors.clippy.review = true
+
 [website]
 name = "Clippy"
 description = "design and implementation of the Clippy linter"

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -19,6 +19,7 @@ members = [
 [permissions]
 perf = true
 crater = true
+bors.rust.review = true
 
 [website]
 name = "Compiler team"

--- a/teams/core.toml
+++ b/teams/core.toml
@@ -13,6 +13,9 @@ members = [
     "wycats",
 ]
 
+[permissions]
+bors.rust.review = true
+
 [website]
 name = "Core team"
 description = "Direction of the project, subteam leadership, cross-cutting concerns."

--- a/teams/docs.toml
+++ b/teams/docs.toml
@@ -11,6 +11,9 @@ members = [
     "celaus",
 ]
 
+[permissions]
+bors.rust.review = true
+
 [website]
 page = "documentation"
 name = "Documentation team"

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -19,6 +19,8 @@ members = [
 [permissions]
 perf = true
 crater = true
+bors.rust.review = true
+bors.crater.review = true
 
 [website]
 name = "Infrastructure team"

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -16,6 +16,7 @@ members = [
 
 [permissions]
 perf = true
+bors.rust.review = true
 
 [website]
 name = "Language team"

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -18,6 +18,7 @@ members = [
 [permissions]
 perf = true
 crater = true
+bors.rust.review = true
 
 [website]
 page = "library"

--- a/teams/release.toml
+++ b/teams/release.toml
@@ -22,6 +22,7 @@ members = [
 
 [permissions]
 crater = true
+bors.rust.try = true
 
 [website]
 name = "Release team"

--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -12,6 +12,7 @@ members = [
 
 [permissions]
 crater = true
+bors.rust.review = true
 
 [website]
 name = "Rustdoc team"


### PR DESCRIPTION
This PR adds support for bors permissions in the schema and imports the current ones. The permissions are the same as the current `homu.toml.template`, with those exceptions:

* @ashleygwilliams gains review access to rustc since she's on the core team.
* @sgrif gains review access to rustc since he's on the infra team.
* @onur gains review access to rustc since they're on the rustdoc team.
* @rylev and @celaus gains review access to rustc since they're on the docs team.
* The whole infra team is allowed to review Crater PRs, instead of just Aidan, Mark and me.
* @killercup gains review access to clippy since he's in the clippy team.

Synchronization with the bors config is not yet implemented, but I plan to write that soon.