### PR TITLE
Add the inside-rust-reviewers marker team

### DIFF
--- a/teams/inside-rust-reviewers.toml
+++ b/teams/inside-rust-reviewers.toml
@@ -1,0 +1,11 @@
+name = "inside-rust-reviewers"
+kind = "marker-team"
+
+[people]
+leads = []
+members = []
+include-team-leads = true
+include-project-group-leads = true
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
This PR adds the `inside-rust-reviewers` marker team, which is composed by all team leads and project group leads. This is part of the work needed to address https://github.com/rust-lang/core-team/issues/18.

I chose to create a dedicated "reviewers" marker team instead of creating a `project-group-leads` team because that allows adding extra people as reviewers without having to change the CODEOWNERS file on the blog.