### PR TITLE
add a compiler-private mailing list

### DIFF
--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -32,6 +32,9 @@ repo = "http://github.com/rust-lang/compiler-team"
 description = "compiler internals, optimizations"
 
 [[lists]]
+address = "compiler-private@rust-lang.org"
+
+[[lists]]
 address = "compiler@rust-lang.org"
 extra-people = [
     "arielb1",


### PR DESCRIPTION
This is presently an alias for compiler@rust-lang.org -- except that it includes only active members. It will be used to make membership decisions only.