### PR TITLE
Note that rustdoc does not manage docs.rs

### DIFF
--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -28,7 +28,7 @@ ping = "rust-lang/rustdoc"
 
 [website]
 name = "Rustdoc team"
-description = "Developing and managing documentation tools, including Rustdoc and docs.rs"
+description = "Developing and managing the Rustdoc documentation tool
 discord-invite = "https://discord.gg/4yEYPuT"
 discord-name = "#rustdoc"
 

--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -28,7 +28,7 @@ ping = "rust-lang/rustdoc"
 
 [website]
 name = "Rustdoc team"
-description = "Developing and managing the Rustdoc documentation tool
+description = "Developing and managing the Rustdoc documentation tool"
 discord-invite = "https://discord.gg/4yEYPuT"
 discord-name = "#rustdoc"
 


### PR DESCRIPTION
Left over from https://github.com/rust-lang/team/pull/182, I noticed it in https://github.com/rust-lang/rust/issues/75619#issuecomment-677641995.