### PR TITLE
Remove rylev from wg-prioritization

### DIFF
--- a/teams/wg-prioritization.toml
+++ b/teams/wg-prioritization.toml
@@ -23,7 +23,6 @@ members = [
     "mstallmo",
     "o0Ignition0o",
     "pnkfelix",
-    "rylev",
     "spastorino",
     "Stupremee",
     "TaKO8Ki",


### PR DESCRIPTION
I don't have the time to properly participate in the working group. I've not added myself to alumni since I don't think I was deeply involved enough to qualify for that designation. 

@apiraino 