### PR TITLE
Add alumni team deprecation notice and fix changes from #337

### DIFF
--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -1,3 +1,6 @@
+# DEPRECATED: Do not add new members to this team, instead add to `people.alumni`
+# in the team's file or create a new `people.alumni` key and add the
+# person's name there instead.
 name = "alumni"
 
 [people]
@@ -25,7 +28,6 @@ members = [
     "jonathandturner",
     "jseyfried",
     "levex",
-    "nasa42",
     "niconii",
     "pcwalton",
     "peschkaj",

--- a/teams/community-content.toml
+++ b/teams/community-content.toml
@@ -9,6 +9,9 @@ members = [
     "skade",
     "wezm",
 ]
+alumni = [
+    "nasa42",
+]
 
 [website]
 name = "Content team"

--- a/teams/twir.toml
+++ b/teams/twir.toml
@@ -6,6 +6,9 @@ members = [
     "llogiq",
     "nellshamrell",
 ]
+alumni = [
+    "nasa42",
+]
 
 [[lists]]
 address = "twir@rust-lang.org"


### PR DESCRIPTION
We should let people know not to use the `alumni.toml`. 