### PR TITLE
Remove mgattozzi from working groups and teams

### DIFF
--- a/people/mgattozzi.toml
+++ b/people/mgattozzi.toml
@@ -1,3 +1,0 @@
-name = "Michael Gattozzi"
-github = "mgattozzi"
-email = "mgattozzi@gmail.com"

--- a/teams/community-events.toml
+++ b/teams/community-events.toml
@@ -10,7 +10,6 @@ members = [
     "flaki",
     "badboy",
     "Manishearth",
-    "mgattozzi",
 ]
 
 [website]

--- a/teams/community-rustbridge.toml
+++ b/teams/community-rustbridge.toml
@@ -11,7 +11,6 @@ members = [
     "spacekookie",
     "sebasmagri",
     "mattgathu",
-    "mgattozzi",
 ]
 
 [website]

--- a/teams/community-survey.toml
+++ b/teams/community-survey.toml
@@ -6,7 +6,6 @@ leads = ["jonathandturner"]
 members = [
     "jonathandturner",
     "Manishearth",
-    "mgattozzi",
 ]
 
 [website]

--- a/teams/wg-governance.toml
+++ b/teams/wg-governance.toml
@@ -8,7 +8,6 @@ members = [
     "skade",
     "gnunicorn",
     "nellshamrell",
-    "mgattozzi",
     "arshiamufti",
     "nikomatsakis",
     "jonathandturner",

--- a/teams/wg-wasm.toml
+++ b/teams/wg-wasm.toml
@@ -12,7 +12,6 @@ address = "wasm@rust-lang.org"
 extra-people = [
     "alexcrichton",
     "aturon",
-    "mgattozzi",
 ]
 
 [website]


### PR DESCRIPTION
I haven't contributed in a while for some of these groups and I'm
scaling down my contributions to open source for a variety of personal
reasons including mental health. This commit removes every reference to
me in the repo.