### PR TITLE
Remove lenary from RISC-V

### DIFF
--- a/people/lenary.toml
+++ b/people/lenary.toml
@@ -1,6 +1,0 @@
-name = 'Sam Elliott'
-email = "sam@lenary.co.uk"
-github = 'lenary'
-github-id = 14548
-discord-id = 646368775599423489
-zulip-id = 325842

--- a/teams/risc-v.toml
+++ b/teams/risc-v.toml
@@ -6,6 +6,5 @@ leads = []
 members = [
     "denisvasilik",
     "Disasm",
-    "lenary",
     "tblah",
 ]


### PR DESCRIPTION
I no longer work on the RISC-V LLVM target, and I cannot help to triage RISC-V issues any longer.