### PR TITLE
Remove non-existent Zulip stream for libs-api team

### DIFF
--- a/teams/libs-api.toml
+++ b/teams/libs-api.toml
@@ -39,7 +39,6 @@ ping = "rust-lang/libs-api"
 weight = 100
 name = "Library API team"
 description = "Designing and maintaining the standard library API and guarding its stability"
-zulip-stream = "t-libs-api"
 
 [[lists]]
 address = "libs-api@rust-lang.org"


### PR DESCRIPTION
As discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/t-libs-api.20stream).

I think it wouldn't make sense to link to `t-libs`, which the overall libs team already has a link to, and the info about the Library API team is rendered on the same page just below.