### PR TITLE
Acknowledge past members of the Cargo team

### DIFF
--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -12,6 +12,9 @@ members = [
 ]
 alumni = [
     "nrc",
+    "dwijnand",
+    "wycats",
+    "withoutboats",
 ]
 
 [permissions]


### PR DESCRIPTION
This adds some people to the alumni list of the Cargo Team:
- @dwijnand who left the team in https://github.com/rust-lang/team/pull/54
- @wycats who left the team in https://github.com/rust-lang/team/pull/56
- @withoutboats who left the team in https://github.com/rust-lang/team/pull/202

Do we have others we should acknowledge?