### PR TITLE
Create new log team

### DIFF
--- a/people/Thomasdezeeuw.toml
+++ b/people/Thomasdezeeuw.toml
@@ -1,0 +1,4 @@
+name = 'Thomas de Zeeuw'
+github = 'Thomasdezeeuw'
+github-id = 3159064
+email = 'thomasdezeeuw@gmail.com'

--- a/teams/log.toml
+++ b/teams/log.toml
@@ -1,0 +1,20 @@
+name = "logs"
+subteam-of = "libs"
+
+[people]
+leads = []
+members = [
+    "KodrAus",
+    "sfackler",
+]
+
+[permissions]
+bors.libc.review = true
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "Log crate team"
+description = "Developing and maintaining the log crate"
+repo = "https://github.com/rust-lang/log"

--- a/teams/log.toml
+++ b/teams/log.toml
@@ -6,6 +6,7 @@ leads = []
 members = [
     "KodrAus",
     "sfackler",
+    "Thomasdezeeuw",
 ]
 
 [permissions]


### PR DESCRIPTION
To maintain the log crate https://github.com/rust-lang/log.

I've added @KodrAus, @sfackler and myself to it. If either of you don't want to be part of the team let me know.