### PR TITLE
Add `wg-const-eval` team

### DIFF
--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -12,7 +12,7 @@ members = [
 
 [website]
 name = "Compile-time function evaluation"
-description = "Expanding the capabilities of compile-time function evaluation in Rust"
+description = "Soundly expanding the capabilities of compile-time function evaluation in Rust"
 repo = "https://github.com/rust-lang/const-eval"
 
 [github]

--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -1,0 +1,19 @@
+name = "wg-const-eval"
+subteam-of = "compiler"
+wg = true
+
+[people]
+leads = ["oli-obk", "RalfJung"]
+members = [
+    "ecstatic-morse",
+    "oli-obk",
+    "RalfJung",
+]
+
+[website]
+name = "Compile-time function evaluation"
+description = "Expanding the capabilities of compile-time function evaluation in Rust"
+repo = "https://github.com/rust-lang/const-eval"
+
+[github]
+orgs = ["rust-lang", "rust-lang-nursery"]

--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -16,4 +16,4 @@ description = "Soundly expanding the capabilities of compile-time function evalu
 repo = "https://github.com/rust-lang/const-eval"
 
 [github]
-orgs = ["rust-lang", "rust-lang-nursery"]
+orgs = ["rust-lang"]

--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [website]
-name = "Compile-time function evaluation"
+name = "Compile-time Function Evaluation Working Group"
 description = "Soundly expanding the capabilities of compile-time function evaluation in Rust"
 repo = "https://github.com/rust-lang/const-eval"
 


### PR DESCRIPTION
...with @oli-obk and @RalfJung as co-leads and myself as a member. I don't think this implies any additional level of commitment from the two leads, it's just a reflection of seniority.

We might need to block this on me reviving rust-lang/compiler-team#201? Not sure what the process is here.

r? @XAMPPRocky 
(since they requested this on Zulip)