### PR TITLE
teams/rust-by-example: synchronize with GitHub

### DIFF
--- a/teams/rust-by-example.toml
+++ b/teams/rust-by-example.toml
@@ -8,6 +8,9 @@ members = [
     "marioidival",
 ]
 
+[github]
+orgs = ["rust-lang"]
+
 [website]
 name = "Rust by Example team"
 description = "maintaining and updating Rust By Example"


### PR DESCRIPTION
This will create a new `rust-by-example` team in the `rust-lang` GitHub organization with steveklabnik and marioidival. Then we should configure the rust-by-example repo to authorize the team instead of individual members.

r? @steveklabnik 