### PR TITLE
Add BurntSushi back to FCP list

### DIFF
--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -29,7 +29,6 @@ label = "T-libs"
 name = "Libraries"
 ping = "rust-lang/libs"
 exclude-members = [
-    "BurntSushi",
     "LukasKalbertodt",
     "SimonSapin",
 ]


### PR DESCRIPTION
I _think_ this should add a @BurntSushi checkbox to FCPs without returning them to the `r?` rotation?

cc @Mark-Simulacrum @BurntSushi 