### PR TITLE
Add support for declaring team alumni

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -42,6 +42,11 @@ members = [
     "craterbot",
     "rust-timer",
 ]
+# Past members of the team. They will not be considered as part of the team,
+# but they will be recognized on the website.
+alumni = [
+    "buildbot",
+]
 
 [permissions]
 # Optional, see the permissions documentation

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -19,6 +19,7 @@ pub struct Team {
     pub kind: TeamKind,
     pub subteam_of: Option<String>,
     pub members: Vec<TeamMember>,
+    pub alumni: Vec<TeamMember>,
     pub github: Option<TeamGitHub>,
     pub website_data: Option<TeamWebsite>,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -179,7 +179,18 @@ impl Team {
                 }
             }
         }
+        if self.people.include_all_alumni {
+            for team in data.teams() {
+                for person in &team.people.alumni {
+                    members.insert(&person);
+                }
+            }
+        }
         Ok(members)
+    }
+
+    pub(crate) fn alumni(&self) -> &[String] {
+        &self.people.alumni
     }
 
     pub(crate) fn raw_lists(&self) -> &[TeamList] {
@@ -291,12 +302,16 @@ impl std::cmp::Ord for GitHubTeam<'_> {
 struct TeamPeople {
     leads: Vec<String>,
     members: Vec<String>,
+    #[serde(default)]
+    alumni: Vec<String>,
     #[serde(default = "default_false")]
     include_team_leads: bool,
     #[serde(default = "default_false")]
     include_wg_leads: bool,
     #[serde(default = "default_false")]
     include_all_team_members: bool,
+    #[serde(default = "default_false")]
+    include_all_alumni: bool,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -49,6 +49,19 @@ impl<'a> Generator<'a> {
             members.sort_by_key(|member| member.github.to_lowercase());
             members.sort_by_key(|member| !member.is_lead);
 
+            let mut alumni = Vec::new();
+            for github_name in team.alumni() {
+                if let Some(person) = self.data.person(github_name) {
+                    alumni.push(v1::TeamMember {
+                        name: person.name().into(),
+                        github: github_name.to_string(),
+                        github_id: person.github_id(),
+                        is_lead: false,
+                    });
+                }
+            }
+            alumni.sort_by_key(|member| member.github.to_lowercase());
+
             let mut github_teams = team.github_teams(&self.data)?;
             github_teams.sort();
 
@@ -63,6 +76,7 @@ impl<'a> Generator<'a> {
                 },
                 subteam_of: team.subteam_of().map(|st| st.into()),
                 members,
+                alumni,
                 github: Some(v1::TeamGitHub {
                     teams: github_teams
                         .into_iter()

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -151,6 +151,9 @@ fn validate_inactive_members(data: &Data, errors: &mut Vec<String>) {
         for member in members {
             active_members.insert(member);
         }
+        for person in team.alumni() {
+            active_members.insert(&person);
+        }
         Ok(())
     });
 

--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -34,6 +34,9 @@ members = [
     "whitequark",
     "wycats",
 ]
+# Temporary key that includes all members listed as alumni in the individual
+# teams. This is needed while we migrate away from the alumni team.
+include-all-alumni = true
 
 [website]
 name = "Rust team alumni"


### PR DESCRIPTION
This PR adds support for declaring team alumni, which will be properly shown on the website. Team alumni will be automatically included in the `alumni` team. Team alumni will be included in the API.

r? @XAMPPRocky 