### PR TITLE
promote lcnr to compiler team member

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -13,7 +13,6 @@ members = [
   "flodiebold",
   "jonas-schievink",
   "lqd",
-  "lcnr",
   "Mark-Simulacrum",
   "matklad",
   "Nadrieril",

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -5,6 +5,7 @@ leads = ["wesleywiser", "pnkfelix"]
 members = [
     "eddyb",
     "estebank",
+    "lcnr",
     "nagisa",
     "oli-obk",
     "petrochenkov",


### PR DESCRIPTION
promote lcnr to compiler team member as announced in https://blog.rust-lang.org/inside-rust/2020/12/14/changes-to-compiler-team.html

r? @wesleywiser 