### PR TITLE
Add a command to show information about a person

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod schema;
 mod static_api;
 mod validate;
 
-use crate::data::Data;
+use crate::{data::Data, schema::Email};
 use failure::{err_msg, Error};
 use log::{error, info, warn};
 use std::path::PathBuf;
@@ -35,6 +35,8 @@ enum Cli {
     AddPerson { github_name: String },
     #[structopt(name = "static-api", help = "generate the static API")]
     StaticApi { dest: String },
+    #[structopt(name = "show-person", help = "print information about a person")]
+    ShowPerson { github_username: String },
     #[structopt(name = "dump-team", help = "print the members of a team")]
     DumpTeam { name: String },
     #[structopt(name = "dump-list", help = "print all the emails in a list")]
@@ -131,6 +133,38 @@ fn run() -> Result<(), Error> {
             let generator = crate::static_api::Generator::new(&dest, &data)?;
             generator.generate()?;
         }
+        Cli::ShowPerson {
+            ref github_username,
+        } => {
+            let person = data
+                .person(github_username)
+                .ok_or_else(|| err_msg("unknown person"))?;
+
+            println!("-- {} --", person.name());
+            println!();
+
+            println!("github: @{}", person.github());
+            if let Email::Present(email) = person.email() {
+                println!("email:  {}", email);
+            }
+            println!();
+
+            println!("teams:");
+            let mut teams: Vec<&str> = data
+                .teams()
+                .filter(|team| team.members(&data).unwrap().contains(person.github()))
+                .map(|team| team.name())
+                .collect();
+            teams.sort_unstable();
+            if teams.is_empty() {
+                println!("  (none)");
+            } else {
+                for team in teams {
+                    println!("  - {}", team);
+                }
+            }
+        }
+
         Cli::DumpTeam { ref name } => {
             let team = data.team(name).ok_or_else(|| err_msg("unknown team"))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,18 +149,38 @@ fn run() -> Result<(), Error> {
             }
             println!();
 
+            let mut bors_permissions = person.permissions().bors().clone();
+
             println!("teams:");
-            let mut teams: Vec<&str> = data
+            let mut teams: Vec<_> = data
                 .teams()
                 .filter(|team| team.members(&data).unwrap().contains(person.github()))
-                .map(|team| team.name())
                 .collect();
-            teams.sort_unstable();
+            teams.sort_by_key(|team| team.name());
             if teams.is_empty() {
                 println!("  (none)");
             } else {
                 for team in teams {
-                    println!("  - {}", team);
+                    println!("  - {}", team.name());
+                    bors_permissions.extend(team.permissions().bors().clone());
+                }
+            }
+            println!();
+
+            let mut bors_permissions: Vec<_> = bors_permissions.into_iter().collect();
+            bors_permissions.sort_by_key(|(repo, _)| repo.clone());
+            println!("bors permissions:");
+            if bors_permissions.is_empty() {
+                println!("  (none)");
+            } else {
+                for (repo, perms) in bors_permissions {
+                    println!("  - {}", repo);
+                    if perms.review() {
+                        println!("    - review");
+                    }
+                    if perms.try_() {
+                        println!("    - try");
+                    }
                 }
             }
         }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -3,7 +3,7 @@ use crate::schema::{Config, Person};
 use failure::{bail, Error};
 use std::collections::{HashMap, HashSet};
 
-#[derive(serde_derive::Deserialize, Debug)]
+#[derive(serde_derive::Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct BorsACL {
     #[serde(default)]
@@ -18,6 +18,16 @@ impl Default for BorsACL {
             review: false,
             try_: false,
         }
+    }
+}
+
+impl BorsACL {
+    pub(crate) fn review(&self) -> bool {
+        self.review
+    }
+
+    pub(crate) fn try_(&self) -> bool {
+        self.try_
     }
 }
 
@@ -43,6 +53,10 @@ impl Default for Permissions {
 }
 
 impl Permissions {
+    pub(crate) fn bors(&self) -> &HashMap<String, BorsACL> {
+        &self.bors
+    }
+
     pub(crate) fn available(config: &Config) -> Vec<String> {
         let mut result = Vec::new();
 


### PR DESCRIPTION
It shows their name, GitHub username, email (if present), and all of the
teams (including WGs) that they're a member of.

It's like `dump-team`, but for people.

The output looks like this:

    -- Camelid --

    github: @camelid

    teams:
      - icebreakers-cleanup-crew
      - icebreakers-llvm
      - wg-prioritization
      - wg-triage

    bors permissions:
      (none)

or, for someone on more teams and with an email:

    -- Pietro Albini --

    github: @pietroalbini
    email:  pietro@pietroalbini.org

    teams:
      - all
      - core
      - crates-io
      - docs-rs
      - infra
      - infra-admins
      - inside-rust-reviewers
      - leads
      - project-foundation
      - release
      - website
      - wg-rustfix
      - wg-security-response

    bors permissions:
      - crater
        - review
      - crates-io
        - review
      - rust
        - review
      - team
        - review

or, for someone on no teams (rustbot's not actually in the teams data, I
created an entry for it just for this purpose):

    -- rustbot --

    github: @rustbot

    teams:
      (none)

    bors permissions:
      (none)