### PR TITLE
show-person: Show other permissions as well

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ fn run() -> Result<(), Error> {
             println!();
 
             let mut bors_permissions = person.permissions().bors().clone();
+            let mut other_permissions = person.permissions().booleans().clone();
 
             println!("teams:");
             let mut teams: Vec<_> = data
@@ -163,6 +164,7 @@ fn run() -> Result<(), Error> {
                 for team in teams {
                     println!("  - {}", team.name());
                     bors_permissions.extend(team.permissions().bors().clone());
+                    other_permissions.extend(team.permissions().booleans().clone());
                 }
             }
             println!();
@@ -181,6 +183,21 @@ fn run() -> Result<(), Error> {
                     if perms.try_() {
                         println!("    - try");
                     }
+                }
+            }
+            println!();
+
+            let mut other_permissions: Vec<_> = other_permissions
+                .into_iter()
+                .filter_map(|(key, value)| if value { Some(key) } else { None })
+                .collect();
+            other_permissions.sort();
+            println!("other permissions:");
+            if other_permissions.is_empty() {
+                println!("  (none)");
+            } else {
+                for key in other_permissions {
+                    println!("  - {}", key);
                 }
             }
         }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -57,6 +57,10 @@ impl Permissions {
         &self.bors
     }
 
+    pub(crate) fn booleans(&self) -> &HashMap<String, bool> {
+        &self.booleans
+    }
+
     pub(crate) fn available(config: &Config) -> Vec<String> {
         let mut result = Vec::new();
 


### PR DESCRIPTION
Now it shows other permissions like `perf` and `crater` in addition to
bors permissions.

For example:

    -- Pietro Albini --

    github: @pietroalbini
    email:  pietro@pietroalbini.org

    teams:
      - all
      - core
      - crates-io
      - docs-rs
      - infra
      - infra-admins
      - inside-rust-reviewers
      - leads
      - project-foundation
      - release
      - website
      - wg-rustfix
      - wg-security-response

    bors permissions:
      - crater
        - review
      - crates-io
        - review
      - rust
        - review
      - team
        - review

    other permissions:
      - crater
      - perf
