### PR TITLE
Sync the cargo team with GitHub

### DIFF
--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -15,6 +15,9 @@ members = [
 [permissions]
 bors.cargo.review = true
 
+[github]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
 [rfcbot]
 label = "T-cargo"
 name = "Cargo"


### PR DESCRIPTION
Changes to the teams that are going to be applied:

```
rust-lang/cargo: user wycats is not in the team anymore, removing them...
rust-lang/cargo: user dwijnand is not in the team anymore, removing them...
rust-lang/cargo: user Xanewok is not in the team anymore, removing them...
rust-lang-nursery/cargo: user ehuss is missing, adding them...
rust-lang-nursery/cargo: user nrc is missing, adding them...
rust-lang-nursery/cargo: user Eh2406 is missing, adding them...
rust-lang-nursery/cargo: user withoutboats has the role maintainer instead of member, changing them...
rust-lang-nursery/cargo: user carols10cents is not in the team anymore, removing them...
rust-lang-nursery/cargo: user matklad is not in the team anymore, removing them...
rust-lang-nursery/cargo: user aturon is not in the team anymore, removing them...
```

r? @nrc @ehuss