### PR TITLE
Grant rust-timer try permissions on rust-lang/rust

### DIFF
--- a/people/rust-timer.toml
+++ b/people/rust-timer.toml
@@ -1,0 +1,8 @@
+name = 'Rust timing data pusher'
+github = 'rust-timer'
+github-id = 12471139
+
+[permissions]
+# Needed for try builds and rollup=never, used to extract PRs from rollups to
+# benchmark separately.
+bors.rust.try = true


### PR DESCRIPTION
This should be sufficient to start working towards automated anti-perf sensitive
rolling up.