### PR TITLE
Edit team description for `wg-rustc-dev-guide`

### DIFF
--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -22,6 +22,6 @@ orgs = ["rust-lang"]
 
 [website]
 name = "Rustc Dev Guide working group"
-description = "Make the compiler easier to learn by ensuring that rustc-dev-guide is \"complete\""
+description = "Making the compiler easier to learn by maintaining and improving the Rustc Dev Guide"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/rustc-dev-guide/"
 zulip-stream = "t-compiler/wg-rustc-dev-guide"


### PR DESCRIPTION
I noticed that the description for the rustc-dev-guide working group [on this page](https://www.rust-lang.org/governance/teams/compiler) does not match the others. This fixes that by starting the sentence with "Mak*ing*..."

I also propose to change the description to read:

> Making the compiler easier to learn by maintaining and improving the Rustc Dev Guide

I believe this more accurately reflects our work.

Thoughts, @rust-lang/wg-rustc-dev-guide?