### PR TITLE
Add library reviewers to website.

### DIFF
--- a/teams/library-reviewers.toml
+++ b/teams/library-reviewers.toml
@@ -1,5 +1,5 @@
 name = "library-reviewers"
-subteam-of = "compiler"
+subteam-of = "libs"
 
 [people]
 leads = []

--- a/teams/library-reviewers.toml
+++ b/teams/library-reviewers.toml
@@ -24,3 +24,7 @@ orgs = ["rust-lang", "rust-lang-nursery"]
 perf = true
 crater = true
 bors.rust.review = true
+
+[website]
+name = "Library reviewers"
+description = "Developing and reviewing changes to the Rust standard library"


### PR DESCRIPTION
The other (sub)teams are listed on the website, but this one was missing a `[website]` section in the config.

cc @dtolnay