### PR TITLE
Remove myself from the CLI-WG roster

### DIFF
--- a/teams/wg-cli.toml
+++ b/teams/wg-cli.toml
@@ -5,7 +5,6 @@ wg = true
 leads = ["spacekookie"]
 members = [
     "Dylan-DPC",
-    "XAMPPRocky",
     "codesections",
     "epage",
     "killercup",


### PR DESCRIPTION
I'm no longer an active member in the CLI working group, so it doesn't make sense to keep this.