### PR TITLE
Reflect embedded WG leadership change

### DIFF
--- a/teams/wg-embedded.toml
+++ b/teams/wg-embedded.toml
@@ -2,7 +2,7 @@ name = "wg-embedded"
 wg = true
 
 [people]
-leads = ["japaric", "therealprof", "jamesmunns"]
+leads = ["adamgreig", "japaric", "therealprof"]
 members = [
     "adamgreig",
     "almindor",


### PR DESCRIPTION
James Munns stepped down from the embedded WG leadership and Adam Greig
will take over.

CC https://github.com/rust-embedded/wg/pull/463

Signed-off-by: Daniel Egger <daniel@eggers-club.de>