### PR TITLE
Use my real name on the Rust website

### DIFF
--- a/people/BatmanAoD.toml
+++ b/people/BatmanAoD.toml
@@ -1,4 +1,4 @@
-name = "BatmanAoD"
+name = "Kyle J Strand"
 github = "BatmanAoD"
 github-id = 2313807
 email = "batmanaod@gmail.com"


### PR DESCRIPTION
Since 'batmanaod' is already visible as the name of my GitHub profile, and since other team members have their real names listed, I would like to use my real name as well.