### PR TITLE
Sync Discord Roles

### DIFF
--- a/people/technetos.toml
+++ b/people/technetos.toml
@@ -2,3 +2,4 @@ name = "Joshua Gould"
 github = "technetos"
 github-id = 10949810
 email = "mrgould93@gmail.com"
+discord-id = 443810603417731092

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -23,6 +23,7 @@ pub struct Team {
     pub alumni: Vec<TeamMember>,
     pub github: Option<TeamGitHub>,
     pub website_data: Option<TeamWebsite>,
+    pub discord_role: Option<DiscordRole>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,6 +56,13 @@ pub struct TeamWebsite {
     pub discord: Option<DiscordInvite>,
     pub zulip_stream: Option<String>,
     pub weight: i64,
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscordRole {
+    pub name: String,
+    pub role_id: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -63,6 +63,7 @@ pub struct TeamDiscord {
     pub name: String,
     pub role_id: usize,
     pub members: Vec<usize>,
+    pub color: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -23,7 +23,7 @@ pub struct Team {
     pub alumni: Vec<TeamMember>,
     pub github: Option<TeamGitHub>,
     pub website_data: Option<TeamWebsite>,
-    pub discord_role: Option<DiscordRole>,
+    pub discord: Option<TeamDiscord>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,11 +58,11 @@ pub struct TeamWebsite {
     pub weight: i64,
 }
 
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DiscordRole {
+pub struct TeamDiscord {
     pub name: String,
     pub role_id: usize,
+    pub members: Vec<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -354,6 +354,7 @@ impl Team {
 pub(crate) struct DiscordRole {
     name: String,
     role_id: usize,
+    color: Option<String>,
 }
 
 impl DiscordRole {
@@ -363,6 +364,10 @@ impl DiscordRole {
 
     pub(crate) fn role_id(&self) -> usize {
         self.role_id
+    }
+
+    pub(crate) fn color(&self) -> Option<&str> {
+        self.color.as_ref().map(|s| &s[..])
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -335,6 +335,15 @@ impl Team {
         Ok(result)
     }
 
+    pub(crate) fn discord_ids(&self, data: &Data) -> Result<Vec<usize>, Error> {
+        Ok(self
+            .members(data)?
+            .iter()
+            .flat_map(|name| data.person(name).map(|p| p.discord_id()))
+            .flatten()
+            .collect())
+    }
+
     pub(crate) fn is_alumni_team(&self) -> bool {
         self.people.include_all_alumni
     }
@@ -355,6 +364,11 @@ impl DiscordRole {
     pub(crate) fn role_id(&self) -> usize {
         self.role_id
     }
+}
+
+#[derive(Eq, PartialEq, Debug)]
+pub(crate) struct DiscordTeam {
+    pub(crate) members: Vec<usize>,
 }
 
 #[derive(Eq, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -169,6 +169,7 @@ pub(crate) struct Team {
     website: Option<WebsiteData>,
     #[serde(default)]
     lists: Vec<TeamList>,
+    discord_role: Option<DiscordRole>,
 }
 
 impl Team {
@@ -194,6 +195,10 @@ impl Team {
 
     pub(crate) fn website_data(&self) -> Option<&WebsiteData> {
         self.website.as_ref()
+    }
+
+    pub(crate) fn discord_role(&self) -> Option<&DiscordRole> {
+        self.discord_role.as_ref()
     }
 
     pub(crate) fn members<'a>(&'a self, data: &'a Data) -> Result<HashSet<&'a str>, Error> {
@@ -332,6 +337,23 @@ impl Team {
 
     pub(crate) fn is_alumni_team(&self) -> bool {
         self.people.include_all_alumni
+    }
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) struct DiscordRole {
+    name: String,
+    role_id: usize,
+}
+
+impl DiscordRole {
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn role_id(&self) -> usize {
+        self.role_id
     }
 }
 

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -100,6 +100,12 @@ impl<'a> Generator<'a> {
                     zulip_stream: ws.zulip_stream().map(|s| s.into()),
                     weight: ws.weight(),
                 }),
+                discord_role: team.discord_role().map(|role| {
+                    v1::DiscordRole {
+                        name: role.name().into(),
+                        role_id: role.role_id(),
+                    }
+                }),
             };
 
             self.add(&format!("v1/teams/{}.json", team.name()), &team_data)?;

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -65,6 +65,8 @@ impl<'a> Generator<'a> {
             let mut github_teams = team.github_teams(&self.data)?;
             github_teams.sort();
 
+            let member_discord_ids = team.discord_ids(&self.data)?;
+
             let team_data = v1::Team {
                 name: team.name().into(),
                 kind: match team.kind() {
@@ -100,10 +102,11 @@ impl<'a> Generator<'a> {
                     zulip_stream: ws.zulip_stream().map(|s| s.into()),
                     weight: ws.weight(),
                 }),
-                discord_role: team.discord_role().map(|role| {
-                    v1::DiscordRole {
+                discord: team.discord_role().map(|role| {
+                    v1::TeamDiscord {
                         name: role.name().into(),
                         role_id: role.role_id(),
+                        members: member_discord_ids,
                     }
                 }),
             };

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -106,6 +106,7 @@ impl<'a> Generator<'a> {
                     v1::TeamDiscord {
                         name: role.name().into(),
                         role_id: role.role_id(),
+                        color: role.color().map(String::from),
                         members: member_discord_ids,
                     }
                 }),

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -102,13 +102,11 @@ impl<'a> Generator<'a> {
                     zulip_stream: ws.zulip_stream().map(|s| s.into()),
                     weight: ws.weight(),
                 }),
-                discord: team.discord_role().map(|role| {
-                    v1::TeamDiscord {
-                        name: role.name().into(),
-                        role_id: role.role_id(),
-                        color: role.color().map(String::from),
-                        members: member_discord_ids,
-                    }
+                discord: team.discord_role().map(|role| v1::TeamDiscord {
+                    name: role.name().into(),
+                    role_id: role.role_id(),
+                    color: role.color().map(String::from),
+                    members: member_discord_ids,
                 }),
             };
 

--- a/teams/all.toml
+++ b/teams/all.toml
@@ -27,3 +27,7 @@ include-team-members = false
 extra-emails = [
     "rust-verification@googlegroups.com",
 ]
+
+[discord-role]
+name = "WGs and Teams"
+role-id = 590248810127818752

--- a/teams/community.toml
+++ b/teams/community.toml
@@ -86,3 +86,4 @@ extra-people = [
 [discord-role]
 name = "community-team"
 role-id = 474953197354483714
+color = "#c27c0e"

--- a/teams/community.toml
+++ b/teams/community.toml
@@ -82,3 +82,7 @@ extra-people = [
     "spastorino",
     "skade",
 ]
+
+[discord-role]
+name = "community-team"
+role-id = 474953197354483714

--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -31,3 +31,7 @@ address = "docs-rs@rust-lang.org"
 
 [[lists]]
 address = "help@docs.rs"
+
+[discord-role]
+name = "docs-rs"
+role-id = 489135963319304212

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -46,3 +46,7 @@ address = "infra-team@rust-lang.org"
 
 [[lists]]
 address = "craterbot@rust-lang.org"
+
+[discord-role]
+name = "infra-team"
+role-id = 489135963319304212


### PR DESCRIPTION
This PR adds support for syncing team members discord roles with their membership in the teams api.  

In addition, this PR adds discord-role entries to the docs-rs, infra, and community teams.  

A team that
  1. Has a `[discord-role]` in the team config
  2. Has members who have their `discord-id` in the people config

will have their members automatically updated on discord with that corresponding teams role.  

Examples of discord role in team config
```toml
[discord-role]
name = "community-team" // required
role-id = 1234 // required
color = "#000000" // optional
```

Blocks: 