### PR TITLE
add escstatic-morse to compiler contributors

### DIFF
--- a/people/ecstatic-morse.toml
+++ b/people/ecstatic-morse.toml
@@ -1,0 +1,4 @@
+name = 'Dylan MacKenzie'
+github = 'ecstatic-morse'
+github-id = 29463364
+email = "ecstaticmorse@gmail.com"

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -6,6 +6,7 @@ leads = []
 members = [
   "Centril",
   "davidtwco",
+  "esctatic-morse",
   "flodiebold",
   "lqd",
   "Mark-Simulacrum",

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -6,7 +6,7 @@ leads = []
 members = [
   "Centril",
   "davidtwco",
-  "esctatic-morse",
+  "ecstatic-morse",
   "flodiebold",
   "lqd",
   "Mark-Simulacrum",


### PR DESCRIPTION
They're working to make compile-time evaluation more expressive by enabling `if`, `match` and other control flow in constants. As one of their first major contributions, they implemented a dataflow analysis to validate the bodies of `const`s and `const fn`s (rust-lang/rust#64470).

Congratulations @ecstatic-morse, and thanks!

cc @rust-lang/compiler 