### PR TITLE
Add GitHub teams sync to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ automatically synchronized with:
 | [Crater and @craterbot][crater] | *In real time* | [Integration source][crater-src] |
 | [Perf and @rust-timer][perf] | *In real time* | [Integration source][perf-src] |
 | [@rfcbot][rfcbot] | 5 minutes | [Integration source][rfcbot-src] |
-| Mailing lists and aliases (`@rust-lang.org`, `@crates.io`) | 5 minutes | [Integration source][ml-src]
+| GitHub teams membership | 5 minutes | [Integration source][github-teams-src] |
+| Mailing lists and aliases (`@rust-lang.org`, `@crates.io`) | 5 minutes | [Integration source][ml-src] |
 | [Governance section on the website][www] | 2 minutes | [Integration source][www-src] |
 
 If you need to add or remove a person from a team send a PR to this repository,
@@ -27,6 +28,7 @@ supported services.
 [perf-src]: https://github.com/rust-lang-nursery/rustc-perf/blob/master/site/src/server.rs
 [rfcbot]: https://rfcbot.rs
 [rfcbot-src]: https://github.com/anp/rfcbot-rs/blob/master/src/teams.rs
+[github-teams-src]: https://github.com/rust-lang/rust-central-station/tree/master/sync-github
 
 ## Documentation
 


### PR DESCRIPTION
It's finally running :tada: 

cc https://github.com/rust-lang/team/issues/2