### PR TITLE
Include all core team members on trademark@

### DIFF
--- a/teams/core.toml
+++ b/teams/core.toml
@@ -52,8 +52,6 @@ address = "legal@crates.io"
 
 [[lists]]
 address = "trademark@rust-lang.org"
-include-team-members = false
-extra-people = ["nikomatsakis"]
 
 [[lists]]
 address = "mediation@rust-lang.org"


### PR DESCRIPTION
This should spread the burden out a little on noticing these emails.