### PR TITLE
Add michaelwoerister to wg-async-foundations

### DIFF
--- a/teams/wg-async-foundations.toml
+++ b/teams/wg-async-foundations.toml
@@ -17,6 +17,7 @@ members = [
   "estebank",
   "gilescope",
   "lbernick",
+  "michaelwoerister",
   "nellshamrell",
   "nikomatsakis",
   "pnkfelix",


### PR DESCRIPTION
mw's leading https://github.com/rust-lang/async-crashdump-debugging-initiative.