### PR TITLE
Add the infrastructure team to the bors-rs organization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ allowed-mailing-lists-domains = [
 ]
 
 allowed-github-orgs = [
+    "bors-rs",
     "rust-lang",
     "rust-lang-ci",
     "rust-lang-nursery",

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -120,7 +120,8 @@ pub(crate) struct Team {
     people: TeamPeople,
     #[serde(default)]
     permissions: Permissions,
-    github: Option<GitHubData>,
+    #[serde(default)]
+    github: Vec<GitHubData>,
     rfcbot: Option<RfcbotData>,
     website: Option<WebsiteData>,
     #[serde(default)]
@@ -243,7 +244,8 @@ impl Team {
     }
 
     pub(crate) fn github_teams<'a>(&'a self, data: &Data) -> Result<Vec<GitHubTeam<'a>>, Error> {
-        if let Some(github) = &self.github {
+        let mut result = Vec::new();
+        for github in &self.github {
             let mut members = self
                 .members(data)?
                 .iter()
@@ -259,18 +261,16 @@ impl Team {
                 );
             }
             let name = github.team_name.as_deref().unwrap_or(&self.name);
-            Ok(github
-                .orgs
-                .iter()
-                .map(|org| GitHubTeam {
+
+            for org in &github.orgs {
+                result.push(GitHubTeam {
                     org: org.as_str(),
                     name,
                     members: members.clone(),
-                })
-                .collect())
-        } else {
-            Ok(Vec::new())
+                });
+            }
         }
+        Ok(result)
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -260,6 +260,7 @@ impl Team {
                         .filter_map(|name| data.person(name).map(|p| p.github_id())),
                 );
             }
