### PR TITLE
Update wg-async-foundations membership according to charter

### DIFF
--- a/teams/wg-async-foundations.toml
+++ b/teams/wg-async-foundations.toml
@@ -4,33 +4,34 @@ kind = "working-group"
 [people]
 leads = ["nikomatsakis", "tmandry"]
 members = [
-  "Aaron1011",
-  "betamos",
-  "bIgBV",
-  "LucioFranco",
-  "cramertj",
-  "csmoe",
-  "doc-jones",
   "eholk",
-  "eminence",
-  "emmanuelantony2000",
   "estebank",
-  "gilescope",
   "guswynn",
-  "lbernick",
   "michaelwoerister",
-  "nellshamrell",
   "nikomatsakis",
+  "nrc",
   "pnkfelix",
-  "rylev",
   "spastorino",
   "taiki-e",
   "tmandry",
   "yoshuawuyts",
-  "zeenix",
 ]
 alumni = [
+  "Aaron1011",
+  "LucioFranco",
+  "bIgBV",
+  "betamos",
+  "cramertj",
+  "csmoe",
+  "doc-jones",
+  "eminence",
+  "emmanuelantony2000",
+  "gilescope",
+  "lbernick",
+  "nellshamrell",
+  "rylev",
   "withoutboats",
+  "zeenix",
 ]
 
 [[github]]


### PR DESCRIPTION
This updates the membership list of @rust-lang/wg-async-foundations according to the new [membership criteria](https://rust-lang.github.io/wg-async-foundations/CHARTER.html) in our charter.

Thanks to everyone who has helped out with the working group – whether it was compiler work, vision doc, documentation, or other contributions. You're always welcome back!

This is partially based on my recollection, which may be wrong. If you feel that you do meet the criteria but were moved to alumni, please ping me on Zulip or comment on this PR and we'll get it sorted. Thanks!