### PR TITLE
Add Hirochika Matsumoto to wg-prioritization

### DIFF
--- a/people/hkmatsumoto.toml
+++ b/people/hkmatsumoto.toml
@@ -1,0 +1,3 @@
+name = 'Hirochika Matsumoto'
+github = 'hkmatsumoto'
+github-id = 57856193

--- a/teams/wg-prioritization.toml
+++ b/teams/wg-prioritization.toml
@@ -13,6 +13,7 @@ members = [
     "Dylan-DPC",
     "frxstrem",
     "hameerabbasi",
+    "hkmatsumoto",
     "inquisitivecrystal",
     "JamesPatrickGill",
     "jechasteen",


### PR DESCRIPTION
Discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/227806-t-compiler.2Fwg-prioritization/topic/Hirochika.20Matsumoto.20wants.20to.20join)

@hkmatsumoto also review if I picked the correct usernames/ID, thanks.

cc: @spastorino 