### PR TITLE
Add icebreakers-llvm team

### DIFF
--- a/teams/icebreakers-llvm.toml
+++ b/teams/icebreakers-llvm.toml
@@ -1,0 +1,9 @@
+name = "icebreakers-llvm"
+marker-team = true
+
+[people]
+leads = []
+members = [
+    "nagisa",
+    "nikic",
+]


### PR DESCRIPTION
We've [discussed on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/185694-t-compiler.2Fwg-meta) about adding icebreakers-llvm as a team with minimal everything (no github, no website) as can be seen on the toml file, instead of doing this as a working group.

From what we've quickly seen on team repo by doing what I've done in the PR this group would end included in `all@`. What would be the best way to avoid that?.

/cc @nikomatsakis @pietroalbini @Mark-Simulacrum (this is also related to https://github.com/rust-lang/triagebot/issues/169)