### PR TITLE
Add johndoe to Incr. Comp. WG

### DIFF
--- a/people/johndoe.toml
+++ b/people/johndoe.toml
@@ -1,0 +1,3 @@
+name = 'johndoe'
+github = 'johndoe'
+github-id = 29063

--- a/teams/wg-incr-comp.toml
+++ b/teams/wg-incr-comp.toml
@@ -4,7 +4,7 @@ wg = true
 
 [people]
 leads = ["pnkfelix", "spastorino"]
-members = ["davidtwco", "pnkfelix", "spastorino", "wesleywiser"]
+members = ["davidtwco", "pnkfelix", "spastorino", "wesleywiser", "johndoe"]
 
 [github]
 orgs = ["rust-lang"]


### PR DESCRIPTION
This PR is meant to serve as an example! To add yourself to the Incr. Comp. WG, just create a commit like this one, but using your own username instead of `john-doe`.

If you are already a member of a Rust team you don't need to add a `people/john-doe.toml` like file because you will have an existing one for your username. If you're not part of the team, you have to checkout the repository, run the command below and commit the new file it creates

```shell
cargo run add-person $your_user_name
```