### PR TITLE
Add support for project groups

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -30,6 +30,13 @@ directory. The structure of the file is this:
 name = "overlords"  # Name of the team, used for GitHub (required)
 subteam-of = "gods"  # Name of the parent team of this team (optional)
 
+# The kind of the team (optional). Could be be:
+# - team (default)
+# - working-group
+# - project-group
+# - marker-team
+kind = "working-group"
+
 [people]
 # Leads of the team, can be more than one and must be members of the team.
 # Required, but it can be empty

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -8,6 +8,7 @@ pub static BASE_URL: &str = "https://team-api.infra.rust-lang.org/v1";
 pub enum TeamKind {
     Team,
     WorkingGroup,
+    ProjectGroup,
     MarkerTeam,
     #[serde(other)]
     Unknown,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -108,12 +108,26 @@ impl Person {
     }
 }
 
-#[derive(serde_derive::Deserialize, Debug, PartialEq, Eq)]
+#[derive(serde_derive::Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum TeamKind {
     Team,
     WorkingGroup,
     MarkerTeam,
+}
+
+impl std::fmt::Display for TeamKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Team => "team",
+                Self::WorkingGroup => "working group",
+                Self::MarkerTeam => "marker team",
+            }
+        )
+    }
 }
 
 impl Default for TeamKind {
@@ -145,12 +159,8 @@ impl Team {
         &self.name
     }
 
-    pub(crate) fn is_wg(&self) -> bool {
-        self.kind == TeamKind::WorkingGroup
-    }
-
-    pub(crate) fn is_marker_team(&self) -> bool {
-        self.kind == TeamKind::MarkerTeam
+    pub(crate) fn kind(&self) -> TeamKind {
+        self.kind
     }
 
     pub(crate) fn subteam_of(&self) -> Option<&str> {
@@ -173,9 +183,12 @@ impl Team {
         let mut members: HashSet<_> = self.people.members.iter().map(|s| s.as_str()).collect();
         if self.people.include_team_leads || self.people.include_wg_leads {
             for team in data.teams() {
-                let include_wg = team.is_wg() && self.people.include_wg_leads;
-                let include_team = !team.is_wg() && self.people.include_team_leads;
-                if team.name != self.name && (include_wg || include_team) {
+                let should_include = match self.kind {
+                    TeamKind::Team => self.people.include_team_leads,
+                    TeamKind::WorkingGroup => self.people.include_wg_leads,
+                    TeamKind::MarkerTeam => false,
+                };
+                if team.name != self.name && should_include {
                     for lead in team.leads() {
                         members.insert(lead);
                     }
@@ -184,8 +197,7 @@ impl Team {
         }
         if self.people.include_all_team_members {
             for team in data.teams() {
-                if team.is_wg()
-                    || team.is_marker_team()
+                if team.kind != TeamKind::Team
                     || team.name == self.name
                     // This matches the special alumni team.
                     || team.people.include_all_alumni

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -108,14 +108,26 @@ impl Person {
     }
 }
 
+#[derive(serde_derive::Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum TeamKind {
+    Team,
+    WorkingGroup,
+    MarkerTeam,
+}
+
+impl Default for TeamKind {
+    fn default() -> Self {
+        Self::Team
+    }
+}
+
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Team {
     name: String,
-    #[serde(default = "default_false")]
-    wg: bool,
-    #[serde(default = "default_false")]
-    marker_team: bool,
+    #[serde(default)]
+    kind: TeamKind,
     subteam_of: Option<String>,
     people: TeamPeople,
     #[serde(default)]
@@ -134,11 +146,11 @@ impl Team {
     }
 
     pub(crate) fn is_wg(&self) -> bool {
-        self.wg
+        self.kind == TeamKind::WorkingGroup
     }
 
     pub(crate) fn is_marker_team(&self) -> bool {
-        self.marker_team
+        self.kind == TeamKind::MarkerTeam
     }
 
     pub(crate) fn subteam_of(&self) -> Option<&str> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -113,6 +113,7 @@ impl Person {
 pub(crate) enum TeamKind {
     Team,
     WorkingGroup,
+    ProjectGroup,
     MarkerTeam,
 }
 
@@ -124,6 +125,7 @@ impl std::fmt::Display for TeamKind {
             match self {
                 Self::Team => "team",
                 Self::WorkingGroup => "working group",
+                Self::ProjectGroup => "project group",
                 Self::MarkerTeam => "marker team",
             }
         )
@@ -186,6 +188,7 @@ impl Team {
                 let should_include = match self.kind {
                     TeamKind::Team => self.people.include_team_leads,
                     TeamKind::WorkingGroup => self.people.include_wg_leads,
+                    TeamKind::ProjectGroup => self.people.include_project_group_leads,
                     TeamKind::MarkerTeam => false,
                 };
                 if team.name != self.name && should_include {
@@ -334,6 +337,8 @@ struct TeamPeople {
     include_team_leads: bool,
     #[serde(default = "default_false")]
     include_wg_leads: bool,
+    #[serde(default = "default_false")]
+    include_project_group_leads: bool,
     #[serde(default = "default_false")]
     include_all_team_members: bool,
     #[serde(default = "default_false")]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -1,5 +1,5 @@
 use crate::data::Data;
-use crate::schema::Permissions;
+use crate::schema::{Permissions, TeamKind};
 use failure::Error;
 use indexmap::IndexMap;
 use log::info;
@@ -67,12 +67,10 @@ impl<'a> Generator<'a> {
 
             let team_data = v1::Team {
                 name: team.name().into(),
-                kind: if team.is_wg() {
-                    v1::TeamKind::WorkingGroup
-                } else if team.is_marker_team() {
-                    v1::TeamKind::MarkerTeam
-                } else {
-                    v1::TeamKind::Team
+                kind: match team.kind() {
+                    TeamKind::Team => v1::TeamKind::Team,
+                    TeamKind::WorkingGroup => v1::TeamKind::WorkingGroup,
+                    TeamKind::MarkerTeam => v1::TeamKind::MarkerTeam,
                 },
                 subteam_of: team.subteam_of().map(|st| st.into()),
                 members,

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -70,6 +70,7 @@ impl<'a> Generator<'a> {
                 kind: match team.kind() {
                     TeamKind::Team => v1::TeamKind::Team,
                     TeamKind::WorkingGroup => v1::TeamKind::WorkingGroup,
+                    TeamKind::ProjectGroup => v1::TeamKind::ProjectGroup,
                     TeamKind::MarkerTeam => v1::TeamKind::MarkerTeam,
                 },
                 subteam_of: team.subteam_of().map(|st| st.into()),

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,13 +1,13 @@
 use crate::data::Data;
 use crate::github::GitHubApi;
-use crate::schema::{Email, Permissions};
+use crate::schema::{Email, Permissions, Team, TeamKind};
 use failure::{bail, Error};
 use log::{error, warn};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
 static CHECKS: &[fn(&Data, &mut Vec<String>)] = &[
-    validate_wg_names,
+    validate_name_prefixes,
     validate_subteam_of,
     validate_team_leads,
     validate_team_members,
@@ -23,7 +23,6 @@ static CHECKS: &[fn(&Data, &mut Vec<String>)] = &[
     validate_rfcbot_exclude_members,
     validate_team_names,
     validate_github_teams,
-    validate_marker_team,
     validate_discord_permissions,
     validate_zulip_stream_name,
 ];
@@ -66,19 +65,28 @@ pub(crate) fn validate(data: &Data, strict: bool) -> Result<(), Error> {
 }
 
 /// Ensure working group names start with `wg-`
-fn validate_wg_names(data: &Data, errors: &mut Vec<String>) {
-    wrapper(data.teams(), errors, |team, _| {
-        match (team.is_wg() == team.name().starts_with("wg-"), team.is_wg()) {
-            (false, true) => bail!(
-                "working group `{}`'s name doesn't start with wg-",
-                team.name()
-            ),
-            (false, false) => bail!(
-                "team `{}` seems like a working group but has `wg = false`",
-                team.name()
-            ),
-            (true, _) => {}
+fn validate_name_prefixes(data: &Data, errors: &mut Vec<String>) {
+    fn ensure_prefix(team: &Team, kind: TeamKind, prefix: &str) -> Result<(), Error> {
+        if team.kind() == kind && !team.name().starts_with(prefix) {
+            bail!(
+                "{} `{}`'s name doesn't start with `{}`",
+                kind,
+                team.name(),
+                prefix,
+            );
+        } else if team.kind() != kind && team.name().starts_with(prefix) {
+            bail!(
+                "{} `{}` seems like a {} (since it has the `{}` prefix)",
+                team.kind(),
+                team.name(),
+                kind,
+                prefix,
+            );
         }
+        Ok(())
+    }
+    wrapper(data.teams(), errors, |team, _| {
+        ensure_prefix(team, TeamKind::WorkingGroup, "wg-")?;
         Ok(())
     });
 }
@@ -359,17 +367,6 @@ fn validate_team_names(data: &Data, errors: &mut Vec<String>) {
                 team.name()
             );
         }
-        match (team.is_wg() == team.name().starts_with("wg-"), team.is_wg()) {
-            (false, true) => bail!(
-                "working group `{}`'s name doesn't start with wg-",
-                team.name()
-            ),
-            (false, false) => bail!(
-                "team `{}` seems like a working group but has `wg = false`",
-                team.name()
-            ),
-            (true, _) => {}
-        }
         Ok(())
     });
 }
@@ -422,19 +419,6 @@ fn validate_github_usernames(data: &Data, github: &GitHubApi, errors: &mut Vec<S
         }),
         Err(err) => errors.push(format!("couldn't verify GitHub usernames: {}", err)),
     }
-}
-
-/// Ensure teams are not working group and marker team at the same time
-fn validate_marker_team(data: &Data, errors: &mut Vec<String>) {
-    wrapper(data.teams(), errors, |team, _| {
-        if team.is_wg() && team.is_marker_team() {
-            bail!(
-                "`{}` is a working group and marker team at the same time",
-                team.name()
-            );
-        }
-        Ok(())
-    });
 }
 
 /// Ensure all users with a Discord permission have a Discord ID.

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -25,6 +25,7 @@ static CHECKS: &[fn(&Data, &mut Vec<String>)] = &[
     validate_github_teams,
     validate_discord_permissions,
     validate_zulip_stream_name,
+    validate_project_groups_have_parent_teams,
 ];
 
 static GITHUB_CHECKS: &[fn(&Data, &GitHubApi, &mut Vec<String>)] = &[validate_github_usernames];
@@ -472,6 +473,19 @@ fn validate_zulip_stream_name(data: &Data, errors: &mut Vec<String>) {
                     team.name()
                 );
             }
+        }
+        Ok(())
+    })
+}
+
+/// Ensure each project group has a parent team, according to RFC 2856.
+fn validate_project_groups_have_parent_teams(data: &Data, errors: &mut Vec<String>) {
+    wrapper(data.teams(), errors, |team, _| {
+        if team.kind() == TeamKind::ProjectGroup && team.subteam_of().is_none() {
+            bail!(
+                "the project group `{}` doesn't have a parent team, but it's required to have one",
+                team.name()
+            );
         }
         Ok(())
     })

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -87,6 +87,7 @@ fn validate_name_prefixes(data: &Data, errors: &mut Vec<String>) {
     }
     wrapper(data.teams(), errors, |team, _| {
         ensure_prefix(team, TeamKind::WorkingGroup, "wg-")?;
+        ensure_prefix(team, TeamKind::ProjectGroup, "project-")?;
         Ok(())
     });
 }

--- a/teams/archive/wg-net-async.toml
+++ b/teams/archive/wg-net-async.toml
@@ -1,6 +1,6 @@
 name = "wg-net-async"
 subteam-of = "wg-net"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["cramertj", "MajorBreakfast"]

--- a/teams/archive/wg-net-embedded.toml
+++ b/teams/archive/wg-net-embedded.toml
@@ -1,6 +1,6 @@
 name = "wg-net-embedded"
 subteam-of = "wg-net"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["Nemo157", "levex"]

--- a/teams/archive/wg-net-web.toml
+++ b/teams/archive/wg-net-web.toml
@@ -1,6 +1,6 @@
 name = "wg-net-web"
 subteam-of = "wg-net"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["aturon", "yoshuawuyts"]

--- a/teams/archive/wg-net.toml
+++ b/teams/archive/wg-net.toml
@@ -1,5 +1,5 @@
 name = "wg-net"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["withoutboats", "cramertj"]

--- a/teams/arm.toml
+++ b/teams/arm.toml
@@ -1,5 +1,5 @@
 name = "arm"
-marker-team = true
+kind = "marker-team"
 
 [people]
 leads = []

--- a/teams/icebreakers-cleanup-crew.toml
+++ b/teams/icebreakers-cleanup-crew.toml
@@ -1,5 +1,5 @@
 name = "icebreakers-cleanup-crew"
-marker-team = true
+kind = "marker-team"
 
 [people]
 leads = []

--- a/teams/icebreakers-llvm.toml
+++ b/teams/icebreakers-llvm.toml
@@ -1,5 +1,5 @@
 name = "icebreakers-llvm"
-marker-team = true
+kind = "marker-team"
 
 [people]
 leads = []

--- a/teams/risc-v.toml
+++ b/teams/risc-v.toml
@@ -1,5 +1,5 @@
 name = "risc-v"
-marker-team = true
+kind = "marker-team"
 
 [people]
 leads = []

--- a/teams/wg-async-foundations.toml
+++ b/teams/wg-async-foundations.toml
@@ -1,5 +1,5 @@
 name = "wg-async-foundations"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "tmandry"]

--- a/teams/wg-bindgen.toml
+++ b/teams/wg-bindgen.toml
@@ -1,6 +1,6 @@
 name = "wg-bindgen"
 subteam-of = "devtools"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["emilio", "fitzgen"]

--- a/teams/wg-cli.toml
+++ b/teams/wg-cli.toml
@@ -1,5 +1,5 @@
 name = "wg-cli"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["spacekookie"]

--- a/teams/wg-compiler-performance.toml
+++ b/teams/wg-compiler-performance.toml
@@ -1,6 +1,6 @@
 name = "wg-compiler-performance"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis"]

--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -1,6 +1,6 @@
 name = "wg-const-eval"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["oli-obk", "RalfJung"]

--- a/teams/wg-debugging.toml
+++ b/teams/wg-debugging.toml
@@ -1,6 +1,6 @@
 name = "wg-debugging"
 subteam-of = "devtools"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["Manishearth", "michaelwoerister"]

--- a/teams/wg-diagnostics.toml
+++ b/teams/wg-diagnostics.toml
@@ -1,6 +1,6 @@
 name = "wg-diagnostics"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["estebank", "oli-obk"]

--- a/teams/wg-embedded-infra.toml
+++ b/teams/wg-embedded-infra.toml
@@ -1,6 +1,6 @@
 name = "wg-embedded-infra"
 subteam-of = "wg-embedded"
-wg = true
+kind = "working-group"
 
 [people]
 leads = []

--- a/teams/wg-embedded-resources.toml
+++ b/teams/wg-embedded-resources.toml
@@ -1,6 +1,6 @@
 name = "wg-embedded-resources"
 subteam-of = "wg-embedded"
-wg = true
+kind = "working-group"
 
 [people]
 leads = []

--- a/teams/wg-embedded.toml
+++ b/teams/wg-embedded.toml
@@ -1,5 +1,5 @@
 name = "wg-embedded"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["adamgreig", "japaric", "therealprof"]

--- a/teams/wg-ffi-unwind.toml
+++ b/teams/wg-ffi-unwind.toml
@@ -1,6 +1,6 @@
 name = "wg-ffi-unwind"
 subteam-of = "lang"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "acfoltzer", "BatmanAoD"]

--- a/teams/wg-gamedev.toml
+++ b/teams/wg-gamedev.toml
@@ -1,5 +1,5 @@
 name = "wg-gamedev"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["AlexEne", "erlend-sh", "kvark"]

--- a/teams/wg-governance.toml
+++ b/teams/wg-governance.toml
@@ -1,6 +1,6 @@
 name = "wg-governance"
 subteam-of = "core"
-wg = true
+kind = "working-group"
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-grammar.toml
+++ b/teams/wg-grammar.toml
@@ -1,6 +1,6 @@
 name = "wg-grammar"
 subteam-of = "lang"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["eddyb", "qmx"]

--- a/teams/wg-incr-comp.toml
+++ b/teams/wg-incr-comp.toml
@@ -1,6 +1,6 @@
 name = "wg-incr-comp"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["pnkfelix", "spastorino"]

--- a/teams/wg-inline-asm.toml
+++ b/teams/wg-inline-asm.toml
@@ -1,6 +1,6 @@
 name = "wg-inline-asm"
 subteam-of = "lang"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["Amanieu", "joshtriplett"]

--- a/teams/wg-leads.toml
+++ b/teams/wg-leads.toml
@@ -1,5 +1,5 @@
 name = "wg-leads"
-wg = true
+kind = "working-group"
 
 [people]
 leads = []

--- a/teams/wg-leads.toml
+++ b/teams/wg-leads.toml
@@ -5,6 +5,7 @@ kind = "working-group"
 leads = []
 members = []
 include-wg-leads = true
+include-project-group-leads = true
 
 [[lists]]
 address = "wg-leads@rust-lang.org"

--- a/teams/wg-llvm.toml
+++ b/teams/wg-llvm.toml
@@ -1,6 +1,6 @@
 name = "wg-llvm"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nagisa"]

--- a/teams/wg-meta.toml
+++ b/teams/wg-meta.toml
@@ -1,6 +1,6 @@
 name = "wg-meta"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "davidtwco", "spastorino"]

--- a/teams/wg-mir-opt.toml
+++ b/teams/wg-mir-opt.toml
@@ -1,6 +1,6 @@
 name = "wg-mir-opt"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["oli-obk"]

--- a/teams/wg-nll.toml
+++ b/teams/wg-nll.toml
@@ -1,6 +1,6 @@
 name = "wg-nll"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "pnkfelix"]

--- a/teams/wg-parallel-rustc.toml
+++ b/teams/wg-parallel-rustc.toml
@@ -1,6 +1,6 @@
 name = "wg-parallel-rustc"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["Mark-Simulacrum", "nikomatsakis"]

--- a/teams/wg-pgo.toml
+++ b/teams/wg-pgo.toml
@@ -1,6 +1,6 @@
 name = "wg-pgo"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["michaelwoerister"]

--- a/teams/wg-polonius.toml
+++ b/teams/wg-polonius.toml
@@ -1,6 +1,6 @@
 name = "wg-polonius"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["lqd", "nikomatsakis"]

--- a/teams/wg-polymorphization.toml
+++ b/teams/wg-polymorphization.toml
@@ -1,6 +1,6 @@
 name = "wg-polymorphization"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["davidtwco"]

--- a/teams/wg-prioritization.toml
+++ b/teams/wg-prioritization.toml
@@ -1,6 +1,6 @@
 name = "wg-prioritization"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["spastorino", "wesleywiser"]

--- a/teams/wg-rfc-2229.toml
+++ b/teams/wg-rfc-2229.toml
@@ -1,6 +1,6 @@
 name = "wg-rfc-2229"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "matthewjasper"]

--- a/teams/wg-rls-2.toml
+++ b/teams/wg-rls-2.toml
@@ -1,6 +1,6 @@
 name = "wg-rls-2"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["matklad"]

--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -1,6 +1,6 @@
 name = "wg-rustc-dev-guide"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["spastorino", "mark-i-m"]

--- a/teams/wg-rustfix.toml
+++ b/teams/wg-rustfix.toml
@@ -1,6 +1,6 @@
 name = "wg-rustfix"
 subteam-of = "devtools"
-wg = true
+kind = "working-group"
 
 [people]
 leads = []

--- a/teams/wg-rustfmt.toml
+++ b/teams/wg-rustfmt.toml
@@ -1,6 +1,6 @@
 name = "wg-rustfmt"
 subteam-of = "devtools"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["topecongiro"]

--- a/teams/wg-rustup.toml
+++ b/teams/wg-rustup.toml
@@ -1,6 +1,6 @@
 name = "wg-rustup"
 subteam-of = "devtools"
-wg = true
+kind = "working-group"
 
 [people]
 leads = [

--- a/teams/wg-safe-transmute.toml
+++ b/teams/wg-safe-transmute.toml
@@ -1,6 +1,6 @@
 name = "wg-safe-transmute"
 subteam-of = "lang"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["rylev", "joshtriplett"]

--- a/teams/wg-secure-code.toml
+++ b/teams/wg-secure-code.toml
@@ -1,5 +1,5 @@
 name = "wg-secure-code"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["Shnatsel", "tarcieri"]

--- a/teams/wg-security-response.toml
+++ b/teams/wg-security-response.toml
@@ -1,5 +1,5 @@
 name = "wg-security-response"
-wg = true
+kind = "working-group"
 
 [people]
 leads = []

--- a/teams/wg-self-profile.toml
+++ b/teams/wg-self-profile.toml
@@ -1,6 +1,6 @@
 name = "wg-self-profile"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["michaelwoerister", "wesleywiser"]

--- a/teams/wg-traits.toml
+++ b/teams/wg-traits.toml
@@ -1,6 +1,6 @@
 name = "wg-traits"
 subteam-of = "compiler"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "jackh726"]

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -1,6 +1,6 @@
 name = "wg-triage"
 subteam-of = "operations"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["Dylan-DPC"]

--- a/teams/wg-unsafe-code-guidelines.toml
+++ b/teams/wg-unsafe-code-guidelines.toml
@@ -1,6 +1,6 @@
 name = "wg-unsafe-code-guidelines"
 subteam-of = "lang"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "avadacatavra", "RalfJung"]

--- a/teams/wg-wasm.toml
+++ b/teams/wg-wasm.toml
@@ -1,5 +1,5 @@
 name = "wg-wasm"
-wg = true
+kind = "working-group"
 
 [people]
 leads = ["fitzgen"]

--- a/teams/windows.toml
+++ b/teams/windows.toml
@@ -1,5 +1,5 @@
 name = "windows"
-marker-team = true
+kind = "marker-team"
 
 [people]
 leads = []


### PR DESCRIPTION
This PR refactors the backend to use an enum to represent the team kind, and adds support for project groups ([RFC 2856](https://github.com/rust-lang/rfcs/blob/master/text/2856-project-groups.md)).

This PR is best reviewed commit-by-commit.