### PR TITLE
Add macos notification group

### DIFF
--- a/people/hkratz.toml
+++ b/people/hkratz.toml
@@ -1,0 +1,4 @@
+name = 'Hans Kratz'
+github = 'hkratz'
+github-id = 3736990
+email = 'hans@appfour.com'

--- a/people/inflation.toml
+++ b/people/inflation.toml
@@ -1,0 +1,3 @@
+name = 'Inflation'
+github = 'inflation'
+github-id = 2375962

--- a/people/thomcc.toml
+++ b/people/thomcc.toml
@@ -1,0 +1,4 @@
+name = 'Thom Chiovoloni'
+github = 'thomcc'
+github-id = 860665
+email = 'chiovolonit@gmail.com'

--- a/teams/macos.toml
+++ b/teams/macos.toml
@@ -1,0 +1,11 @@
+name = "macos"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "hkratz",
+    "inflation",
+    "shepmaster",
+    "thomcc",
+]


### PR DESCRIPTION
The MCP for creating a Macos [notification group](https://rustc-dev-guide.rust-lang.org/notification-groups/about.html) (rust-lang/compiler-team#470) was accepted. This PR creates the notification group with the initial group members.

cc @inflation @shepmaster @thomcc 