### PR TITLE
create a `core-private` mailing list

### DIFF
--- a/teams/core.toml
+++ b/teams/core.toml
@@ -34,6 +34,9 @@ address = "core@rust-lang.org"
 extra-teams = ["core-observers"]
 
 [[lists]]
+address = "core-private@rust-lang.org"
+
+[[lists]]
 address = "core-team@rust-lang.org"
 extra-teams = ["core-observers"]
 


### PR DESCRIPTION
This excludes "observers", and is analogous to `lang-private` and other such lists. 

