### PR TITLE
Add john-doe to Cleanup Crew ICE-breakers

### DIFF
--- a/people/john-doe.toml
+++ b/people/john-doe.toml
@@ -1,0 +1,3 @@
+name = 'john-doe'
+github = 'john-doe'
+github-id = 1704176

--- a/teams/icebreakers-cleanup-crew.toml
+++ b/teams/icebreakers-cleanup-crew.toml
@@ -5,4 +5,5 @@ marker-team = true
 leads = []
 members = [
     "spastorino",
+    "john-doe",
 ]


### PR DESCRIPTION
This PR is meant to serve as an example! To add yourself to the Cleanup Crew ICE-breaker team, just create a commit like this one, but using your own username instead of `john-doe`.

If you are already a member of a Rust team you don't need to add a `people/john-doe.toml` like file because you will have an existing one for your username. If you're not part of the team, you have to checkout the repository, run the command below and commit the new file it creates

```shell
cargo run add-person $your_user_name
```