### PR TITLE
Add `your_name_here` to the RISC-V team

### DIFF
--- a/teams/risc-v.toml
+++ b/teams/risc-v.toml
@@ -7,4 +7,5 @@ members = [
     "denisvasilik",
     "Disasm",
     "tblah",
+    "your_name_here", # Don't forget to run `cargo run add-person` if you're new!
 ]


### PR DESCRIPTION
This is an example PR to show how to add yourself to the RISC-V notification group. It will not be merged.

Once you add your name to the list, you also want to run `cargo run add-person your_name_here`, unless you're already in the team repository.