### PR TITLE
Replace Discord with Zulip in clippy team

### DIFF
--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -26,5 +26,4 @@ orgs = ["rust-lang"]
 [website]
 name = "Clippy team"
 description = "Designing and implementing the Clippy linter"
-discord-invite = "https://discord.gg/vNNtpyD"
-discord-name = "#clippy"
+zulip-stream = "clippy"


### PR DESCRIPTION
cc @flip1995 

Refer to https://github.com/rust-lang/rust-clippy/issues/5943#issuecomment-693735771

Moving from Discord to Zulip was discussed at https://github.com/rust-lang/rust-clippy/issues/5943 and new stream in Zulip has been already created.