### PR TITLE
Add library-reviewers team with rust-lang/rust review permission

### DIFF
--- a/teams/library-reviewers.toml
+++ b/teams/library-reviewers.toml
@@ -1,0 +1,25 @@
+name = "library-reviewers"
+subteam-of = "compiler"
+
+[people]
+leads = []
+members = [
+    "cramertj",
+    "dtolnay",
+    "joshtriplett",
+    "kennytm",
+    "KodrAus",
+    "LukasKalbertodt",
+    "Mark-Simulacrum",
+    "sfackler",
+    "shepmaster",
+    "withoutboats",
+]
+
+[[github]]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
+[permissions]
+perf = true
+crater = true
+bors.rust.review = true


### PR DESCRIPTION
Member list is taken from: https://github.com/rust-lang/highfive/blob/4420ccbffd38c700dbcfd3fb943f8b5ab53ee10d/highfive/configs/rust-lang/rust.json#L7-L9

The current list in this commit all already have at least these permissions.

- via libs team: dtolnay, KodrAus, LukasKalbertodt, sfackler, withoutboats
- via lang team: cramertj, joshtriplett
- via infra team: kennytm, Mark-Simulacrum, shepmaster

However, I am hoping to add another standard library reviewer who is not already in one of the other teams with review permission.