### PR TITLE
Update wg-traits review permissions

### DIFF
--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -169,6 +169,7 @@ permissions! {
     }
     bors_repos {
         cargo,
+        chalk,
         clippy,
         compiler_builtins,
         crater,

--- a/teams/wg-traits.toml
+++ b/teams/wg-traits.toml
@@ -30,3 +30,6 @@ repo = "https://rust-lang.github.io/compiler-team/working-groups/traits/"
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
+
+[permissions]
+bors.chalk.review = true


### PR DESCRIPTION
As a preliminary for getting bors set up in the chalk repo.