### PR TITLE
add ffi-unwind project group

### DIFF
--- a/people/acfoltzer.toml
+++ b/people/acfoltzer.toml
@@ -1,0 +1,4 @@
+name = 'Adam C. Foltzer'
+github = 'acfoltzer'
+github-id = 205266
+email = 'acfoltzer@acfoltzer.net'

--- a/teams/wg-ffi-unwind.toml
+++ b/teams/wg-ffi-unwind.toml
@@ -14,7 +14,7 @@ members = [
 
 [website]
 name = "ffi-unwind project group"
-description = "Figureing out how unwinding and FFI should interact"
+description = "A working-group project to extend the Rust language to support unwinding that crosses FFI boundaries"
 repo = "https://github.com/rust-lang/project-ffi-unwind"
 
 [github]

--- a/teams/wg-ffi-unwind.toml
+++ b/teams/wg-ffi-unwind.toml
@@ -1,0 +1,21 @@
+name = "wg-ffi-unwind"
+subteam-of = "lang"
+wg = true
+
+[people]
+leads = ["nikomatsakis", "acfoltzer", "BatmanAoD"]
+members = [
+    "acfoltzer",
+    "Amanieu",
+    "BatmanAoD",
+    "gnzlbg",
+    "nikomatsakis",
+]
+
+[website]
+name = "ffi-unwind project group"
+description = "Figureing out how unwinding and FFI should interact"
+repo = "https://github.com/rust-lang/project-ffi-unwind"
+
+[github]
+orgs = ["rust-lang"]


### PR DESCRIPTION
For now, we have to use the wg- prefix because team repo has to be
taught about project groups.

cc @BatmanAoD @acfoltzer 