### PR TITLE
Move clippy reviewers to team, add Yaah, remove Georg

### DIFF
--- a/people/birkenfeld.toml
+++ b/people/birkenfeld.toml
@@ -1,6 +1,4 @@
 name = "Georg Brandl"
 github = "birkenfeld"
 github-id = 144359
-
-[permissions]
-bors.clippy.review = true
+email = "georg@python.org"

--- a/people/flip1995.toml
+++ b/people/flip1995.toml
@@ -1,6 +1,4 @@
 name = "Philipp Krones"
 github = "flip1995"
 github-id = 9744647
-
-[permissions]
-bors.clippy.review = true
+email = "hello@philkrones.com"

--- a/people/matthiaskrgr.toml
+++ b/people/matthiaskrgr.toml
@@ -1,6 +1,4 @@
 name = "Matthias Krüger"
 github = "matthiaskrgr"
 github-id = 476013
-
-[permissions]
-bors.clippy.review = true
+email = "matthias.krueger@famsik.de"

--- a/people/mcarton.toml
+++ b/people/mcarton.toml
@@ -1,6 +1,5 @@
 name = "Martin Carton"
 github = "mcarton"
 github-id = 3751788
+email = "cartonmartin@gmail.com"
 
-[permissions]
-bors.clippy.review = true

--- a/people/mikerite.toml
+++ b/people/mikerite.toml
@@ -1,6 +1,4 @@
 name = "mikerite"
 github = "mikerite"
 github-id = 33983332
-
-[permissions]
-bors.clippy.review = true
+email = "mikerite@lavabit.com"

--- a/people/phansch.toml
+++ b/people/phansch.toml
@@ -1,6 +1,4 @@
 name = "Philipp Hansch"
 github = "phansch"
 github-id = 2042399
-
-[permissions]
-bors.clippy.review = true
+email = "dev@phansch.net"

--- a/people/yaahc.toml
+++ b/people/yaahc.toml
@@ -1,0 +1,4 @@
+name = 'Jane Lusby'
+github = 'yaahc'
+github-id = 1993852
+email = "jlusby42@gmail.com"

--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -7,6 +7,7 @@ members = [
     "Aatch",
     "alercah",
     "arielb1",
+    "birkenfeld",
     "bkoropoff",
     "booyaa",
     "brson",

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -10,10 +10,10 @@ members = [
     "oli-obk",
     "matthiaskrgr",
     "phansch",
-    "birkenfeld",
     "mikerite",
     "flip1995",
     "mcarton",
+    "yaahc",
 ]
 
 [permissions]

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -8,6 +8,12 @@ members = [
     "killercup",
     "Manishearth",
     "oli-obk",
+    "matthiaskrgr",
+    "phansch",
+    "birkenfeld",
+    "mikerite",
+    "flip1995",
+    "mcarton",
 ]
 
 [permissions]


### PR DESCRIPTION
We don't use the clippy "team" much for anything special, but folks with review should be on it, they all deserve it :)

This also moves @birkenfeld to alumni since he's been inactive for two years, but he's free to rerequest r+ whenever he wishes.

This also adds @yaahc to the team/reviewers, she's been doing excellent work on the cargo side lately and should be a part of this.

r? @oli-obk