### PR TITLE
Remove end stop punctuation in team descriptions

### DIFF
--- a/teams/wg-allocators.toml
+++ b/teams/wg-allocators.toml
@@ -20,7 +20,7 @@ orgs = ["rust-lang"]
 
 [website]
 name = "Allocator working group"
-description = "Paving a path for a standard set of allocator traits to be used in collections."
+description = "Paving a path for a standard set of allocator traits to be used in collections"
 repo = "https://github.com/rust-lang/wg-allocators"
 zulip-stream = "t-libs/wg-allocators"
 

--- a/teams/wg-embedded-infra.toml
+++ b/teams/wg-embedded-infra.toml
@@ -11,7 +11,7 @@ members = [
 
 [website]
 name = "Embedded infrastructure team"
-description = "Managing wg-embedded domains, DNS records, e-mails aliases, etc."
+description = "Managing infrastructure for wg-embedded"
 
 [[github]]
 orgs = ["rust-embedded"]

--- a/teams/wg-gamedev.toml
+++ b/teams/wg-gamedev.toml
@@ -22,7 +22,7 @@ members = [
 [website]
 page = "gamedev"
 name = "Game development working group"
-description = "Focusing on making Rust the default choice for game development."
+description = "Focusing on making Rust the default choice for game development"
 repo = "https://github.com/rust-gamedev"
 discord-invite = "https://discord.gg/sG23nSS"
 discord-name = "#wg-gamedev"

--- a/teams/wg-rustc-reading-club.toml
+++ b/teams/wg-rustc-reading-club.toml
@@ -8,7 +8,7 @@ members = ["doc-jones", "nikomatsakis"]
 
 [website]
 name = "Rust Code Reading Club working group"
-description = "Helping new and experienced contributors learn more about rustc."
+description = "Helping new and experienced contributors learn more about rustc"
 repo = "https://rust-lang.github.io/rustc-reading-club/"
 zulip-stream = "rustc-reading-club"
 


### PR DESCRIPTION
Another formatting cleanup to make these descriptions consistent.

I did

```sh
cd team/
rg description | grep "\.\"$"
```

Also edited the description for teams `embedded-infra`, to remove the somewhat awkward "etc."