### PR TITLE
add dev tools zulip info

### DIFF
--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -16,8 +16,7 @@ name = "Dev tools team"
 email = "tools@rust-lang.org"
 description = "Contributing to and creating the Rust development tools"
 repo = "https://github.com/rust-dev-tools/dev-tools-team"
-discord-invite = "https://discord.gg/sG23nSS"
-discord-name = "#dev-tools"
+zulip-stream = "t-devtools"
 
 [[github]]
 orgs = ["rust-lang", "rust-dev-tools"]


### PR DESCRIPTION
r? @Manishearth or @killercup 

Think this was mentioned in passing at the last Dev tools meeting but seems like the right thing to do either way given the move from Discord to Zulip