### PR TITLE
Synchronize wg-llvm with GitHub

### DIFF
--- a/teams/wg-llvm.toml
+++ b/teams/wg-llvm.toml
@@ -6,6 +6,9 @@ wg = true
 leads = ["nagisa"]
 members = ["nagisa"]
 
+[[github]]
+orgs = ["rust-lang"]
+
 [website]
 name = "LLVM working group"
 description = "Working with LLVM upstream to represent Rust in its development"


### PR DESCRIPTION
cc @cuviper @nikic -- I've added this which should make @rust-lang/wg-llvm actually pingable (something I've at least personally wanted for a long time now).

cc @nikomatsakis @pnkfelix as t-compiler leads

r? @pietroalbini to make sure I did it right