### PR TITLE
Add discord moderation subteam, fix mods mailing list

### DIFF
--- a/people/Khionu.toml
+++ b/people/Khionu.toml
@@ -1,0 +1,4 @@
+name = "Khionu Sybiern"
+github = "Khionu"
+email = "dev@khionu.net"
+

--- a/people/notriddle.toml
+++ b/people/notriddle.toml
@@ -1,0 +1,3 @@
+name = "Michael Howell"
+github = "notriddle"
+email = "notriddle+rust-mod@protonmail.com"

--- a/teams/mods-discord.toml
+++ b/teams/mods-discord.toml
@@ -5,7 +5,7 @@ subteam-of = "mods"
 leads = []
 members = [
     "komaeda",
-    "centril",
+    "Centril",
     "Khionu",
     "sgrif",
     "technetos",
@@ -14,4 +14,7 @@ members = [
 
 [website]
 name = "Discord moderators"
-description = "Moderating the Discord channel"
+description = "Moderating the Discord server"
+
+[[lists]]
+address = "discord-mods@rust-lang.org"

--- a/teams/mods-discord.toml
+++ b/teams/mods-discord.toml
@@ -1,0 +1,17 @@
+name = "mods-discord"
+subteam-of = "mods"
+
+[people]
+leads = []
+members = [
+    "komaeda",
+    "centril",
+    "Khionu",
+    "sgrif",
+    "technetos",
+    "pietroalbini",
+]
+
+[website]
+name = "Discord moderators"
+description = "Moderating the Discord channel"

--- a/teams/mods-discourse.toml
+++ b/teams/mods-discourse.toml
@@ -1,0 +1,16 @@
+name = "mods-discourse"
+subteam-of = "mods"
+
+[people]
+leads = []
+members = [
+    "notriddle",
+    "mbrubeck",
+]
+
+[website]
+name = "Discourse moderators"
+description = "Moderating users.rust-lang.org and internals.rust-lang.org"
+
+[[lists]]
+address = "discourse-mods@rust-lang.org"

--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -21,3 +21,9 @@ address = "rust-mods@rust-lang.org"
 
 [[lists]]
 address = "mods@rust-lang.org"
+
+[[lists]]
+address = "mods-all@rust-lang.org"
+extra-teams = [
+    "mods-discord",
+]

--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -18,7 +18,6 @@ email = "rust-mods@rust-lang.org"
 
 [[lists]]
 address = "rust-mods@rust-lang.org"
-include-team-members = false
-extra-emails = [
-    "rust-mods@googlegroups.com"
-]
+
+[[lists]]
+address = "mods@rust-lang.org"

--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -27,3 +27,4 @@ address = "mods-all@rust-lang.org"
 extra-teams = [
     "mods-discord",
 ]
+extra-people = ["Manishearth"] # Temporary, while we focus on trying to improve moderation and stuff

--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -26,5 +26,6 @@ address = "mods@rust-lang.org"
 address = "mods-all@rust-lang.org"
 extra-teams = [
     "mods-discord",
+    "mods-discourse",
 ]
 extra-people = ["Manishearth"] # Temporary, while we focus on trying to improve moderation and stuff


### PR DESCRIPTION
This adds a subteam to the mod team for Discord moderation. It also moves the mod team off the old Google Group and onto using a regular Rust mailing list, so as to centralize everything into the teams repo.

r? @rust-lang/moderation