### PR TITLE
Add a rust-lang/all github team

### DIFF
--- a/teams/all.toml
+++ b/teams/all.toml
@@ -5,6 +5,9 @@ leads = []
 members = []
 include-all-team-members = true
 
+[[github]]
+orgs = ["rust-lang"]
+
 [[lists]]
 address = "all@rust-lang.org"
 


### PR DESCRIPTION
This PR adds the **`@rust-lang/all`** GitHub team, which will be useful to grant access to everyone in the Rust Team to a repository.