### PR TITLE
Remove privacy@ from team repository management

### DIFF
--- a/teams/core.toml
+++ b/teams/core.toml
@@ -65,9 +65,6 @@ extra-people = [
 ]
 
 [[lists]]
-address = "privacy@rust-lang.org"
-
-[[lists]]
 address = "accounting@rust-lang.org"
 include-team-members = false
 extra-people = [


### PR DESCRIPTION
This is currently managed via the Mailgun UI directly; we will want to move this to a more comprehensive solution eventually, but this should be OK for the time being.