### PR TITLE
Update perf team

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,7 @@ permissions-bors-repos = [
     "crater",
     "crates-io",
     "hashbrown",
+    "measureme",
     "miri",
     "libc",
     "regex",

--- a/teams/wg-compiler-performance.toml
+++ b/teams/wg-compiler-performance.toml
@@ -10,6 +10,7 @@ members = [
     "rylev",
     "tgnottingham",
     "pnkfelix",
+    "michaelwoerister"
 ]
 
 [[github]]
@@ -22,3 +23,4 @@ description = "Improving rustc compilation performance (build times)"
 [permissions]
 perf = true
 bors.rust.try = true
+bors.measureme.review = true


### PR DESCRIPTION
Updates the perf team in three ways:
* Adds @michaelwoerister as member
* Adds measureme to bors list
* Adds bors permission for measureme to perf team

r? @Mark-Simulacrum 