### PR TITLE
add jtgeibel as co-lead of the crates.io team

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -1,7 +1,7 @@
 name = "crates-io"
 
 [people]
-leads = ["ashleygwilliams", "sgrif"]
+leads = ["ashleygwilliams", "sgrif", "jtgeibel"]
 members = [
     "carols10cents",
     "ashleygwilliams",


### PR DESCRIPTION
I understand that @jtgeibel is co-lead of the crates.io team now, as [announced here on Discord](https://discordapp.com/channels/442252698964721669/448525639469891595/655071728883728397). Huzzah!