### PR TITLE
teams/rustdoc: Retire Kinnison (for now)

### DIFF
--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -6,9 +6,11 @@ leads = ["GuillaumeGomez"]
 members = [
     "GuillaumeGomez",
     "ollie27",
-    "kinnison",
     "jyn514",
     "Manishearth",
+]
+alumni = [
+    "kinnison",
 ]
 
 [[github]]


### PR DESCRIPTION
I am not really in a position to continue as an active member of the rustdoc team for now.  I have limited free software time and it's all focussed on rustup.  This was agreed with @GuillaumeGomez and @Manishearth as likely the best path for now.