### PR TITLE
Add a team for '@rustbot ping fuchsia'

### DIFF
--- a/teams/fuchsia.toml
+++ b/teams/fuchsia.toml
@@ -1,0 +1,8 @@
+name = "fuchsia"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "tmandry",
+]


### PR DESCRIPTION
I was looking for this in response to https://github.com/rust-lang/rust/pull/93858#issuecomment-1041367498. Keeping track of the right people involved here will be easier than piecing together from LinkedIn who to ping.