### PR TITLE
Add gamedev working group discord link

### DIFF
--- a/teams/wg-gamedev.toml
+++ b/teams/wg-gamedev.toml
@@ -18,7 +18,8 @@ page = "gamedev"
 name = "Game development working group"
 description = "Focusing on making rust the default choice for game development."
 repo = "https://github.com/rust-gamedev"
-
+discord-invite = "https://discord.gg/sG23nSS"
+discord-name = "#wg-gamedev"
 
 [[lists]]
 address = "gamedev-wg@rust-lang.org"


### PR DESCRIPTION
The gamedev WG has a channel on the official Rust Discord - figured it'd be a good idea to add it here too :)