### PR TITLE
Remove mw from alumni list.

### DIFF
--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -20,7 +20,6 @@ members = [
 ]
 alumni = [
     "cramertj",
-    "michaelwoerister",
     "nrc",
     "Zoxc",
 ]


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/team/pull/579.