### PR TITLE
Add GitHub teams in the schema and the API

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,3 +3,8 @@ allowed-mailing-lists-domains = [
     "crates.io",
     "docs.rs",
 ]
+
+allowed-github-orgs = [
+    "rust-lang",
+    "rust-lang-nursery",
+]

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -45,6 +45,12 @@ members = [
 [permissions]
 # Optional, see the permissions documentation
 
+# Configure the GitHub integration
+# This is optional, and if missing the team won't be synchronized with GitHub
+[github]
+name = "overlords-team"  # The name of the GitHub team (optional)
+orgs = ["rust-lang"]  # Organizations to create the team in (required)
+
 # Define the mailing lists used by the team
 # It's optional, and there can be more than one
 [[lists]]

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -48,7 +48,7 @@ members = [
 # Configure the GitHub integration
 # This is optional, and if missing the team won't be synchronized with GitHub
 [github]
-name = "overlords-team"  # The name of the GitHub team (optional)
+team-name = "overlords-team"  # The name of the GitHub team (optional)
 orgs = ["rust-lang"]  # Organizations to create the team in (required)
 
 # Define the mailing lists used by the team

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -16,6 +16,7 @@ pub struct Team {
     pub kind: TeamKind,
     pub subteam_of: Option<String>,
     pub members: Vec<TeamMember>,
+    pub github: Option<TeamGitHub>,
     pub website_data: Option<TeamWebsite>,
 }
 
@@ -25,6 +26,17 @@ pub struct TeamMember {
     pub github: String,
     pub github_id: usize,
     pub is_lead: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamGitHub {
+    pub teams: Vec<GitHubTeam>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubTeam {
+    pub org: String,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -223,7 +223,7 @@ impl Team {
     pub(crate) fn github_teams(&self) -> Vec<(&str, &str)> {
         if let Some(github) = &self.github {
             let name = github
-                .name
+                .team_name
                 .as_ref()
                 .map(|n| n.as_str())
                 .unwrap_or(&self.name);
@@ -250,7 +250,7 @@ struct TeamPeople {
 #[derive(serde::Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct GitHubData {
-    name: Option<String>,
+    team_name: Option<String>,
     orgs: Vec<String>,
 }
 

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -48,6 +48,9 @@ impl<'a> Generator<'a> {
             members.sort_by_key(|member| member.github.to_lowercase());
             members.sort_by_key(|member| !member.is_lead);
 
+            let mut github_teams = team.github_teams();
+            github_teams.sort();
+
             let team_data = v1::Team {
                 name: team.name().into(),
                 kind: if team.is_wg() {
@@ -57,6 +60,16 @@ impl<'a> Generator<'a> {
                 },
                 subteam_of: team.subteam_of().map(|st| st.into()),
                 members,
+                github: Some(v1::TeamGitHub {
+                    teams: github_teams
+                        .iter()
+                        .map(|(org, name)| v1::GitHubTeam {
+                            org: org.to_string(),
+                            name: name.to_string(),
+                        })
+                        .collect::<Vec<_>>(),
+                })
+                .filter(|gh| !gh.teams.is_empty()),
                 website_data: team.website_data().map(|ws| v1::TeamWebsite {
                     name: ws.name().into(),
                     description: ws.description().into(),

--- a/teams/release.toml
+++ b/teams/release.toml
@@ -25,6 +25,9 @@ crater = true
 perf = true
 bors.rust.review = true
 
+[github]
+orgs = ["rust-lang"]
+
 [rfcbot]
 label = "T-release"
 name = "Release"


### PR DESCRIPTION
This PR is the first step of the synchronization of GitHub teams with the team repo. This adds all the relevant fields to the schema and the API, and "enables" synchronization for the release team (chosen because it's already synchronized so no accidental changes will be applied to GitHub).

After the PR is merged the next steps are sending a PR to the central station adding the synchronization tool (already working in a local branch), creating a bot account to do the work and then enabling synchronization for all teams. The last step will require coordination with the team leads to make sure no unwanted changes are applied.

cc #2 