### PR TITLE
Add rust review perms for clippy

### DIFF
--- a/people/killercup.toml
+++ b/people/killercup.toml
@@ -2,6 +2,3 @@ name = "Pascal Hertleif"
 github = "killercup"
 github-id = 20063
 email = "killercup@gmail.com"
-
-[permissions]
-bors.rust.review = true

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -19,6 +19,7 @@ alumni = ["ebroto"]
 
 [permissions]
 bors.clippy.review = true
+bors.rust.review = true
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
For clippyups and such


Want to make sure @rust-lang/compiler is okay with this; the cargo team also has this bit, and I realized today that @\yaahc wouldn't be able to approve a clippyup.


r? @pietroalbini 