+            members.sort();
             let name = github.team_name.as_deref().unwrap_or(&self.name);
 
             for org in &github.orgs {

--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -14,7 +14,7 @@ members = [
 bors.rust.review = true
 bors.cargo.review = true
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [rfcbot]

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -19,7 +19,7 @@ members = [
 [permissions]
 bors.clippy.review = true
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [website]

--- a/teams/community-content.toml
+++ b/teams/community-content.toml
@@ -20,5 +20,5 @@ repo = "https://github.com/rust-community/content-team"
 discord-invite = "https://discord.gg/b7a22kw"
 discord-name = "#content-team"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/community-events.toml
+++ b/teams/community-events.toml
@@ -20,5 +20,5 @@ repo = "https://github.com/rust-community/events-team"
 discord-invite = "https://discord.gg/cj5HMXA"
 discord-name = "#events"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/community-localization.toml
+++ b/teams/community-localization.toml
@@ -20,7 +20,7 @@ name = "Localization team"
 description = "Working on localization of compiler, documentation and websites"
 repo = "https://github.com/rust-lang/community-localization"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [[lists]]

--- a/teams/community-rustbridge.toml
+++ b/teams/community-rustbridge.toml
@@ -20,5 +20,5 @@ repo = "https://github.com/rustbridge/team"
 discord-invite = "https://discord.gg/cj5HMXA"
 discord-name = "#rustbridge"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/community-survey.toml
+++ b/teams/community-survey.toml
@@ -11,5 +11,5 @@ members = [
 name = "Survey team"
 description = "Running, analysing, and presenting the community survey"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/community.toml
+++ b/teams/community.toml
@@ -24,7 +24,7 @@ repo = "https://github.com/rust-community/team"
 discord-invite = "https://discord.gg/KskHZGT"
 discord-name = "#community-team"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [[lists]]

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -31,7 +31,7 @@ perf = true
 crater = true
 bors.rust.review = true
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 extra-teams = ["compiler"]
 

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -26,7 +26,7 @@ crater = true
 bors.rust.review = true
 bors.miri.review = true
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [rfcbot]

--- a/teams/core-observers.toml
+++ b/teams/core-observers.toml
@@ -7,7 +7,7 @@ members = [
     "skade",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [permissions]

--- a/teams/core.toml
+++ b/teams/core.toml
@@ -18,7 +18,7 @@ members = [
 bors.rust.review = true
 bors.team.review = true
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [rfcbot]

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -24,7 +24,7 @@ members = [
 bors.crates_io.review = true
 crates-io-ops-bot.staging_crates_io = true
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [rfcbot]

--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -18,7 +18,7 @@ repo = "https://github.com/rust-dev-tools/dev-tools-team"
 discord-invite = "https://discord.gg/sG23nSS"
 discord-name = "#dev-tools"
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-dev-tools"]
 
 [[lists]]

--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -12,7 +12,7 @@ members = [
     "pietroalbini",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [rfcbot]

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -16,6 +16,10 @@ members = [
 [[github]]
 orgs = ["rust-lang", "rust-lang-ci", "rust-lang-nursery"]
 
+[[github]]
+team-name = "rust-infra"
+orgs = ["bors-rs"]
+
 [permissions]
 perf = true
 crater = true

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -13,7 +13,7 @@ members = [
     "shepmaster",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-ci", "rust-lang-nursery"]
 
 [permissions]

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -19,7 +19,7 @@ perf = true
 crater = true
 bors.rust.review = true
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [rfcbot]

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -13,7 +13,7 @@ members = [
     "LukasKalbertodt",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [permissions]

--- a/teams/miri.toml
+++ b/teams/miri.toml
@@ -13,5 +13,5 @@ name = "Miri"
 description = "design and implementation of the Miri interpreter"
 repo = "https://github.com/rust-lang/miri"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/release.toml
+++ b/teams/release.toml
@@ -23,7 +23,7 @@ crater = true
 perf = true
 bors.rust.review = true
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [rfcbot]

--- a/teams/rust-by-example.toml
+++ b/teams/rust-by-example.toml
@@ -8,7 +8,7 @@ members = [
     "marioidival",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [website]

--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -9,7 +9,7 @@ members = [
     "kinnison",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [permissions]

--- a/teams/website.toml
+++ b/teams/website.toml
@@ -10,5 +10,5 @@ members = [
     "skade",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-async-foundations.toml
+++ b/teams/wg-async-foundations.toml
@@ -16,7 +16,7 @@ members = [
   "LucioFranco",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [website]

--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -15,5 +15,5 @@ name = "Compile-time Function Evaluation Working Group"
 description = "Soundly expanding the capabilities of compile-time function evaluation in Rust"
 repo = "https://github.com/rust-lang/const-eval"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-embedded-infra.toml
+++ b/teams/wg-embedded-infra.toml
@@ -13,7 +13,7 @@ members = [
 name = "Embedded infrastructure team"
 description = "This teams manages embedded-wg domains, DNS records, e-mails aliases, etc."
 
-[github]
+[[github]]
 orgs = ["rust-embedded"]
 team-name = "infrastructure"
 

--- a/teams/wg-embedded-resources.toml
+++ b/teams/wg-embedded-resources.toml
@@ -18,5 +18,5 @@ members = [
 name = "Embedded resources working group"
 description = "Managing various resources owned by the embedded working group"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-ffi-unwind.toml
+++ b/teams/wg-ffi-unwind.toml
@@ -17,5 +17,5 @@ name = "ffi-unwind project group"
 description = "A working-group project to extend the Rust language to support unwinding that crosses FFI boundaries"
 repo = "https://github.com/rust-lang/project-ffi-unwind"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-governance.toml
+++ b/teams/wg-governance.toml
@@ -2,7 +2,7 @@ name = "wg-governance"
 subteam-of = "core"
 wg = true
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [people]

--- a/teams/wg-incr-comp.toml
+++ b/teams/wg-incr-comp.toml
@@ -6,7 +6,7 @@ wg = true
 leads = ["pnkfelix", "spastorino"]
 members = ["davidtwco", "pnkfelix", "spastorino", "wesleywiser"]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [website]

--- a/teams/wg-inline-asm.toml
+++ b/teams/wg-inline-asm.toml
@@ -14,5 +14,5 @@ name = "inline-asm project group"
 description = "A working-group project to extend the Rust language to support inline assembly"
 repo = "https://github.com/rust-lang/project-inline-asm"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-mir-opt.toml
+++ b/teams/wg-mir-opt.toml
@@ -6,7 +6,7 @@ wg = true
 leads = ["oli-obk"]
 members = ["oli-obk", "spastorino", "eddyb", "davidtwco", "wesleywiser", "vertexclique"]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [website]

--- a/teams/wg-polonius.toml
+++ b/teams/wg-polonius.toml
@@ -11,5 +11,5 @@ name = "Polonius working group"
 description = "Working on an experimental new borrow-checker implementation"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/polonius/"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-prioritization.toml
+++ b/teams/wg-prioritization.toml
@@ -25,5 +25,5 @@ name = "Prioritization working group"
 description = "Triaging bugs, mainly deciding if bugs are critical (potential release blockers) or not"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/prioritization/"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-rfc-2229.toml
+++ b/teams/wg-rfc-2229.toml
@@ -16,7 +16,7 @@ members = [
         "roxelo"
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [website]

--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -6,7 +6,7 @@ wg = true
 leads = ["spastorino", "mark-i-m"]
 members = ["spastorino", "mark-i-m", "amanjeev", "tshepang", "togiberlin", "JohnTitor", "chrissimpkins", "LeSeulArtichaut", "Nashenas88"]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [website]

--- a/teams/wg-rustfmt.toml
+++ b/teams/wg-rustfmt.toml
@@ -10,7 +10,7 @@ members = [
     "calebcartwright",
 ]
 
-[github]
+[[github]]
 orgs = ["rust-lang"]
 
 [website]

--- a/teams/wg-safe-transmute.toml
+++ b/teams/wg-safe-transmute.toml
@@ -14,5 +14,5 @@ name = "safe-transmute project group"
 description = "A working-group project to extend the Rust language to support safe transmute between types"
 repo = "https://github.com/rust-lang/project-safe-transmute"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-security-response.toml
+++ b/teams/wg-security-response.toml
@@ -10,7 +10,7 @@ members = [
     "steveklabnik",
 ]
 
-[github]
+[[github]]
 team-name = "security"
 orgs = ["rust-lang"]
 

--- a/teams/wg-traits.toml
+++ b/teams/wg-traits.toml
@@ -28,5 +28,5 @@ name = "Traits working group"
 description = "Revamping the rustc trait implementation to follow the Chalk approach"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/traits/"
 
-[github]
+[[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -23,5 +23,5 @@ description = "Triaging repositories under the rust-lang organisation"
 discord-invite = "https://discord.gg/e6Q3cvu"
 discord-name = "#triage-wg"
 
-[github]
+[[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
This PR synchronizes the infrastructure team with the [bors-rs](https://github.com/bors-rs) GitHub organization. Along with this change, the schema is changed to allow multiple instances of `[github]` in a single team file (turning it into `[[github]]`).