### PR TITLE
Synchronize wg-rustfmt with GitHub teams

### DIFF
--- a/people/otavio.toml
+++ b/people/otavio.toml
@@ -1,4 +1,0 @@
-name = "Otavio Salvador"
-github = "otavio"
-github-id = 25278
-email = "otavio@ossystems.com.br"

--- a/teams/wg-rustfmt.toml
+++ b/teams/wg-rustfmt.toml
@@ -11,6 +11,9 @@ members = [
     "topecongiro",
 ]
 
+[github]
+orgs = ["rust-lang"]
+
 [website]
 name = "Rustfmt working group"
 description = "design and implementation of Rustfmt"

--- a/teams/wg-rustfmt.toml
+++ b/teams/wg-rustfmt.toml
@@ -5,8 +5,6 @@ wg = true
 [people]
 leads = ["topecongiro"]
 members = [
-    "nrc",
-    "otavio",
     "scampi",
     "topecongiro",
 ]


### PR DESCRIPTION
This will create a new `wg-rustfmt` team in the `rust-lang` GitHub organization with nrc, otavio, scampi and topecongiro. Then we should configure the rustfmt repo to authorize the team instead of individual members.

@topecongiro is the list of the members of the wg still accurate? otavio doesn't have write perms on the rustfmt repo anymore.