### PR TITLE
Remove myself from the Cargo team

### DIFF
--- a/people/alexcrichton.toml
+++ b/people/alexcrichton.toml
@@ -3,7 +3,3 @@ github = "alexcrichton"
 github-id = 64996
 irc = "acrichto"
 email = "alex@alexcrichton.com"
-
-[permissions]
-bors.rustup-rs.review = true
-bors.compiler-builtins.review = true

--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -4,7 +4,6 @@ subteam-of = "devtools"
 [people]
 leads = ["ehuss"]
 members = [
-    "alexcrichton",
     "Eh2406",
     "ehuss",
     "joshtriplett",


### PR DESCRIPTION
Lately I don't have quite the time I used to have to dedicate to Cargo
and I'm also lacking much of my prior enthusiasm, so I'm going to be
stepping down from the Cargo team. While I was here I figured I'd also
update the extra repos that I have permission to review and remove
myself there as well, I haven't looked at those in quite some time so
it's probably good to clean that up as well.