### PR TITLE
spin off docs.rs team from rustdoc team

### DIFF
--- a/people/jyn514.toml
+++ b/people/jyn514.toml
@@ -1,0 +1,4 @@
+name = 'Joshua Nelson'
+github = 'jyn514'
+github-id = 23638587
+email = 'jyn514@gmail.com'

--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -1,0 +1,27 @@
+name = "docs-rs"
+subteam-of = "devtools"
+
+[people]
+leads = ["QuietMisdreavus"]
+members = [
+    "QuietMisdreavus",
+    "onur",
+    "pietroalbini",
+]
+
+[github]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
+[rfcbot]
+label = "T-docs-rs"
+name = "Docs.rs"
+ping = "rust-lang/docs-rs"
+
+[website]
+name = "Docs.rs team"
+description = "Docs.rs, the documentation hosting service for crates"
+discord-invite = "https://discord.gg/f7mTXPW"
+discord-name = "#docs-rs"
+
+[[lists]]
+address = "docs-rs@rust-lang.org"

--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -5,6 +5,7 @@ subteam-of = "devtools"
 leads = ["QuietMisdreavus"]
 members = [
     "QuietMisdreavus",
+    "GuillaumeGomez",
     "onur",
     "pietroalbini",
 ]

--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -8,6 +8,7 @@ members = [
     "GuillaumeGomez",
     "onur",
     "pietroalbini",
+    "jyn514",
 ]
 
 [github]

--- a/teams/docsrs-ops.toml
+++ b/teams/docsrs-ops.toml
@@ -6,6 +6,7 @@ leads = []
 members = [
     "QuietMisdreavus",
     "onur",
+    "jyn514",
 ]
 
 [github]

--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -2,12 +2,11 @@ name = "rustdoc"
 subteam-of = "devtools"
 
 [people]
-leads = ["QuietMisdreavus"]
+leads = ["GuillaumeGomez"]
 members = [
     "GuillaumeGomez",
     "QuietMisdreavus",
     "ollie27",
-    "onur",
     "kinnison",
 ]
 
@@ -25,7 +24,7 @@ ping = "rust-lang/rustdoc"
 
 [website]
 name = "Rustdoc team"
-description = "Documentation tools including Rustdoc and docs.rs"
+description = "Rustdoc, the documentation tool"
 discord-invite = "https://discord.gg/4yEYPuT"
 discord-name = "#rustdoc"
 


### PR DESCRIPTION
This PR officially creates a new team, the Docs.rs Team, by formally splitting off the responsibilities from the existing Rustdoc Team. While some feature development may have some overlap between these two products, they wind up having totally separate responsibilities in the end.

This creates the following structure:

* Rustdoc Team (parent team: Dev-Tools)
  * @GuillaumeGomez (lead)
  * @QuietMisdreavus
  * @ollie27
  * @kinnison
* Docs.rs Team (parent team: Dev-Tools)
  * @QuietMisdreavus (lead)
  * @onur
  * @pietroalbini
  * @jyn514

One open question i'd like to pose is what team the Docs.rs team should be child of. I placed it under Dev-Tools since it's splitting off from Rustdoc, and that's where Rustdoc is currently placed, but it doesn't ultimately seem like the right place for it. The best analog i can think of for an existing team to emulate is the Crates.io team, which is directly under Core.

Another notable thing about this PR is that it involves me stepping down from leadership of the Rustdoc Team (even though i would start leading the Docs.rs Team). My involvement in rustdoc-the-tool has been a lot less recently, both because my involvement in the Rust Project has gone down overall and also because i started doing more with Docs.rs specifically. Guillaume is still quite active with Rustdoc, so he's better suited to having organizational say over the team and the tool's direction. This move should help us both out in working on our respective tools and bringing up new contributors.

This also formally recognizes Pietro's work in keeping up the operations of Docs.rs by adding him as a formal team member. He's been helping out Docs.rs a lot from the perspective of the Infra Team, in keeping the service up and running smoothly.

A question i have about the process of creating a new team - should we create the GitHub teams, issue labels, and the email alias ahead of time, or will the backend piece do that for us?

I'd like to get this merged before approving https://github.com/rust-lang/team/pull/181, since it'll let Guillaume have the final say on that.