### PR TITLE
Add ayazhafiz to llvm and cleanup-crew notification groups

### DIFF
--- a/people/ayazhafiz.toml
+++ b/people/ayazhafiz.toml
@@ -1,0 +1,4 @@
+name = 'hafiz'
+email = "ayaz.hafiz.1@gmail.com"
+github = 'ayazhafiz'
+github-id = 20735482

--- a/teams/icebreakers-cleanup-crew.toml
+++ b/teams/icebreakers-cleanup-crew.toml
@@ -5,6 +5,7 @@ kind = "marker-team"
 leads = []
 members = [
     "AminArria",
+    "ayazhafiz",
     "camelid",
     "chrissimpkins",
     "contrun",

--- a/teams/icebreakers-llvm.toml
+++ b/teams/icebreakers-llvm.toml
@@ -4,6 +4,7 @@ kind = "marker-team"
 [people]
 leads = []
 members = [
+    "ayazhafiz",
     "camelid",
     "comex",
     "cuviper",


### PR DESCRIPTION
Adding @ayazhafiz (myself) to these notification groups as described
in [the dev guide](https://rustc-dev-guide.rust-lang.org/notification-groups/about.html).

Please let me know if there is anything missing here. Thanks!