### PR TITLE
Remove the operations team

### DIFF
--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -1,5 +1,4 @@
 name = "infra"
-subteam-of = "operations"
 
 [people]
 leads = ["aidanhs", "pietroalbini"]

--- a/teams/operations.toml
+++ b/teams/operations.toml
@@ -1,9 +1,0 @@
-name = "operations"
-
-[people]
-leads = []
-members = []
-
-[website]
-name = "Operations team"
-description = "Handling releases, bots, infra, and more"

--- a/teams/release.toml
+++ b/teams/release.toml
@@ -1,5 +1,4 @@
 name = "release"
-subteam-of = "operations"
 
 [people]
 leads = ["Mark-Simulacrum"]

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -1,5 +1,5 @@
 name = "wg-triage"
-subteam-of = "operations"
+subteam-of = "release"
 kind = "working-group"
 
 [people]


### PR DESCRIPTION
The operations team was supposed to be an umbrella for the infrastructure and release teams, but it never had any actual use, meeting or role. This removes the team, putting both infra and release as top-level teams on the website.

r? @Mark-Simulacrum 