### PR TITLE
Add compiler team wg-debugging

### DIFF
--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -32,7 +32,6 @@ extra-teams = [
     "ides",
     "rustdoc",
     "wg-bindgen",
-    "wg-debugging",
     "wg-rustfmt",
     "wg-rustup",
     "wg-rustfix",

--- a/teams/wg-debugging.toml
+++ b/teams/wg-debugging.toml
@@ -1,16 +1,23 @@
 name = "wg-debugging"
-subteam-of = "devtools"
+subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["Manishearth", "michaelwoerister"]
+leads = ["pnkfelix", "wesleywiser"]
 members = [
-    "Manishearth",
+    "davidtwco",
     "michaelwoerister",
+    "pnkfelix",
+    "wesleywiser"
+]
+alumni = [
+    "Manishearth"
 ]
 
 [website]
-name = "Debugging working group"
-description = "Developing and managing Rust debugging tools"
-discord-invite = "https://discord.gg/UW3rnhd"
-discord-name = "#wg-debugging"
+name = "Debugging Working Group"
+description = "Providing users with a great experience when debugging Rust code"
+zulip-stream = "t-compiler/wg-debugging"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
The compiler team is [creating a working group](https://github.com/rust-lang/compiler-team/pull/489) to focus our efforts on [improving the debugging experience in 2022](https://blog.rust-lang.org/inside-rust/2022/02/22/compiler-team-ambitions-2022.html#debugging-initiatives-). 

Since a wg-debugging already existed in the repo, I talked to @Manishearth and we decided it made the most sense to just move this over to the compiler team rather than have two different working groups. I've gone ahead and added folks we talked to who are planning to contribute to this effort. 

cc @pnkfelix @michaelwoerister @davidtwco 

Thanks for your prior work in this area @Manishearth! 