### PR TITLE
add pnkfelix as compiler team co-lead

### DIFF
--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -1,7 +1,7 @@
 name = "compiler"
 
 [people]
-leads = ["nikomatsakis"]
+leads = ["nikomatsakis", "pnkfelix"]
 members = [
     "cramertj",
     "eddyb",


### PR DESCRIPTION
This PR makes official what has been true for some time, by adding @pnkfelix as the @rust-lang/compiler team co-lead. Felix was a "founding member" of the compiler team when it first started, and was involved with Rust long before that. For the last year or so, he's been taking over an increasingly large share of "compiler team leadership", including running the weekly triage meeting and generally tending to the quality of the compiler as a whole. So many thanks to @pnkfelix for all that he does, and congratulations! 🎉 