### PR TITLE
Create the "THIR Unsafety Checker Project Group"

### DIFF
--- a/teams/project-thir-unsafeck.toml
+++ b/teams/project-thir-unsafeck.toml
@@ -1,0 +1,14 @@
+name = "project-thir-unsafeck"
+kind = "project-group"
+subteam-of = "compiler"
+
+[people]
+leads = ["nikomatsakis"]
+members = ["LeSeulArtichaut", "nikomatsakis"]
+
+[website]
+name = "THIR Unsafety Checker Project Group"
+description = "Working on refactoring unsafety checking to operate on THIR"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Couldn't find a better name than "THIR Unsafety Checker Project Group" 🙄
The group should probably also have write access to the [project-thir-unsafeck](https://github.com/rust-lang/project-thir-unsafeck/) repo.

r? @pnkfelix @wesleywiser cc @nikomatsakis