### PR TITLE
Give smarnach bors permissions on crates.io.

### DIFF
--- a/people/smarnach.toml
+++ b/people/smarnach.toml
@@ -2,3 +2,6 @@ name = "Sven Marnach"
 github = "smarnach"
 github-id = 249196
 email = "sven@marnach.net"
+
+[permissions]
+bors.crates_io.review = true


### PR DESCRIPTION
@sgrif This change gives me `bors r+` permissions for crates.io.