### PR TITLE
Add zulip ID field to people

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -9,6 +9,7 @@ The file structure is this:
 name = "John Doe"  # Real name of the person (required)
 github = "johndoe"  # GitHub username of the person (required)
 github-id = 123456  # GitHub ID of the person (required)
+zulip-id = 123456   # Zulip ID of the person (optional)
 # You can also set `email = false` to explicitly disable the email for the user.
 # This will, for example, avoid adding the person to the mailing lists.
 email = "john@doe.com"  # Email address used for mailing lists (optional)

--- a/people/Mark-Simulacrum.toml
+++ b/people/Mark-Simulacrum.toml
@@ -1,6 +1,7 @@
 name = "Mark Rousskov"
 github = "Mark-Simulacrum"
 github-id = 5047365
+zulip-id = 116112
 irc = "simulacrum"
 email = "mark.simulacrum@gmail.com"
 

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -94,3 +94,9 @@ pub struct RfcbotTeam {
     pub ping: String,
     pub members: Vec<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZulipMapping {
+    /// Zulip ID to GitHub ID
+    pub users: IndexMap<usize, usize>,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -48,6 +48,7 @@ pub(crate) struct Person {
     name: String,
     github: String,
     github_id: usize,
+    zulip_id: Option<usize>,
     irc: Option<String>,
     #[serde(default)]
     email: EmailField,
@@ -67,6 +68,10 @@ impl Person {
 
     pub(crate) fn github_id(&self) -> usize {
         self.github_id
+    }
+
+    pub(crate) fn zulip_id(&self) -> Option<usize> {
+        self.zulip_id
     }
 
     #[allow(unused)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -26,6 +26,7 @@ impl<'a> Generator<'a> {
         self.generate_lists()?;
         self.generate_permissions()?;
         self.generate_rfcbot()?;
+        self.generate_zulip_map()?;
         Ok(())
     }
 
@@ -162,6 +163,25 @@ impl<'a> Generator<'a> {
 
         teams.sort_keys();
         self.add("v1/rfcbot.json", &v1::Rfcbot { teams })?;
+        Ok(())
+    }
+
+    fn generate_zulip_map(&self) -> Result<(), Error> {
+        let mut zulip_people = IndexMap::new();
+
+        for person in self.data.people() {
+            if let Some(zulip_id) = person.zulip_id() {
+                zulip_people.insert(zulip_id, person.github_id());
+            }
+        }
+
+        zulip_people.sort_keys();
+        self.add(
+            "v1/zulip-map.json",
+            &v1::ZulipMapping {
+                users: zulip_people,
+            },
+        )?;
         Ok(())
     }
 


### PR DESCRIPTION
This will be used by triagebot for authentication; we also provide a mapping
from Zulip ID to the GitHub user ID which is the canonical "identifer" of a
person in the Rust organization.

r? @pietroalbini 