### PR TITLE
Avoid including "partial alumni" in the alumni team

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,7 @@
 use crate::schema::{Config, List, Person, Team};
 use failure::{Error, ResultExt};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::path::Path;
 
@@ -83,6 +83,19 @@ impl Data {
 
     pub(crate) fn people(&self) -> impl Iterator<Item = &Person> {
         self.people.values()
+    }
+
+    pub(crate) fn active_members(&self) -> Result<HashSet<&str>, Error> {
+        let mut result = HashSet::new();
+        for team in self.teams.values() {
+            if team.is_alumni_team() {
+                continue;
+            }
+            for member in team.members(self)? {
+                result.insert(member);
+            }
+        }
+        Ok(result)
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -203,7 +203,7 @@ impl Team {
                 if team.kind != TeamKind::Team
                     || team.name == self.name
                     // This matches the special alumni team.
-                    || team.people.include_all_alumni
+                    || team.is_alumni_team()
                 {
                     continue;
                 }
@@ -213,8 +213,12 @@ impl Team {
             }
         }
         if self.people.include_all_alumni {
+            let active_members = data.active_members()?;
             for team in data.teams() {
                 for person in &team.people.alumni {
+                    if active_members.contains(person.as_str()) {
+                        continue;
+                    }
                     members.insert(&person);
                 }
             }
@@ -304,6 +308,10 @@ impl Team {
             }
         }
         Ok(result)
+    }
+
+    pub(crate) fn is_alumni_team(&self) -> bool {
+        self.people.include_all_alumni
     }
 }
 

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -1,4 +1,26 @@
 {
+  "alumni": {
+    "name": "alumni",
+    "kind": "team",
+    "subteam_of": null,
+    "members": [
+      {
+        "name": "Fourth user",
+        "github": "user-4",
+        "github_id": 4,
+        "is_lead": false
+      },
+      {
+        "name": "Fifth user",
+        "github": "user-5",
+        "github_id": 5,
+        "is_lead": false
+      }
+    ],
+    "alumni": [],
+    "github": null,
+    "website_data": null
+  },
   "foo": {
     "name": "foo",
     "kind": "team",
@@ -86,6 +108,12 @@
         "name": "Zeroth user",
         "github": "user-0",
         "github_id": 0,
+        "is_lead": false
+      },
+      {
+        "name": "Fifth user",
+        "github": "user-5",
+        "github_id": 5,
         "is_lead": false
       }
     ],

--- a/tests/static-api/_expected/v1/teams/alumni.json
+++ b/tests/static-api/_expected/v1/teams/alumni.json
@@ -1,0 +1,22 @@
+{
+  "name": "alumni",
+  "kind": "team",
+  "subteam_of": null,
+  "members": [
+    {
+      "name": "Fourth user",
+      "github": "user-4",
+      "github_id": 4,
+      "is_lead": false
+    },
+    {
+      "name": "Fifth user",
+      "github": "user-5",
+      "github_id": 5,
+      "is_lead": false
+    }
+  ],
+  "alumni": [],
+  "github": null,
+  "website_data": null
+}

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -16,6 +16,12 @@
       "github": "user-0",
       "github_id": 0,
       "is_lead": false
+    },
+    {
+      "name": "Fifth user",
+      "github": "user-5",
+      "github_id": 5,
+      "is_lead": false
     }
   ],
   "github": null,

--- a/tests/static-api/people/user-4.toml
+++ b/tests/static-api/people/user-4.toml
@@ -1,0 +1,5 @@
+name = 'Fourth user'
+github = 'user-4'
+github-id = 4
+email = "user4@example.com"
+

--- a/tests/static-api/people/user-5.toml
+++ b/tests/static-api/people/user-5.toml
@@ -1,0 +1,5 @@
+name = 'Fifth user'
+github = 'user-5'
+github-id = 5
+email = "user5@example.com"
+

--- a/tests/static-api/teams/alumni.toml
+++ b/tests/static-api/teams/alumni.toml
@@ -1,0 +1,8 @@
+name = "alumni"
+
+[people]
+leads = []
+members = [
+    "user-4",
+]
+include-all-alumni = true

--- a/tests/static-api/teams/wg-test.toml
+++ b/tests/static-api/teams/wg-test.toml
@@ -4,4 +4,4 @@ kind = "working-group"
 [people]
 leads = ["user-2"]
 members = ["user-2"]
-alumni = ["user-0"]
+alumni = ["user-0", "user-5"]


### PR DESCRIPTION
There are some members of the Rust project that retired from one team but are still active in other teams. Before this commit they were listed in the "alumni" page, as they were marked as alumni of the team they retired of, but that didn't feel right as they haven't fully left the project.

This PR excludes members that are active in any team from being listed in the alumni team, even if they are alumni of one team.