### PR TITLE
Add more people to wg-rls-2 and give them r+ permission

### DIFF
--- a/people/Veykril.toml
+++ b/people/Veykril.toml
@@ -1,0 +1,3 @@
+name = "Lukas Wirth"
+github = "Veykril"
+github-id = 3757771

--- a/people/lnicola.toml
+++ b/people/lnicola.toml
@@ -1,0 +1,3 @@
+name = "Laurențiu Nicola"
+github = "lnicola"
+github-id = 308347

--- a/teams/wg-rls-2.toml
+++ b/teams/wg-rls-2.toml
@@ -4,10 +4,13 @@ kind = "working-group"
 
 [people]
 leads = ["matklad"]
-members = ["matklad"]
+members = ["matklad", "lnicola", "Veykril", "flodiebold", "jonas-schievink"]
 
 [website]
 name = "RLS 2.0 working group"
 description = "Experimenting with a new compiler architecture tailored for IDEs"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/rls-2.0/"
 zulip-stream = "t-compiler/wg-rls-2.0"
+
+[permissions]
+bors.rust.review = true

--- a/teams/wg-rls-2.toml
+++ b/teams/wg-rls-2.toml
@@ -10,7 +10,7 @@ members = ["matklad", "lnicola", "Veykril", "flodiebold", "jonas-schievink"]
 name = "RLS 2.0 working group"
 description = "Experimenting with a new compiler architecture tailored for IDEs"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/rls-2.0/"
-zulip-stream = "t-compiler/wg-rls-2.0"
+zulip-stream = "t-compiler/rust-analyzer"
 
 [permissions]
 bors.rust.review = true


### PR DESCRIPTION
r+ permission is needed only to sync the rust-lang/rust submodule.

@lnicola @Veykril @flodiebold please let me know if you're ok with this (cc @matklad)