### PR TITLE
remove eddyb from active lang team duty

### DIFF
--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -5,7 +5,6 @@ leads = ["nikomatsakis", "joshtriplett"]
 members = [
     "Centril",
     "cramertj",
-    "eddyb",
     "joshtriplett",
     "nikomatsakis",
     "pnkfelix",


### PR DESCRIPTION
For quite some time now, eddyb has narrowed their focus to compiler team projects (as well as targeted involvement in specific areas, like compile team evaluation). This PR makes that official by moving eddyb to alumni status in the lang team. We'll miss you, @eddyb! ❤️ 