### PR TITLE
Adding embedded-wg team definitions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ allowed-mailing-lists-domains = [
     "docs.rs",
     "rust-embedded.org",
     "rustconf.com",
+    "teams.rust-embedded.org",
 ]
 
 allowed-github-orgs = [

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,6 @@ allowed-mailing-lists-domains = [
     "docs.rs",
     "rust-embedded.org",
     "rustconf.com",
-    "teams.rust-embedded.org",
 ]
 
 allowed-github-orgs = [

--- a/people/YuhanLiin.toml
+++ b/people/YuhanLiin.toml
@@ -1,0 +1,4 @@
+name = 'Yuhan Lin'
+github = 'YuhanLiin'
+github-id = 15389635
+email = 'yuhanliin+github@protonmail.com'

--- a/people/jonathanpallant.toml
+++ b/people/jonathanpallant.toml
@@ -1,0 +1,4 @@
+name = 'Jonathan Pallant'
+github = 'jonathanpallant'
+github-id = 18005923
+email = 'jonathan.pallant@ferrous-systems.com'

--- a/people/mathk.toml
+++ b/people/mathk.toml
@@ -1,0 +1,3 @@
+name = 'Mathieu Suen'
+github = 'mathk'
+github-id = 314381

--- a/people/newAM.toml
+++ b/people/newAM.toml
@@ -1,0 +1,3 @@
+name = 'Alex Martens'
+github = 'newAM'
+github-id = 7845120

--- a/teams/wg-embedded-core.toml
+++ b/teams/wg-embedded-core.toml
@@ -1,0 +1,19 @@
+name = "wg-embedded-core"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "adamgreig",
+    "therealprof",
+    "japaric",
+]
+
+[website]
+name = "Embedded core team"
+description = "The core team represents the WG in meetings with the Rust teams"
+
+[[github]]
+orgs = ["rust-embedded"]
+team-name = "core"

--- a/teams/wg-embedded-cortex-a.toml
+++ b/teams/wg-embedded-cortex-a.toml
@@ -1,0 +1,17 @@
+name = "wg-embedded-cortex-a"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "raw-bin",
+    "andre-richter",
+]
+
+[website]
+name = "Embedded Cortex-A team"
+description = "Develops and maintains the core of the Cortex-A crate ecosystem "
+
+[[github]]
+orgs = ["rust-embedded"]

--- a/teams/wg-embedded-cortex-m.toml
+++ b/teams/wg-embedded-cortex-m.toml
@@ -1,0 +1,19 @@
+name = "wg-embedded-cortex-m"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "adamgreig",
+    "thejpster",
+    "therealprof",
+    "thalesfragoso",
+]
+
+[website]
+name = "Embedded Cortex-M team"
+description = "Develops and maintains the core of the Cortex-M crate ecosystem "
+
+[[github]]
+orgs = ["rust-embedded"]

--- a/teams/wg-embedded-cortex-m.toml
+++ b/teams/wg-embedded-cortex-m.toml
@@ -9,6 +9,7 @@ members = [
     "thejpster",
     "therealprof",
     "thalesfragoso",
+    "newAM",
 ]
 
 [website]

--- a/teams/wg-embedded-cortex-r.toml
+++ b/teams/wg-embedded-cortex-r.toml
@@ -1,0 +1,16 @@
+name = "wg-embedded-cortex-r"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "japaric",
+]
+
+[website]
+name = "Embedded Cortex-R team"
+description = "Develops and maintains the core of the Cortex-R crate ecosystem "
+
+[[github]]
+orgs = ["rust-embedded"]

--- a/teams/wg-embedded-hal.toml
+++ b/teams/wg-embedded-hal.toml
@@ -1,0 +1,19 @@
+name = "wg-embedded-hal"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "eldruin",
+    "ryankurte",
+    "therealprof",
+]
+
+[website]
+name = "Embedded HAL team"
+description = "Develops and maintains crates that ease the development of Hardware Abstraction Layers, Board Support Crates and drivers"
+
+[[github]]
+orgs = ["rust-embedded"]
+team-name = "embedded-hal"

