### PR TITLE
add Miri team consisting of Oli and me

### DIFF
--- a/people/RalfJung.toml
+++ b/people/RalfJung.toml
@@ -1,6 +1,7 @@
 name = "Ralf Jung"
 github = "RalfJung"
 github-id = 330628
+email = "post@ralfj.de"
 
 [permissions]
 perf = true

--- a/people/RalfJung.toml
+++ b/people/RalfJung.toml
@@ -5,4 +5,3 @@ github-id = 330628
 [permissions]
 perf = true
 bors.rust.review = true
-bors.miri.review = true

--- a/teams/miri.toml
+++ b/teams/miri.toml
@@ -1,0 +1,14 @@
+name = "miri"
+subteam-of = "compiler"
+
+[people]
+leads = ["RalfJung", "oli-obk"]
+members = ["RalfJung", "oli-obk"]
+
+[permissions]
+bors.miri.review = true
+
+[website]
+name = "Miri"
+description = "design and implementation of the Miri interpreter"
+repo = "https://github.com/rust-lang/miri"


### PR DESCRIPTION
Cc @oli-obk 

t-compiler also has Miri r+ rights, and I guess there is no good reason to change that. Still, saying that Miri is a subteam of t-compiler is kind-of arbitrary. Does it matter much?

I was not sure about the `repo` key, as Clippy doesn't have it.