### PR TITLE
Add RISC-V group

### DIFF
--- a/people/denisvasilik.toml
+++ b/people/denisvasilik.toml
@@ -1,0 +1,4 @@
+name = 'Denis Vasilik'
+github = 'denisvasilik'
+github-id = 18697981
+email = 'contact@denisvasilik.com'

--- a/people/tblah.toml
+++ b/people/tblah.toml
@@ -1,0 +1,3 @@
+name = 'Tom Eccles'
+github = 'tblah'
+github-id = 3716681

--- a/teams/risc-v.toml
+++ b/teams/risc-v.toml
@@ -1,0 +1,10 @@
+name = "riscv"
+marker-team = true
+
+[people]
+leads = []
+members = [
+    "denisvasilik",
+    "Disasm",
+    "tblah",
+]

--- a/teams/risc-v.toml
+++ b/teams/risc-v.toml
@@ -1,4 +1,4 @@
-name = "riscv"
+name = "risc-v"
 marker-team = true
 
 [people]


### PR DESCRIPTION
cc @denisvasilik @Disasm

On https://github.com/rust-lang/rust/pull/72973 @nikomatsakis  suggested creating a RISC-V group (similar to the ARM and Windows groups). 

r? @nikomatsakis 