### PR TITLE
Include compiler team members on @rust-lang/compiler-contributors

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -50,6 +50,8 @@ members = [
 [github]
 team-name = "overlords-team"  # The name of the GitHub team (optional)
 orgs = ["rust-lang"]  # Organizations to create the team in (required)
+# Include members of these Rust teams in this GitHub team (optional)
+extra-teams = ["bots-nursery"]
 
 # Define the mailing lists used by the team
 # It's optional, and there can be more than one

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -26,6 +26,7 @@ bors.rust.review = true
 
 [github]
 orgs = ["rust-lang", "rust-lang-nursery"]
+extra-teams = ["compiler"]
 
 [website]
 name = "Compiler team contributors"


### PR DESCRIPTION
This PR includes compiler team members on the `compiler-contributors` team on GitHub. This allows them to be mentioned along with the contributors, and to publish packages on crates.io owned by the contributors team.

r? @nikomatsakis 