### PR TITLE
Give the Cargo team r+ rights on rust-lang/rust

### DIFF
--- a/people/ehuss.toml
+++ b/people/ehuss.toml
@@ -2,6 +2,3 @@ name = "Eric Huss"
 github = "ehuss"
 github-id = 43198
 email = "eric@huss.org"
-
-[permissions]
-bors.rust.review = true

--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -12,6 +12,7 @@ members = [
 ]
 
 [permissions]
+bors.rust.review = true
 bors.cargo.review = true
 
 [github]


### PR DESCRIPTION
It looks like I don't have r+ any more on rust-lang/rust, but it would
still be pretty useful to have. I think Cargo folks in general should
probably have r+ anyway to do things like submodule updates as well.