### PR TITLE
add github team sync to rustdoc team

### DIFF
--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -10,6 +10,9 @@ members = [
     "onur",
 ]
 
+[github]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
 [permissions]
 crater = true
 bors.rust.review = true


### PR DESCRIPTION
cc #146

I checked the Rustdoc team listings for the rust-lang and rust-lang-nursery orgs, and it looks like they've gone out of sync. I've updated the rust-lang one manually, but i don't have Maintainer status on the rust-lang-nursery one, so i'm counting on this update to fix that for me.