### PR TITLE
Update the `wg-nll` team

### DIFF
--- a/teams/wg-nll.toml
+++ b/teams/wg-nll.toml
@@ -4,7 +4,7 @@ kind = "working-group"
 
 [people]
 leads = ["nikomatsakis", "pnkfelix"]
-members = ["nikomatsakis", "pnkfelix"]
+members = ["nikomatsakis", "pnkfelix", "davidtwco", "spastorino", "matthewjasper", "lqd"]
 
 [website]
 name = "Non-Lexical Lifetimes (NLL) working group"


### PR DESCRIPTION
I've noticed that the `wg-nll` team only contained Niko and Felix, but there were a few more members. 

This PR adds the people I could definitely remember being active in the WG, basically the `WG-nll` user group on zulip

(screenshot: 
![image](https://user-images.githubusercontent.com/247183/121961138-4fdad880-cd67-11eb-8594-58a0ce508cad.png))

but I could be missing others. Please let me know if I've forgotten anyone you remember @nikomatsakis and @pnkfelix, and I'll add them.

I know the working group is winding down and its best days are behind us: it's more of a gesture for posterity's sake.