### PR TITLE
Add @michaelwoerister to compiler team

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -14,7 +14,6 @@ members = [
   "lqd",
   "Mark-Simulacrum",
   "matklad",
-  "michaelwoerister",
   "Nadrieril",
   "nikic",
   "nnethercote",

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -8,6 +8,7 @@ members = [
     "eddyb",
     "estebank",
     "lcnr",
+    "michaelwoerister",
     "nagisa",
     "oli-obk",
     "petrochenkov",


### PR DESCRIPTION
Per [RFC 2689](https://rust-lang.github.io/rfcs/2689-compiler-team-contributors.html#alumni-status), @michaelwoerister has asked to be moved out of the compiler-contributor team and back into the compiler team as a full member (which was his previous status).

r? @pnkfelix 