### PR TITLE
Sync Core Team Permissions

### DIFF
--- a/teams/core.toml
+++ b/teams/core.toml
@@ -18,6 +18,9 @@ members = [
 bors.rust.review = true
 bors.team.review = true
 
+[github]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
 [rfcbot]
 label = "T-core"
 name = "Core"


### PR DESCRIPTION
While looking through github's teams I noticed that the core team permissions aren't synced between rust-lang/team and GitHub. I'm not sure if this is intentional, but it seems like an oversight.

r? @nikomatsakis 