### PR TITLE
Remove myself from Release team

### DIFF
--- a/teams/release.toml
+++ b/teams/release.toml
@@ -4,7 +4,6 @@ subteam-of = "operations"
 [people]
 leads = ["Mark-Simulacrum"]
 members = [
-    "BatmanAoD",
     "cuviper",
     "Dylan-DPC",
     "Mark-Simulacrum",
@@ -14,6 +13,7 @@ members = [
     "tmandry",
 ]
 alumni = [
+    "BatmanAoD",
     "Centril",
     "sgrif",
 ]


### PR DESCRIPTION
I have been shifting my focus to other efforts lately, and I now have a conflict during the Release team's weekly meeting, so I think it's best if I no longer be considered an official Release team member.