### PR TITLE
Move yaahc to wg traits alumni

### DIFF
--- a/teams/wg-traits.toml
+++ b/teams/wg-traits.toml
@@ -17,12 +17,12 @@ members = [
     "nikomatsakis",
     "skinny121",
     "spastorino",
-    "yaahc",
     "zaharidichev",
 ]
 alumni = [
     "scalexm",
     "tmandry",
+    "yaahc",
 ]
 
 [website]


### PR DESCRIPTION
Not active enough with wg-traits for it to make sense for me to receive pings to the wg-traits @ on github