### PR TITLE
Convert rustup and rustfmt from working groups to teams

### DIFF
--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -31,9 +31,9 @@ extra-teams = [
     "clippy",
     "ides",
     "rustdoc",
+    "rustfmt",
+    "rustup",
     "wg-bindgen",
-    "wg-rustfmt",
-    "wg-rustup",
     "wg-rustfix",
 ]
 extra-people = ["spacekookie"]

--- a/teams/rustfmt.toml
+++ b/teams/rustfmt.toml
@@ -1,6 +1,5 @@
-name = "wg-rustfmt"
+name = "rustfmt"
 subteam-of = "devtools"
-kind = "working-group"
 
 [people]
 leads = ["topecongiro", "calebcartwright"]
@@ -21,7 +20,7 @@ orgs = ["rust-lang"]
 bors.rust.review = true
 
 [website]
-name = "Rustfmt working group"
+name = "Rustfmt team"
 description = "Designing and implementing rustfmt, a formatting tool for Rust code"
 discord-invite = "https://discord.gg/e6Q3cvu"
 discord-name = "#wg-rustfmt"

--- a/teams/rustup.toml
+++ b/teams/rustup.toml
@@ -1,6 +1,5 @@
-name = "wg-rustup"
+name = "rustup"
 subteam-of = "devtools"
-kind = "working-group"
 
 [people]
 leads = [
@@ -17,7 +16,7 @@ alumni = [
 ]
 
 [website]
-name = "Rustup working group"
+name = "Rustup team"
 description = "Designing and implementing rustup"
 discord-invite = "https://discord.gg/e6Q3cvu"
 discord-name = "#wg-rustup"


### PR DESCRIPTION
This originally started with the realization that some emails, e.g. recent ones from the Foundation, hadn't been received by some rustup and rustfmt folks because working group members are intentionally not included in the `all@rust-lang.org` distribution list.

Subsequent [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/301329-t-devtools/topic/email.20distribution.20lists) with the dev tools team led to an overwhelming consensus that both rustup and rustfmt should be proper subteams under devtools, especially when considering their nature and operating models relative to [RFC 2856](https://rust-lang.github.io/rfcs/2856-project-groups.html).

Let me know if there's any additional changes required to make the conversion.

cc @kinnison @rbtcollins @Manishearth 