### PR TITLE
Add @lenary to RISC-V team

### DIFF
--- a/people/lenary.toml
+++ b/people/lenary.toml
@@ -1,0 +1,6 @@
+name = 'Sam Elliott'
+email = "sam@lenary.co.uk"
+github = 'lenary'
+github-id = 14548
+discord-id = 646368775599423489
+zulip-id = 325842

--- a/teams/risc-v.toml
+++ b/teams/risc-v.toml
@@ -6,5 +6,6 @@ leads = []
 members = [
     "denisvasilik",
     "Disasm",
+    "lenary",
     "tblah",
 ]


### PR DESCRIPTION
I work on the RISC-V LLVM backend, at lowRISC (we are the official maintainers). It is useful to be tagged on bugs which may need upstream fixes, or reviews around expected functionality of the backend - this allows me to prioritise fixes.

I'm not sure who I should be cc'ing on this PR.

