### PR TITLE
Fix my name and email to be the ones I use on GitHub.

### DIFF
--- a/people/eddyb.toml
+++ b/people/eddyb.toml
@@ -1,5 +1,5 @@
-name = "Eduard Burtescu"
+name = "Eduard-Mihai Burtescu"
 github = "eddyb"
 github-id = 77424
-email = "edy.burt@gmail.com"
+email = "eddyb@lyken.rs"
 discord-id = 391665108490649601


### PR DESCRIPTION
I'm not sure how my personal gmail ended up in here, must've been migrated from an older dataset. Hopefully this applies to the team mailing lists, too.