### PR TITLE
Add people with full access to the admin infra mailing lists

### DIFF
--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -47,16 +47,20 @@ address = "craterbot@rust-lang.org"
 address = "admin@rust-lang.org"
 include-team-members = false
 extra-people = [
-    "aturon",
+    "Mark-Simulacrum",
+    "aidanhs",
     "alexcrichton",
+    "pietroalbini",
 ]
 
 [[lists]]
 address = "rust-key@rust-lang.org"
 include-team-members = false
 extra-people = [
-    "aturon",
+    "Mark-Simulacrum",
+    "aidanhs",
     "alexcrichton",
+    "pietroalbini",
 ]
 
 [[lists]]
@@ -77,7 +81,10 @@ extra-emails = [
 address = "bors@rust-lang.org"
 include-team-members = false
 extra-people = [
+    "Mark-Simulacrum",
+    "aidanhs",
     "alexcrichton",
+    "pietroalbini",
 ]
 
 [[lists]]


### PR DESCRIPTION
This adds all people with full access to the infra to the `admin@` mailing list (and related ones).

cc @aidanhs @Mark-Simulacrum 
r? @alexcrichton 
closes https://github.com/rust-lang/team/pull/82