### PR TITLE
create the const generics project group

### DIFF
--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -1,0 +1,23 @@
+name = "project-const-generics"
+kind = "project-group"
+subteam-of = "lang"
+
+[people]
+leads = ["lcnr", "nikomatsakis"]
+members = [
+        "lcnr",
+        "nikomatsakis",
+        "varkor",
+        "davidtwco",
+        "oli-obk",
+        "withoutboats",
+]
+
+[website]
+name = "Const Generics Project Group"
+description = "Working to advance const generics support in the Rust language"
+repo = "https://github.com/rust-lang/project-const-generics"
+zulip-stream = "project-const-generics"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
We've had an active const generics project group for some time, but we never created an entry in the team repo for it!

As of opening this PR, the repo doesn't exist, so the link is dangling, but we should create one (based on the [project group template], with this group as write access).

[project group template]: https://github.com/rust-lang/project-group-template/

