### PR TITLE
Remove myself as rustdoc co-lead

### DIFF
--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -2,7 +2,7 @@ name = "rustdoc"
 subteam-of = "devtools"
 
 [people]
-leads = ["GuillaumeGomez", "jyn514",]
+leads = ["GuillaumeGomez"]
 members = [
     "GuillaumeGomez",
     "ollie27",


### PR DESCRIPTION
I've enjoyed not being the go-to person for "rustdoc is doing strange things", I'd like that to be permanent.