### PR TITLE
fixed types in Reference and Gamedev wg TOML files

### DIFF
--- a/teams/reference.toml
+++ b/teams/reference.toml
@@ -10,4 +10,4 @@ members = [
 
 [website]
 name = "Reference team"
-description = "working on the rust reference"
+description = "working on the Rust reference"

--- a/teams/wg-gamedev.toml
+++ b/teams/wg-gamedev.toml
@@ -16,7 +16,7 @@ members = [
 [website]
 page = "gamedev"
 name = "Game development working group"
-description = "Focusing on making rust the default choice for game development."
+description = "Focusing on making Rust the default choice for game development."
 repo = "https://github.com/rust-gamedev"
 discord-invite = "https://discord.gg/sG23nSS"
 discord-name = "#wg-gamedev"


### PR DESCRIPTION
Some occurrences of "Rust" were not capitalized