### PR TITLE
Add the portable SIMD project group team

### DIFF
--- a/people/KodrAus.toml
+++ b/people/KodrAus.toml
@@ -1,4 +1,4 @@
 name = "Ashley Mannix"
 github = "KodrAus"
 github-id = 6721458
-email = "ashleymannix@live.com.au"
+email = "kodraus@hey.com"

--- a/people/calebzulawski.toml
+++ b/people/calebzulawski.toml
@@ -1,0 +1,3 @@
+name = 'Caleb Zulawski'
+github = 'calebzulawski'
+github-id = 563826

--- a/people/hsivonen.toml
+++ b/people/hsivonen.toml
@@ -1,0 +1,4 @@
+name = 'Henri Sivonen'
+github = 'hsivonen'
+github-id = 478856
+email = 'hsivonen@hsivonen.fi'

--- a/people/workingjubilee.toml
+++ b/people/workingjubilee.toml
@@ -1,0 +1,3 @@
+name = 'Jubilee'
+github = 'workingjubilee'
+github-id = 46493976

--- a/teams/project-portable-simd.toml
+++ b/teams/project-portable-simd.toml
@@ -1,0 +1,26 @@
+name = "project-portable-simd"
+kind = "project-group"
+subteam-of = "libs"
+
+[people]
+leads = [
+    "calebzulawski",
+    "hsivonen",
+    "Lokathor",
+    "workingjubilee",
+]
+members = [
+    "BurntSushi",
+    "calebzulawski",
+    "KodrAus",
+    "hsivonen",
+    "Lokathor",
+    "workingjubilee",
+]
+
+[website]
+name = "Portable SIMD Project Group"
+description = "Adding portable SIMD to the standard library"
+
+[[github]]
+orgs = ["rust-lang"]

--- a/teams/project-portable-simd.toml
+++ b/teams/project-portable-simd.toml
@@ -4,10 +4,9 @@ subteam-of = "libs"
 
 [people]
 leads = [
-    "calebzulawski",
     "hsivonen",
+    "KodrAus",
     "Lokathor",
-    "workingjubilee",
 ]
 members = [
     "BurntSushi",


### PR DESCRIPTION
Adds the Portable SIMD project group team.

Links

- https://github.com/rust-lang/rfcs/pull/2977
- https://github.com/rust-lang/libs-team/issues/4

r? @Mark-Simulacrum 