### PR TITLE
Remove 'vigoux' from the arm team.

### DIFF
--- a/people/vigoux.toml
+++ b/people/vigoux.toml
@@ -1,3 +1,0 @@
-name = 'Thomas Vigouroux'
-github = 'vigoux'
-github-id = 39092278

--- a/teams/arm.toml
+++ b/teams/arm.toml
@@ -8,7 +8,6 @@ members = [
     "Stammark",
     "joaopaulocarreiro",
     "raw-bin",
-    "vigoux",
     "jacobbramley",
     "adamgemmell",
     "hug-dev",


### PR DESCRIPTION
As requested on Zulip: https://rust-lang.zulipchat.com/#narrow/stream/242906-t-compiler.2Farm/topic/Not.20part.20of.20arm.20team.20anymore