--- a/teams/wg-embedded-linux.toml
+++ b/teams/wg-embedded-linux.toml
@@ -1,0 +1,21 @@
+name = "wg-embedded-linux"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "eldruin",
+    "nastevens",
+    "posborne",
+    "ryankurte",
+]
+
+[website]
+name = "Embedded Linux team"
+description = "The embedded Linux team develops and maintains the core of the embedded Linux crate ecosystem."
+
+[[github]]
+orgs = ["rust-embedded"]
+team-name = "embedded-linux"
+

--- a/teams/wg-embedded-msp430.toml
+++ b/teams/wg-embedded-msp430.toml
@@ -1,0 +1,17 @@
+name = "wg-embedded-msp430"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "cr1901",
+]
+
+[website]
+name = "Embedded MSP430 team"
+description = "Develops and maintains the core of the embedded MSP430 crate ecosystem"
+
+[[github]]
+orgs = ["rust-embedded"]
+team-name = "msp430"

--- a/teams/wg-embedded-msp430.toml
+++ b/teams/wg-embedded-msp430.toml
@@ -6,6 +6,7 @@ kind = "working-group"
 leads = []
 members = [
     "cr1901",
+    "YuhanLiin",
 ]
 
 [website]

--- a/teams/wg-embedded-resources.toml
+++ b/teams/wg-embedded-resources.toml
@@ -18,4 +18,5 @@ name = "Embedded resources working group"
 description = "Managing various resources owned by the embedded working group"
 
 [[github]]
-orgs = ["rust-lang"]
+orgs = ["rust-embedded"]
+team-name = "resources"

--- a/teams/wg-embedded-riscv.toml
+++ b/teams/wg-embedded-riscv.toml
@@ -1,0 +1,20 @@
+name = "wg-embedded-riscv"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "almindor",
+    "Disasm",
+    "thejpster",
+    "dkhayes117",
+]
+
+[website]
+name = "Embedded RISCV team"
+description = "Develops and maintains the core of the embedded RISCV crate ecosystem"
+
+[[github]]
+orgs = ["rust-embedded"]
+team-name = "risc-v"

--- a/teams/wg-embedded-riscv.toml
+++ b/teams/wg-embedded-riscv.toml
@@ -7,7 +7,6 @@ leads = []
 members = [
     "almindor",
     "Disasm",
-    "thejpster",
     "dkhayes117",
 ]
 

--- a/teams/wg-embedded-tools.toml
+++ b/teams/wg-embedded-tools.toml
@@ -1,0 +1,20 @@
+name = "wg-embedded-tools"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "almindor",
+    "Disasm",
+    "thejpster",
+    "dkhayes117",
+]
+
+[website]
+name = "Embedded Tools Team"
+description = "Develops and maintains core embedded tools"
+
+[[github]]
+orgs = ["rust-embedded"]
+team-name = "tools"

--- a/teams/wg-embedded-tools.toml
+++ b/teams/wg-embedded-tools.toml
@@ -5,10 +5,14 @@ kind = "working-group"
 [people]
 leads = []
 members = [
-    "almindor",
-    "Disasm",
+    "adamgreig",
+    "ryankurte",
     "thejpster",
-    "dkhayes117",
+    "reitermarkus",
+    "Emilgardis",
+    "burrbull",
+    "therealprof",
+    "jonathanpallant",
 ]
 
 [website]

--- a/teams/wg-embedded-triage.toml
+++ b/teams/wg-embedded-triage.toml
@@ -1,0 +1,17 @@
+name = "wg-embedded-triage"
+subteam-of = "wg-embedded"
+kind = "working-group"
+
+[people]
+leads = []
+members = [
+    "mathk",
+]
+
+[website]
+name = "Embedded Triage Team"
+description = "The triage team keeps PR queues moving; they ensure no PR is left unattended"
+
+[[github]]
+orgs = ["rust-embedded"]
+team-name = "triage"


### PR DESCRIPTION
Adds the remainder of the embedded-wg teams based on membership [here](https://github.com/rust-embedded/wg#organization) per https://github.com/rust-embedded/wg/issues/442, towards moving team mailinglists over to central hosting.

cc. @pietroalbini 