### PR TITLE
infra: remove Ashley and synchronize with GitHub

### DIFF
--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -7,12 +7,14 @@ members = [
     "Mark-Simulacrum",
     "aidanhs",
     "alexcrichton",
-    "ashleygwilliams",
     "kennytm",
     "pietroalbini",
     "sgrif",
     "shepmaster",
 ]
+
+[github]
+orgs = ["rust-lang", "rust-lang-nursery"]
 
 [permissions]
 perf = true


### PR DESCRIPTION
This PR removes @ashleygwilliams from the infra team, as she doesn't have the time anymore to contribute to infra. Thanks Ashley for all you did!

Now that the members list reflects the actual memberships, this PR also enables synchronization with GitHub.

r? @aidanhs 