### PR TITLE
Add website and GH sync for the security team

### DIFF
--- a/teams/security.toml
+++ b/teams/security.toml
@@ -9,5 +9,11 @@ members = [
     "steveklabnik",
 ]
 
+[website]
+name = "Security team"
+description = "Triaging and responding to incoming vulnerability reports"
+email = "security@rust-lang.org"
+repo = "https://github.com/rust-lang/security-team"
+
 [[lists]]
 address = "security@rust-lang.org"

--- a/teams/security.toml
+++ b/teams/security.toml
@@ -9,6 +9,9 @@ members = [
     "steveklabnik",
 ]
 
+[github]
+orgs = ["rust-lang"]
+
 [website]
 name = "Security team"
 description = "Triaging and responding to incoming vulnerability reports"


### PR DESCRIPTION
This adds the security team to the governance section of the website and enables synchronization with GitHub's `@rust-lang/security`.

Fixes https://github.com/rust-lang/security-team/issues/4
r? @alexcrichton 