### PR TITLE
Set up libc team to give members bors perms

### DIFF
--- a/people/gnzlbg.toml
+++ b/people/gnzlbg.toml
@@ -3,5 +3,4 @@ github = "gnzlbg"
 github-id = 904614
 
 [permissions]
-bors.libc.review = true
 bors.stdarch.review = true

--- a/people/malbarbo.toml
+++ b/people/malbarbo.toml
@@ -1,6 +1,0 @@
-name = "Marco A L Barbosa"
-github = "malbarbo"
-github-id = 1678126
-
-[permissions]
-bors.libc.review = true

--- a/teams/libc.toml
+++ b/teams/libc.toml
@@ -1,0 +1,14 @@
+name = "libc"
+
+[people]
+leads = []
+members = [
+    "JohnTitor",
+    "joshtriplett",
+]
+
+[permissions]
+bors.libc.review = true
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
So, we now need to use bors on libc as the number of GHA jobs is large (https://github.com/rust-lang/libc/pull/1918#issuecomment-707140018). And as suggested in #444, I set up libc team to give us bors permission.
I'm not sure, but I think it's worth adding the GitHub team as well for the repository perms.
Closes #444

cc @joshtriplett and @pietroalbini 