### PR TITLE
create the docsrs-ops marker team

### DIFF
--- a/teams/docsrs-ops.toml
+++ b/teams/docsrs-ops.toml
@@ -1,0 +1,12 @@
+name = "docsrs-ops"
+marker-team = true
+
+[people]
+leads = []
+members = [
+    "QuietMisdreavus",
+    "onur",
+]
+
+[github]
+orgs = ["rust-lang"]


### PR DESCRIPTION
This team (synchronized with GitHub) is a marker team as it doesn't
represent any team in our structure, but it's used to grant people
involved with docs.rs operations access to some parts of our infra.

r? @Mark-Simulacrum 