### PR TITLE
reflect reality wrt. the reference

### DIFF
--- a/teams/reference.toml
+++ b/teams/reference.toml
@@ -1,9 +1,11 @@
 name = "reference"
-subteam-of = "docs"
+subteam-of = "lang"
 
 [people]
-leads = ["Havvy"]
+leads = ["Centril", "ehuss"]
 members = [
+    "Centril",
+    "ehuss",
     "Havvy",
     "matthewjasper",
 ]


### PR DESCRIPTION
As requested by @XAMPPRocky...

The docs team is no more, so https://github.com/rust-lang-nursery/reference/ is probably under T-Lang's responsibility (spec and all...).

These days, most work & reviewing is being done by myself and @ehuss.