### PR TITLE
Add jryans to LLVM ICE-breaker group

### DIFF
--- a/people/jryans.toml
+++ b/people/jryans.toml
@@ -1,0 +1,4 @@
+name = 'J. Ryan Stinnett'
+github = 'jryans'
+github-id = 279572
+email = 'jryans@gmail.com'

--- a/teams/icebreakers-llvm.toml
+++ b/teams/icebreakers-llvm.toml
@@ -4,6 +4,7 @@ marker-team = true
 [people]
 leads = []
 members = [
+    "jryans",
     "nagisa",
     "nikic",
     "rkruppe",


### PR DESCRIPTION
I am interested in following the issues Rust hits with LLVM and hopefully helping out with some where possible.