### PR TITLE
Add email to `TeamMember`

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -29,6 +29,7 @@ pub struct Team {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TeamMember {
     pub name: String,
+    pub email: Option<String>,
     pub github: String,
     pub github_id: usize,
     pub is_lead: bool,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -57,6 +57,15 @@ pub(crate) enum Email<'a> {
     Present(&'a str),
 }
 
+impl Email<'_> {
+    pub(crate) fn as_str(&self) -> Option<&str> {
+        match self {
+            Email::Present(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Person {

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -40,6 +40,7 @@ impl<'a> Generator<'a> {
                 if let Some(person) = self.data.person(github_name) {
                     members.push(v1::TeamMember {
                         name: person.name().into(),
+                        email: person.email().as_str().map(|e| e.to_string()),
                         github: (*github_name).into(),
                         github_id: person.github_id(),
                         is_lead: leads.contains(github_name),
@@ -54,6 +55,7 @@ impl<'a> Generator<'a> {
                 if let Some(person) = self.data.person(github_name) {
                     alumni.push(v1::TeamMember {
                         name: person.name().into(),
+                        email: person.email().as_str().map(|e| e.to_string()),
                         github: github_name.to_string(),
                         github_id: person.github_id(),
                         is_lead: false,

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -6,12 +6,14 @@
     "members": [
       {
         "name": "Fourth user",
+        "email": "user4@example.com",
         "github": "user-4",
         "github_id": 4,
         "is_lead": false
       },
       {
         "name": "Fifth user",
+        "email": "user5@example.com",
         "github": "user-5",
         "github_id": 5,
         "is_lead": false
@@ -29,12 +31,14 @@
     "members": [
       {
         "name": "Zeroth user",
+        "email": "user0@example.com",
         "github": "user-0",
         "github_id": 0,
         "is_lead": true
       },
       {
         "name": "First user",
+        "email": "user1@example.com",
         "github": "user-1",
         "github_id": 0,
         "is_lead": false
@@ -84,6 +88,7 @@
     "members": [
       {
         "name": "Zeroth user",
+        "email": "user0@example.com",
         "github": "user-0",
         "github_id": 0,
         "is_lead": false
@@ -101,18 +106,21 @@
     "members": [
       {
         "name": "Sixth user",
+        "email": "user6@example.com",
         "github": "user-6",
         "github_id": 6,
         "is_lead": true
       },
       {
         "name": "Third user",
+        "email": "user3@example.com",
         "github": "user-3",
         "github_id": 3,
         "is_lead": false
       },
       {
         "name": "Fourth user",
+        "email": "user4@example.com",
         "github": "user-4",
         "github_id": 4,
         "is_lead": false
@@ -130,6 +138,7 @@
     "members": [
       {
         "name": "Second user",
+        "email": "user2@example.com",
         "github": "user-2",
         "github_id": 2,
         "is_lead": true
@@ -138,12 +147,14 @@
     "alumni": [
       {
         "name": "Zeroth user",
+        "email": "user0@example.com",
         "github": "user-0",
         "github_id": 0,
         "is_lead": false
       },
       {
         "name": "Fifth user",
+        "email": "user5@example.com",
         "github": "user-5",
         "github_id": 5,
         "is_lead": false

--- a/tests/static-api/_expected/v1/teams/alumni.json
+++ b/tests/static-api/_expected/v1/teams/alumni.json
@@ -5,12 +5,14 @@
   "members": [
     {
       "name": "Fourth user",
+      "email": "user4@example.com",
       "github": "user-4",
       "github_id": 4,
       "is_lead": false
     },
     {
       "name": "Fifth user",
+      "email": "user5@example.com",
       "github": "user-5",
       "github_id": 5,
       "is_lead": false

--- a/tests/static-api/_expected/v1/teams/foo.json
+++ b/tests/static-api/_expected/v1/teams/foo.json
@@ -5,12 +5,14 @@
   "members": [
     {
       "name": "Zeroth user",
+      "email": "user0@example.com",
       "github": "user-0",
       "github_id": 0,
       "is_lead": true
     },
     {
       "name": "First user",
+      "email": "user1@example.com",
       "github": "user-1",
       "github_id": 0,
       "is_lead": false

--- a/tests/static-api/_expected/v1/teams/leaderless.json
+++ b/tests/static-api/_expected/v1/teams/leaderless.json
@@ -5,6 +5,7 @@
   "members": [
     {
       "name": "Zeroth user",
+      "email": "user0@example.com",
       "github": "user-0",
       "github_id": 0,
       "is_lead": false

--- a/tests/static-api/_expected/v1/teams/leads-permissions.json
+++ b/tests/static-api/_expected/v1/teams/leads-permissions.json
@@ -5,18 +5,21 @@
   "members": [
     {
       "name": "Sixth user",
+      "email": "user6@example.com",
       "github": "user-6",
       "github_id": 6,
       "is_lead": true
     },
     {
       "name": "Third user",
+      "email": "user3@example.com",
       "github": "user-3",
       "github_id": 3,
       "is_lead": false
     },
     {
       "name": "Fourth user",
+      "email": "user4@example.com",
       "github": "user-4",
       "github_id": 4,
       "is_lead": false

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -5,6 +5,7 @@
   "members": [
     {
       "name": "Second user",
+      "email": "user2@example.com",
       "github": "user-2",
       "github_id": 2,
       "is_lead": true
@@ -13,12 +14,14 @@
   "alumni": [
     {
       "name": "Zeroth user",
+      "email": "user0@example.com",
       "github": "user-0",
       "github_id": 0,
       "is_lead": false
     },
     {
       "name": "Fifth user",
+      "email": "user5@example.com",
       "github": "user-5",
       "github_id": 5,
       "is_lead": false


### PR DESCRIPTION
I am working on functionality to sync Zulip user groups with the data in this repo. Having email on the user means I can easily check in one place for name, email, and GitHub name. 