### PR TITLE
Add semverver to list of bors repos

### DIFF
--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -182,6 +182,7 @@ permissions! {
         rust,
         rustlings,
         rustup_rs,
+        semverver,
         stdarch,
         team,
     }

--- a/tests/static-api/_expected/v1/permissions/bors.semverver.review.json
+++ b/tests/static-api/_expected/v1/permissions/bors.semverver.review.json
@@ -1,0 +1,5 @@
+{
+  "github_users": [],
+  "github_ids": [],
+  "discord_ids": []
+}

--- a/tests/static-api/_expected/v1/permissions/bors.semverver.try.json
+++ b/tests/static-api/_expected/v1/permissions/bors.semverver.try.json
@@ -1,0 +1,5 @@
+{
+  "github_users": [],
+  "github_ids": [],
+  "discord_ids": []
+}


### PR DESCRIPTION
Step no. 3 of https://forge.rust-lang.org/infra/docs/bors.html#adding-a-new-repository-to-bors.

Step no. 2: https://github.com/rust-lang/rust-semverver/pull/134