### PR TITLE
add `your_name_here` to the ARM team

### DIFF
--- a/teams/arm.toml
+++ b/teams/arm.toml
@@ -9,4 +9,5 @@ members = [
     "joaopaulocarreiro",
     "raw-bin",
     "vigoux",
+    "your_name_here", # Don't forget to run `cargo run add-person` if you're new!
 ]


### PR DESCRIPTION
This is an example PR to show how to add yourself to the ARM notification group. It will not be merged.

Once you add your name to the list, you also want to run `cargo run add-person your_name_here`, unless you're already in the team repository. 