### PR TITLE
Fix Zulip stream name

### DIFF
--- a/teams/lang-docs.toml
+++ b/teams/lang-docs.toml
@@ -19,4 +19,4 @@ orgs = ["rust-lang"]
 [website]
 name = "lang-docs team"
 description = "Developing and writing the docs related to the lang team"
-zulip-stream = "t-lang/docs"
+zulip-stream = "t-lang/doc"


### PR DESCRIPTION
It should've been `t-lang/doc`, sorry for the trouble.