### PR TITLE
Remove wg-incr-comp repo from website

### DIFF
--- a/teams/wg-incr-comp.toml
+++ b/teams/wg-incr-comp.toml
@@ -12,7 +12,6 @@ orgs = ["rust-lang"]
 [website]
 name = "Incremental compilation working group"
 description = "Improving incremental compilation in rustc"
-repo = "https://rust-lang.github.io/compiler-team/working-groups/incr-comp/"
 zulip-stream = "t-compiler/wg-incr-comp"
 
 [permissions]


### PR DESCRIPTION
I think we can safely remove this since it's currently a 404 on the [compiler team page](https://www.rust-lang.org/governance/teams/compiler).

cc @wesleywiser 