### PR TITLE
Add discord ID for jtgeibel and pietroalbini

### DIFF
--- a/people/jtgeibel.toml
+++ b/people/jtgeibel.toml
@@ -2,6 +2,7 @@ name = "Justin Geibel"
 github = "jtgeibel"
 github-id = 22186
 email = "jtgeibel@gmail.com"
+discord-id = 451522714101088258
 
 [permissions]
 crates-io-ops-bot.staging_crates_io = true

--- a/people/pietroalbini.toml
+++ b/people/pietroalbini.toml
@@ -2,6 +2,7 @@ name = "Pietro Albini"
 github = "pietroalbini"
 github-id = 2299951
 email = "pietro@pietroalbini.org"
+discord-id = 296309029947441155
 
 [permissions]
 crates-io-ops-bot.staging_crates_io = true


### PR DESCRIPTION
Following the instructions for [obtaining a discord user id], I looked up values for our `discord-id`s.

r? @pietroalbini

[obtaining a discord user id]: https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-