### PR TITLE
Add website team

### DIFF
--- a/teams/website.toml
+++ b/teams/website.toml
@@ -1,0 +1,14 @@
+name = "website"
+subteam-of = "web-presence"
+
+[people]
+leads = ["Manishearth", "skade"]
+members = [
+    "Manishearth",
+    "XAMPPRocky",
+    "pietroalbini",
+    "skade",
+]
+
+[github]
+orgs = ["rust-lang"]


### PR DESCRIPTION
This is mostly to get a GitHub team we can synchronize permissions with. We'll add it to the website along with the Web Presence team in the future.

r? @Manishearth 