### PR TITLE
Add diagnostics working group

### DIFF
--- a/teams/wg-diagnostics.toml
+++ b/teams/wg-diagnostics.toml
@@ -1,0 +1,15 @@
+name = "wg-diagnostics"
+subteam-of = "compiler"
+wg = true
+
+[people]
+leads = ["estebank", "oli-obk"]
+members = ["davidtwco", "estebank", "JohnTitor", "oli-obk"]
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "Diagnostics working group"
+description = "Aiming to make rustc better at telling the user why the compiler isn't smart enough to understand their code yet"
+repo = "https://rust-lang.github.io/compiler-team/working-groups/diagnostics/"


### PR DESCRIPTION
Manage diagnostics working group here like other WGs based on the discussion on Zulip. Member list is taken from the current GitHub team + me, the leads are from https://rust-lang.github.io/compiler-team/working-groups/diagnostics/.
cc @rust-lang/wg-diagnostics 