### PR TITLE
Synchronize crates-io with GitHub

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -16,6 +16,9 @@ members = [
     "Turbo87",
 ]
 
+[github]
+orgs = ["rust-lang"]
+
 [rfcbot]
 label = "T-crates-io"
 name = "Crates.io"


### PR DESCRIPTION
This PR will synchronize the `crates-io` Rust team with the `@rust-lang/crates-io` GitHub team. Differences that are going to be fixed once the PR is merged:

```
user Turbo87 is missing, adding them...
user smarnach is missing, adding them...
user steveklabnik is missing, adding them...
user locks is missing, adding them...
user wycats is not in the team anymore, removing them...
```

r? @sgrif