### PR TITLE
teams/miri: add github clause

### DIFF
--- a/teams/miri.toml
+++ b/teams/miri.toml
@@ -12,3 +12,6 @@ bors.miri.review = true
 name = "Miri"
 description = "design and implementation of the Miri interpreter"
 repo = "https://github.com/rust-lang/miri"
+
+[github]
+orgs = ["rust-lang"]


### PR DESCRIPTION
I *think* this is what @XAMPPRocky [asked me to do](https://github.com/rust-lang/team/pull/262#discussion_r384749112), but it is not clear at all to me. https://github.com/rust-lang/team/issues/146 lists a dozen things to do and most of them make no sense as the team doesn't exist yet and I have no admin powers.