### PR TITLE
Move onur to docs.rs alumni

### DIFF
--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -7,12 +7,12 @@ members = [
     "GuillaumeGomez",
     "Nemo157",
     "jyn514",
-    "onur",
     "pietroalbini",
     "syphar",
 ]
 alumni = [
     "Kixiron",
+    "onur",
 ]
 
 [[github]]


### PR DESCRIPTION
They haven't been active in 3+ years. I very much appreciate their work originally building docs.rs, but the team list should reflect reality.

cc @onur
cc @pietroalbini , I know you have strong opinions on this