### PR TITLE
sync lang team

### DIFF
--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -22,7 +22,10 @@ members = [
     "jseyfried",
     "pcwalton",
     "peschkaj",
+    "rpjohnst",
+    "solson",
     "tomprince",
+    "whitequark",
     "wycats",
 ]
 

--- a/teams/lang-shepherds.toml
+++ b/teams/lang-shepherds.toml
@@ -1,9 +1,0 @@
-name = "lang-shepherds"
-
-[people]
-leads = []
-members = [
-    "solson",
-    "whitequark",
-    "rpjohnst",
-]

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -17,6 +17,9 @@ members = [
 perf = true
 bors.rust.review = true
 
+[github]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
 [rfcbot]
 label = "T-lang"
 name = "Language"

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -35,8 +35,6 @@ address = "lang-private@rust-lang.org"
 
 [[lists]]
 address = "lang@rust-lang.org"
-extra-teams = ["lang-shepherds"]
 
 [[lists]]
 address = "language-design-team@rust-lang.org"
-extra-teams = ["lang-shepherds"]


### PR DESCRIPTION
This synchronizes @rust-lang/lang as defined on team with the github repository.

This will cause

* @huonw
* @solson

to be removed, and @scottmcm to be added.

I'm also removing the shepherds subteam, as it is not really the way we're operating anymore. (I've discussed this with the participants / lang-team already.)

cc https://github.com/rust-lang/wg-governance/issues/21
