### PR TITLE
Remove myself from the release team

### DIFF
--- a/teams/release.toml
+++ b/teams/release.toml
@@ -7,7 +7,6 @@ members = [
     "Dylan-DPC",
     "Mark-Simulacrum",
     "pietroalbini",
-    "jonas-schievink",
     "XAMPPRocky",
     "tmandry",
 ]
@@ -15,6 +14,7 @@ alumni = [
     "BatmanAoD",
     "Centril",
     "sgrif",
+    "jonas-schievink",
 ]
 
 [permissions]


### PR DESCRIPTION
It's been quite a while since I've been able to help with anything release-related, since I've mostly been focusing on rust-analyzer, so update the team memberships to reflect that.