### PR TITLE
Fix rustdoc Zulip stream

### DIFF
--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -29,7 +29,7 @@ ping = "rust-lang/rustdoc"
 [website]
 name = "Rustdoc team"
 description = "Developing and managing the Rustdoc documentation tool"
-zulip-stream = "t-rustdoc"
+zulip-stream = "rustdoc"
 
 [[lists]]
 address = "rustdoc@rust-lang.org"


### PR DESCRIPTION
It's `rustdoc`, not `t-rustdoc`.
