### PR TITLE
Remove myself from the libs team

### DIFF
--- a/teams/library-reviewers.toml
+++ b/teams/library-reviewers.toml
@@ -9,7 +9,6 @@ members = [
     "joshtriplett",
     "kennytm",
     "KodrAus",
-    "LukasKalbertodt",
     "m-ou-se",
     "Mark-Simulacrum",
     "sfackler",

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -10,8 +10,10 @@ members = [
     "dtolnay",
     "sfackler",
     "withoutboats",
-    "LukasKalbertodt",
     "m-ou-se",
+]
+alumni = [
+    "LukasKalbertodt",
 ]
 
 [[github]]
@@ -30,7 +32,6 @@ label = "T-libs"
 name = "Libraries"
 ping = "rust-lang/libs"
 exclude-members = [
-    "LukasKalbertodt",
     "SimonSapin",
 ]
 


### PR DESCRIPTION
Unfortunately, working as part of the libs team does not currently fit into my life :( 
So I'm already leaving after less than a year. It was a great experience though and I hope to maybe come back some day! And I'm certainly not leaving the Rust community, so you'll see me around. 

Regarding the PRs that I am currently assigned to: I can still review those, but I can't promise how quickly that will happen, so feel free to reassign. (Also, by then I won't be able to merge.) The PRs that I'm the author of I will continue to update, so no change there.

PS: I would not have added myself to the alumni list, but @KodrAus said that I should. If anyone disagrees I can of course change that.

CC @rust-lang/libs 