### PR TITLE
Add @michaelwoerister to compiler-contributors

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -15,6 +15,7 @@ members = [
   "lqd",
   "Mark-Simulacrum",
   "matklad",
+  "michaelwoerister",
   "Nadrieril",
   "nikic",
   "nnethercote",


### PR DESCRIPTION
Per [RFC 2689](https://rust-lang.github.io/rfcs/2689-compiler-team-contributors.html#alumni-status), @michaelwoerister has asked to be moved out of alumni status into the compiler-contributor team. 

Welcome back @michaelwoerister! 

r? @pnkfelix 