### PR TITLE
Add an email alias for Ashley

### DIFF
--- a/teams/core.toml
+++ b/teams/core.toml
@@ -74,3 +74,10 @@ include-team-members = false
 extra-people = [
     "ashleygwilliams",
 ]
+
+# Temporary hacky way to create personal aliases. Ashley urgently needs an
+# alias to continue her work setting up the Rust Foundation.
+[[lists]]
+address = "ashleygwilliams@rust-lang.org"
+include-team-members = false
+extra-people = ["ashleygwilliams"]


### PR DESCRIPTION
There is urgent need for a @rust-lang.org email address for @ashleygwilliams in order to unblock some work for setting up the Rust Foundation. This is a hacky way to set it up until the Infrastructure Team makes a decision on how and whether to support such aliases.