### PR TITLE
wg-security: update names on the website

### DIFF
--- a/teams/wg-security-response.toml
+++ b/teams/wg-security-response.toml
@@ -1,4 +1,4 @@
-name = "wg-security"
+name = "wg-security-response"
 wg = true
 
 [people]
@@ -12,13 +12,14 @@ members = [
 ]
 
 [github]
+team-name = "security"
 orgs = ["rust-lang"]
 
 [website]
-name = "Security WG"
+name = "Security Response WG"
 description = "Triaging and responding to incoming vulnerability reports"
 email = "security@rust-lang.org"
-repo = "https://github.com/rust-lang/wg-security"
+repo = "https://github.com/rust-lang/wg-security-response"
 
 [[lists]]
 address = "security@rust-lang.org"

--- a/teams/wg-security.toml
+++ b/teams/wg-security.toml
@@ -15,10 +15,10 @@ members = [
 orgs = ["rust-lang"]
 
 [website]
-name = "Security team"
+name = "Security WG"
 description = "Triaging and responding to incoming vulnerability reports"
 email = "security@rust-lang.org"
-repo = "https://github.com/rust-lang/security-team"
+repo = "https://github.com/rust-lang/wg-security"
 
 [[lists]]
 address = "security@rust-lang.org"


### PR DESCRIPTION
Followup to https://github.com/rust-lang/team/pull/165

This PR changes the name of the website to be "Security WG", to reflect the WG name. I sort of feel like the name is too vague though, as our scope is just responding to vuln reports. Maybe let's rename ourselves to "Security Response WG"? @rust-lang/wg-security 