### PR TITLE
Remove Manishearth from mods-all

### DIFF
--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -32,4 +32,3 @@ extra-teams = [
     "mods-discord",
     "mods-discourse",
 ]
-extra-people = ["Manishearth"] # Temporary, while we focus on trying to improve moderation and stuff


### PR DESCRIPTION
This was never intended to be permanent, it was a transition thing as I was setting up the discourse/discord moderation.