### PR TITLE
create the "compiler contributors team" and populate it

### DIFF
--- a/people/Xanewok.toml
+++ b/people/Xanewok.toml
@@ -3,6 +3,4 @@ github = "Xanewok"
 email = "xanewok@gmail.com"
 
 [permissions]
-perf = true
-bors.rust.review = true
 bors.rls.review = true

--- a/people/flodiebold.toml
+++ b/people/flodiebold.toml
@@ -1,4 +1,5 @@
 name = "Florian Diebold"
 github = "flodiebold"
+email = "flodiebold@gmail.com"
 
 

--- a/people/flodiebold.toml
+++ b/people/flodiebold.toml
@@ -1,0 +1,4 @@
+name = "Florian Diebold"
+github = "flodiebold"
+
+

--- a/people/lqd.toml
+++ b/people/lqd.toml
@@ -1,0 +1,4 @@
+name = "Rémy Rakic"
+github = "lqd"
+email = "remy.rakic+rust@gmail.com"
+

--- a/people/matthewjasper.toml
+++ b/people/matthewjasper.toml
@@ -1,7 +1,3 @@
 name = "Matthew Jasper"
 github = "matthewjasper"
 email = "mjjasper1@gmail.com"
-
-[permissions]
-crater = true
-bors.rust.review = true

--- a/people/nikic.toml
+++ b/people/nikic.toml
@@ -1,5 +1,2 @@
 name = "Nikita Popov"
 github = "nikic"
-
-[permissions]
-bors.rust.review = true

--- a/people/nikic.toml
+++ b/people/nikic.toml
@@ -1,3 +1,3 @@
 name = "Nikita Popov"
 github = "nikic"
-email = false
+email = "nikita.ppv@gmail.com"

--- a/people/nikic.toml
+++ b/people/nikic.toml
@@ -1,2 +1,3 @@
 name = "Nikita Popov"
 github = "nikic"
+email = false

--- a/people/nnethercote.toml
+++ b/people/nnethercote.toml
@@ -1,2 +1,3 @@
 name = "Nicholas Nethercote"
 github = "nnethercote"
+email = false

--- a/people/nnethercote.toml
+++ b/people/nnethercote.toml
@@ -1,3 +1,3 @@
 name = "Nicholas Nethercote"
 github = "nnethercote"
-email = false
+email = "n.nethercote@gmail.com"

--- a/people/nnethercote.toml
+++ b/people/nnethercote.toml
@@ -1,6 +1,2 @@
 name = "Nicholas Nethercote"
 github = "nnethercote"
-
-[permissions]
-perf = true
-bors.rust.review = true

--- a/people/scalexm.toml
+++ b/people/scalexm.toml
@@ -1,2 +1,3 @@
 name = "Alexandre Martin"
 github = "scalexm"
+email = false

--- a/people/scalexm.toml
+++ b/people/scalexm.toml
@@ -1,5 +1,2 @@
 name = "Alexandre Martin"
 github = "scalexm"
-
-[permissions]
-bors.rust.review = true

--- a/people/scalexm.toml
+++ b/people/scalexm.toml
@@ -1,3 +1,3 @@
 name = "Alexandre Martin"
 github = "scalexm"
-email = false
+email = "alexandre@scalexm.fr"

--- a/people/tmandry.toml
+++ b/people/tmandry.toml
@@ -1,2 +1,3 @@
 name = "Tyler Mandry"
 github = "tmandry"
+email = false

--- a/people/tmandry.toml
+++ b/people/tmandry.toml
@@ -1,3 +1,3 @@
 name = "Tyler Mandry"
 github = "tmandry"
-email = false
+email = "tmandry@gmail.com"

--- a/people/tmandry.toml
+++ b/people/tmandry.toml
@@ -1,5 +1,2 @@
 name = "Tyler Mandry"
 github = "tmandry"
-
-[permissions]
-bors.rust.review = true

--- a/people/wesleywiser.toml
+++ b/people/wesleywiser.toml
@@ -1,6 +1,3 @@
 name = "Wesley Wiser"
 github = "wesleywiser"
 email = "wwiser@gmail.com"
-
-[permissions]
-bors.rust.review = true

--- a/people/zackmdavis.toml
+++ b/people/zackmdavis.toml
@@ -1,2 +1,3 @@
 name = "Zack M. Davis"
 github = "zackmdavis"
+email = false

--- a/people/zackmdavis.toml
+++ b/people/zackmdavis.toml
@@ -1,5 +1,2 @@
 name = "Zack M. Davis"
 github = "zackmdavis"
-
-[permissions]
-bors.rust.review = true

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -1,0 +1,27 @@
+name = "compiler-contributors"
+
+[people]
+leads = []
+members = [
+  "spastorino",
+  "matthewjasper",
+  "wesleywiser",
+  "scalexm",
+  "lqd",
+  "tmandry",
+  "zackmdavis",
+  "nnethercote",
+  "xanewok",
+  "matklad",
+  "flodiebold",
+]
+
+[permissions]
+perf = true
+crater = true
+bors.rust.review = true
+
+[website]
+name = "Compiler team contributors"
+repo = "http://github.com/rust-lang/compiler-team"
+

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -7,6 +7,7 @@ members = [
   "lqd",
   "matklad",
   "matthewjasper",
+  "nikic",
   "nnethercote",
   "scalexm",
   "spastorino",

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -14,7 +14,7 @@ members = [
   "spastorino",
   "tmandry",
   "wesleywiser",
-  "xanewok",
+  "Xanewok",
   "zackmdavis",
 ]
 

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -4,6 +4,7 @@ subteam-of = "compiler"
 [people]
 leads = []
 members = [
+  "davidtwco",
   "flodiebold",
   "lqd",
   "matklad",

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -3,17 +3,17 @@ name = "compiler-contributors"
 [people]
 leads = []
 members = [
-  "spastorino",
-  "matthewjasper",
-  "wesleywiser",
-  "scalexm",
-  "lqd",
-  "tmandry",
-  "zackmdavis",
-  "nnethercote",
-  "xanewok",
-  "matklad",
   "flodiebold",
+  "lqd",
+  "matklad",
+  "matthewjasper",
+  "nnethercote",
+  "scalexm",
+  "spastorino",
+  "tmandry",
+  "wesleywiser",
+  "xanewok",
+  "zackmdavis",
 ]
 
 [permissions]

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -26,4 +26,4 @@ bors.rust.review = true
 [website]
 name = "Compiler team contributors"
 repo = "http://github.com/rust-lang/compiler-team"
-
+description = "folks who contribute on a regular basis"

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -1,4 +1,5 @@
 name = "compiler-contributors"
+subteam-of = "compiler"
 
 [people]
 leads = []

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -36,6 +36,7 @@ address = "compiler-private@rust-lang.org"
 
 [[lists]]
 address = "compiler@rust-lang.org"
+extra-teams = ["compiler-contributors"]
 extra-people = [
     "arielb1",
     "jseyfried",
@@ -43,6 +44,7 @@ extra-people = [
 
 [[lists]]
 address = "compiler-team@rust-lang.org"
+extra-teams = ["compiler-contributors"]
 extra-people = [
     "arielb1",
     "jseyfried",


### PR DESCRIPTION
Contributors are added to the compiler-team mailing list, as well.

One question mark: I would like to tweak how the github teams are setup, but I'm not sure if that is controlled by this repository. I *think* I would prefer to have @rust-lang/compiler include the contributors, and to have some subteam to distinguish "full members" (I believe that is what I specified in the RFC). 

cc @rust-lang/compiler 
r? @pietroalbini 