### PR TITLE
Remove oli-obk from clippy team

### DIFF
--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -7,7 +7,6 @@ members = [
     "llogiq",
     "killercup",
     "Manishearth",
-    "oli-obk",
     "matthiaskrgr",
     "phansch",
     "mikerite",
@@ -17,7 +16,7 @@ members = [
     "giraffate",
     "xFrednet",
 ]
-alumni = ["ebroto", "yaahc"]
+alumni = ["ebroto", "yaahc", "oli-obk"]
 
 [permissions]
 perf = true


### PR DESCRIPTION
Citing myself [on zulip](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Meeting.202021-09-21/near/254214758):

> I think it is time to admit this to myself: I haven't participated in clippy in any meaningful way in the last two years and should probably step down. I still want to help when there are any kind of impl questions wrt rustc APIs, linting logic, MIR linting, or on code crimes I have committed in clippy, but me being part of the team does not help anyone.