### PR TITLE
Add privacy@rust-lang.org, forwarding to core

### DIFF
--- a/teams/core.toml
+++ b/teams/core.toml
@@ -60,3 +60,6 @@ extra-people = [
     "steveklabnik",
     "Manishearth",
 ]
+
+[[lists]]
+address = "privacy@rust-lang.org"


### PR DESCRIPTION
This can be changed in the future, but I believe these concerns are best handled in the team with easiest access to legal advice, as competently answering such request might involve it.