### PR TITLE
Add flip1995 as Clippy co-lead, move Oli back to a regular team member

### DIFF
--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -2,7 +2,7 @@ name = "clippy"
 subteam-of = "devtools"
 
 [people]
-leads = ["Manishearth", "oli-obk"]
+leads = ["Manishearth", "flip1995"]
 members = [
     "llogiq",
     "killercup",


### PR DESCRIPTION
@flip1995 has been doing a lot of great maintenance work in Clippy, organizing reviewers, helping grow new reviewers, etc. I'd like to promote them to being Clippy co-lead.

@oli-obk has stated they don't have bandwidth to give clippy leadership justice; retiring them back to being a "normal" team member. Thanks for everything, Oli!

cc @rust-lang/clippy 