### PR TITLE
add `try` and `perf` permissions to wg-mir-opt

### DIFF
--- a/teams/wg-mir-opt.toml
+++ b/teams/wg-mir-opt.toml
@@ -14,3 +14,7 @@ name = "MIR optimizations working group"
 description = "Writing MIR optimizations and refactoring the MIR to be more optimizable"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/mir-opt/"
 zulip-stream = "t-compiler/wg-mir-opt"
+
+[permissions]
+perf = true
+bors.rust.try = true


### PR DESCRIPTION
This is so that members of the WG don't have to ask others for try and perf runs

r? @Mark-Simulacrum 