### PR TITLE
Add a flag for whether a user has dev_desktop access.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,6 +41,7 @@ permissions-bors-repos = [
 permissions-bools = [
     "perf",
     "crater",
+    "dev-desktop",
 ]
 
 permissions-crates-io-ops-bot-apps = [

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -29,6 +29,7 @@ alumni = [
 [permissions]
 perf = true
 crater = true
+dev-desktop = true
 bors.rust.review = true
 bors.miri.review = true
 bors.measureme.review = true

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -24,6 +24,7 @@ orgs = ["bors-rs"]
 [permissions]
 perf = true
 crater = true
+dev-desktop = true
 bors.rust.review = true
 bors.crater.review = true
 


### PR DESCRIPTION
Right now all non-alumni team members have dev_desktop access.
The field is only relevant for the `all` meta-team.
We may use this field to disable access to users in the future

r? @pietroalbini 

This PR is used to enable https://github.com/rust-lang/simpleinfra/pull/79 to easily decide whether a user has access to the dev desktops, without requiring changes to the dev-desktops in the future (we can just modify the teams repo to switch flags to `false`)