### PR TITLE
Fix `clippy::stable_sort_primitive` warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn run() -> Result<(), Error> {
 
             let leads = team.leads();
             let mut members = team.members(&data)?.into_iter().collect::<Vec<_>>();
-            members.sort();
+            members.sort_unstable();
             for member in members {
                 println!(
                     "{}{}",
@@ -181,7 +181,7 @@ fn run() -> Result<(), Error> {
                 .into_iter()
                 .map(|person| person.github())
                 .collect::<Vec<_>>();
-            allowed.sort();
+            allowed.sort_unstable();
             for github_username in &allowed {
                 println!("{}", github_username);
             }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -292,7 +292,7 @@ impl Team {
                         .filter_map(|name| data.person(name).map(|p| p.github_id())),
                 );
             }
-            members.sort();
+            members.sort_unstable();
             let name = github.team_name.as_deref().unwrap_or(&self.name);
 
             for org in &github.orgs {

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -146,8 +146,8 @@ impl<'a> Generator<'a> {
                 .collect::<Vec<_>>();
 
             github_users.sort();
-            github_ids.sort();
-            discord_ids.sort();
+            github_ids.sort_unstable();
+            discord_ids.sort_unstable();
             self.add(
                 &format!("v1/permissions/{}.json", perm),
                 &v1::Permission {


### PR DESCRIPTION
Found in #452, opening in another PR not to block this minor fix.