### PR TITLE
Add rfcbot data to the Team API

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -64,3 +64,15 @@ pub struct Lists {
 pub struct Permission {
     pub github_users: Vec<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rfcbot {
+    pub teams: IndexMap<String, RfcbotTeam>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RfcbotTeam {
+    pub name: String,
+    pub ping: String,
+    pub members: Vec<String>,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -103,6 +103,7 @@ pub(crate) struct Team {
     people: TeamPeople,
     #[serde(default)]
     permissions: Permissions,
+    rfcbot: Option<RfcbotData>,
     website: Option<WebsiteData>,
     #[serde(default)]
     lists: Vec<TeamList>,
@@ -123,6 +124,10 @@ impl Team {
 
     pub(crate) fn leads(&self) -> HashSet<&str> {
         self.people.leads.iter().map(|s| s.as_str()).collect()
+    }
+
+    pub(crate) fn rfcbot_data(&self) -> Option<&RfcbotData> {
+        self.rfcbot.as_ref()
     }
 
     pub(crate) fn website_data(&self) -> Option<&WebsiteData> {
@@ -216,6 +221,14 @@ struct TeamPeople {
     include_wg_leads: bool,
     #[serde(default = "default_false")]
     include_all_team_members: bool,
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) struct RfcbotData {
+    pub(crate) label: String,
+    pub(crate) name: String,
+    pub(crate) ping: String,
 }
 
 pub(crate) struct DiscordInvite<'a> {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -18,6 +18,7 @@ static CHECKS: &[fn(&Data, &mut Vec<String>)] = &[
     validate_discord_name,
     validate_duplicate_permissions,
     validate_permissions,
+    validate_rfcbot_labels,
 ];
 
 pub(crate) fn validate(data: &Data) -> Result<(), Error> {
@@ -280,6 +281,19 @@ fn validate_permissions(data: &Data, errors: &mut Vec<String>) {
         person
             .permissions()
             .validate(format!("user `{}`", person.github()))?;
+        Ok(())
+    });
+}
+
+/// Ensure there are no duplicate rfcbot labels
+fn validate_rfcbot_labels(data: &Data, errors: &mut Vec<String>) {
+    let mut labels = HashSet::new();
+    wrapper(data.teams(), errors, move |team, errors| {
+        if let Some(rfcbot) = team.rfcbot_data() {
+            if !labels.insert(rfcbot.label.clone()) {
+                errors.push(format!("duplicate rfcbot label: {}", rfcbot.label));
+            }
+        }
         Ok(())
     });
 }

--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -17,6 +17,11 @@ members = [
 [permissions]
 bors.cargo.review = true
 
+[rfcbot]
+label = "T-cargo"
+name = "Cargo"
+ping = "rust-lang/cargo"
+
 [website]
 name = "Cargo team"
 description = "design and implementation of Cargo"

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -21,6 +21,11 @@ perf = true
 crater = true
 bors.rust.review = true
 
+[rfcbot]
+label = "T-compiler"
+name = "Compiler"
+ping = "rust-lang/compiler"
+
 [website]
 name = "Compiler team"
 description = "compiler internals, optimizations"

--- a/teams/core.toml
+++ b/teams/core.toml
@@ -17,6 +17,11 @@ members = [
 [permissions]
 bors.rust.review = true
 
+[rfcbot]
+label = "T-core"
+name = "Core"
+ping = "rust-lang/core"
+
 [website]
 name = "Core team"
 description = "Direction of the project, subteam leadership, cross-cutting concerns."

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -13,6 +13,11 @@ members = [
     "steveklabnik",
 ]
 
+[rfcbot]
+label = "T-crates-io"
+name = "Crates.io"
+ping = "rust-lang/crates-io"
+
 [website]
 name = "Crates.io team"
 description = "management of operations, development, and policies for crates.io"

--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -4,6 +4,11 @@ name = "devtools"
 leads = ["killercup", "Manishearth"]
 members = ["killercup", "Manishearth", "Xanewok", "fitzgen", "GuillaumeGomez", "oli-obk", "dwijnand"]
 
+[rfcbot]
+label = "T-dev-tools"
+name = "Dev tols"
+ping = "rust-lang/dev-tools"
+
 [website]
 page = "dev-tools"
 name = "Dev tools team"

--- a/teams/docs.toml
+++ b/teams/docs.toml
@@ -14,6 +14,11 @@ members = [
 [permissions]
 bors.rust.review = true
 
+[rfcbot]
+label = "T-doc"
+name = "Documentation"
+ping = "rust-lang/docs"
+
 [website]
 page = "documentation"
 name = "Documentation team"

--- a/teams/ides.toml
+++ b/teams/ides.toml
@@ -14,6 +14,11 @@ members = [
     "Xanewok",
 ]
 
+[rfcbot]
+label = "T-IDEs"
+name = "IDEs and editors"
+ping = "rust-lang/ides"
+
 [website]
 name = "IDEs and editors team"
 description = "IDEs, editors, and supporting tools such as Racer and the RLS"

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -22,6 +22,11 @@ crater = true
 bors.rust.review = true
 bors.crater.review = true
 
+[rfcbot]
+label = "T-infra"
+name = "Infrastructure"
+ping = "rust-lang/infra"
+
 [website]
 name = "Infrastructure team"
 description = "infrastructure supporting the Rust project itself: CI, releases, bots, metrics"

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -18,6 +18,11 @@ members = [
 perf = true
 bors.rust.review = true
 
+[rfcbot]
+label = "T-lang"
+name = "Language"
+ping = "rust-lang/lang"
+
 [website]
 name = "Language team"
 description = "designing new language features"

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -20,6 +20,11 @@ perf = true
 crater = true
 bors.rust.review = true
 
+[rfcbot]
+label = "T-libs"
+name = "Libraries"
+ping = "rust-lang/libs"
+
 [website]
 page = "library"
 name = "Library team"

--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -10,6 +10,11 @@ members = [
     "matthieu-m",
 ]
 
+[rfcbot]
+label = "T-moderation"
+name = "Moderation"
+ping = "rust-lang/moderation"
+
 [website]
 page = "moderation"
 name = "Moderation team"

--- a/teams/release.toml
+++ b/teams/release.toml
@@ -24,6 +24,11 @@ members = [
 crater = true
 bors.rust.try = true
 
+[rfcbot]
+label = "T-release"
+name = "Release"
+ping = "rust-lang/release"
+
 [website]
 name = "Release team"
 description = "tracking regressions, stabilizations, and producing Rust releases"

--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -14,6 +14,11 @@ members = [
 crater = true
 bors.rust.review = true
 
+[rfcbot]
+label = "T-rustdoc"
+name = "Rustdoc"
+ping = "rust-lang/rustdoc"
+
 [website]
 name = "Rustdoc team"
 description = "Documentation tools including Rustdoc and docs.rs"


### PR DESCRIPTION
This PR adds the data needed to integrate rfcbot with the repo in the Team API. The actual integration still needs to be done.

cc @Centril @anp