### PR TITLE
Make the security team a WG

### DIFF
--- a/teams/wg-security.toml
+++ b/teams/wg-security.toml
@@ -1,4 +1,5 @@
-name = "security"
+name = "wg-security"
+wg = true
 
 [people]
 leads = []


### PR DESCRIPTION
We noticed this in the core team triage, the team isn't a decisionmaking team and should be classified as a WG.


r? @nikomatsakis