### PR TITLE
Add vscode-rust to list of bors repos

### DIFF
--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -184,6 +184,7 @@ permissions! {
         rustup_rs,
         stdarch,
         team,
+        vscode_rust,
     }
     crates_io_ops_apps {
         crates_io,

--- a/tests/static-api/_expected/v1/permissions/bors.vscode_rust.review.json
+++ b/tests/static-api/_expected/v1/permissions/bors.vscode_rust.review.json
@@ -1,0 +1,5 @@
+{
+  "github_users": [],
+  "github_ids": [],
+  "discord_ids": []
+}

--- a/tests/static-api/_expected/v1/permissions/bors.vscode_rust.try.json
+++ b/tests/static-api/_expected/v1/permissions/bors.vscode_rust.try.json
@@ -1,0 +1,5 @@
+{
+  "github_users": [],
+  "github_ids": [],
+  "discord_ids": []
+}


### PR DESCRIPTION
Step no. 3 of https://forge.rust-lang.org/infra/docs/bors.html#adding-a-new-repository-to-bors.

Step no. 2: https://github.com/rust-lang/vscode-rust/pull/868