### PR TITLE
Move varkor to compiler team alumni

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -24,6 +24,7 @@ members = [
   "spastorino",
   "the8472",
   "tmandry",
+  "varkor",
   "Xanewok",
   "zackmdavis",
 ]

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -15,12 +15,12 @@ members = [
     "pnkfelix",
     "nikomatsakis",
     "matthewjasper",
-    "varkor",
     "wesleywiser",
 ]
 alumni = [
     "cramertj",
     "nrc",
+    "varkor",
     "Zoxc",
 ]
 


### PR DESCRIPTION
Moving @varkor to compiler team alumni but also adding them to
compiler-contributors as they've indicated they would still like to
review PRs as time permits them.

Thanks @varkor!

https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202021-06-24.20.2354818/near/243799203

r? @pnkfelix 
