### PR TITLE
Change crates.io mailing lists

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -43,11 +43,3 @@ extra-people = [
     "sgrif",
     "pietroalbini",
 ]
-
-[[lists]]
-address = "admin@crates.io"
-include-team-members = false
-extra-people = [
-    "aturon",
-    "alexcrichton",
-]

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -32,17 +32,10 @@ discord-invite = "https://discord.gg/Rbq8W5K"
 discord-name = "#crates-io"
 
 [[lists]]
-address = "help@crates.io"
-include-team-members = false
-extra-people = [
-    "carols10cents",
-    "ashleygwilliams",
-    "sgrif",
-    "pietroalbini",
-]
+address = "crates-io@rust-lang.org"
 
 [[lists]]
-address = "crates-io@rust-lang.org"
+address = "help@crates.io"
 include-team-members = false
 extra-people = [
     "carols10cents",

--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -13,6 +13,9 @@ members = [
 address = "admin@rust-lang.org"
 
 [[lists]]
+address = "admin@crates.io"
+
+[[lists]]
 address = "rust-key@rust-lang.org"
 
 [[lists]]


### PR DESCRIPTION
As we discussed in the last crates.io meeting, this PR:

* Adds all team members to `crates-io@rust-lang.org`, while keeping the existing list of members in `help@crates.io`
* Moves `admin@crates.io` with the other infra-admins mailing lists, updating its membership to be infra team members with "sensitive access".

r? @sgrif