### PR TITLE
Update wg-traits membership and description

### DIFF
--- a/teams/wg-traits.toml
+++ b/teams/wg-traits.toml
@@ -6,29 +6,31 @@ kind = "working-group"
 leads = ["nikomatsakis", "jackh726"]
 members = [
     "Aaron1011",
-    "Areredify",
-    "detrumi",
-    "flodiebold",
     "jackh726",
-    "MarkMcCaskey",
-    "AzureMarker",
+    "lcnr",
     "matthewjasper",
-    "nathanwhit",
     "nikomatsakis",
-    "skinny121",
+    "oli-obk",
     "spastorino",
-    "zaharidichev",
 ]
 alumni = [
+    "Areredify",
+    "AzureMarker",
+    "detrumi",
+    "flodiebold",
+    "MarkMcCaskey",
+    "nathanwhit",
     "scalexm",
+    "skinny121",
     "tmandry",
     "yaahc",
+    "zaharidichev",
 ]
 
 [website]
 name = "Traits working group"
-description = "Revamping the rustc trait implementation to follow the Chalk approach"
-repo = "https://rust-lang.github.io/compiler-team/working-groups/traits/"
+description = "Improving the trait checker and related language features"
+repo = "https://github.com/rust-lang/wg-traits"
 zulip-stream = "wg-traits"
 
 [[github]]


### PR DESCRIPTION
- Moved anyone who hasn't been active in the last 6 months to alumni (thank you everyone for your contributions!)
- Added @oli-obk and @lcnr 
- Updated the description to better reflect scope of working group (at this point, we work on many trait checker things - Chalk is a part of this, but not even the core part anymore)
- Changed the repo to point to `rust-lang/wg-traits`

cc @nikomatsakis 