### PR TITLE
Add mailing list for the Web Presence team

### DIFF
--- a/teams/web-presence.toml
+++ b/teams/web-presence.toml
@@ -1,0 +1,18 @@
+name = "web-presence"
+
+[people]
+leads = []
+members = []
+
+[[lists]]
+address = "web-presence@rust-lang.org"
+extra-teams = [
+    "crates-io",
+    "docs-rs",
+]
+extra-people = [
+    "Manishearth",
+    "skade",
+    "XAMPPRocky",
+    "shepmaster",
+]


### PR DESCRIPTION
This adds the web-presence@rust-lang.org mailing list, and it intentionally doesn't include any other information. Memberships, leads and presence on the website will be added later.

r? @Manishearth 