### PR TITLE
Create core-observers GitHub team

### DIFF
--- a/teams/core-observers.toml
+++ b/teams/core-observers.toml
@@ -7,6 +7,9 @@ members = [
     "skade",
 ]
 
+[github]
+orgs = ["rust-lang"]
+
 [permissions]
 bors.rust.review = true
 


### PR DESCRIPTION
This will create a core-observers GitHub team, allowing to give permissions to them without granting individual access.