### PR TITLE
Add team for async-crashdump-debugging initiative.

### DIFF
--- a/teams/project-async-crashdump-debugging.toml
+++ b/teams/project-async-crashdump-debugging.toml
@@ -1,0 +1,20 @@
+name = "project-async-crashdump-debugging"
+kind = "project-group"
+subteam-of = "wg-async-foundations"
+
+[people]
+leads = [
+    "michaelwoerister",
+]
+members = [
+    "michaelwoerister",
+]
+
+[website]
+name = "Async Crashdump Debugging Initiative"
+description = "Simplify crashdump debugging of async programs"
+repo = "https://github.com/rust-lang/async-crashdump-debugging-initiative"
+
+[[github]]
+orgs = ["rust-lang"]
+team-name = "initiative-async-crashdump-debugging"


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/infra-team/issues/52#issuecomment-921857020.

r? @Mark-Simulacrum 
