### PR TITLE
Leave the crates.io, docs.rs and website teams

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -6,7 +6,6 @@ members = [
     "carols10cents",
     "jtgeibel",
     "pichfl",
-    "pietroalbini",
     "locks",
     "Turbo87",
     "smarnach",
@@ -21,6 +20,7 @@ alumni = [
     "sgrif",
     "nellshamrell",
     "hi-rustin",
+    "pietroalbini",
 ]
 
 [permissions]

--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -2,17 +2,17 @@ name = "docs-rs"
 subteam-of = "devtools"
 
 [people]
-leads = ["jyn514", "pietroalbini"]
+leads = ["jyn514"]
 members = [
     "GuillaumeGomez",
     "Nemo157",
     "jyn514",
-    "pietroalbini",
     "syphar",
 ]
 alumni = [
     "Kixiron",
     "onur",
+    "pietroalbini",
 ]
 
 [[github]]

--- a/teams/website.toml
+++ b/teams/website.toml
@@ -5,11 +5,11 @@ subteam-of = "web-presence"
 leads = ["Manishearth"]
 members = [
     "Manishearth",
-    "pietroalbini",
 ]
 alumni = [
     "XAMPPRocky",
     "skade",
+    "pietroalbini",
 ]
 
 [[github]]


### PR DESCRIPTION
The time I have nowadays to contribute to Rust is less than what I had a couple years ago (now having a full time job), and realistically I can't contribute to six teams in my spare time. Being in so many teams resulted in me not being able to meaningfully contribute to any of them.

As I mentioned in [me leaving the Core Team](https://blog.rust-lang.org/2022/01/31/changes-in-the-core-team.html), from now on I'll focus just on leading the Infrastructure Team and being a member of the Release Team and the Security Response WG. I'm sad to leave the crates.io team, the docs.rs team and the website team, but I'm proud of everything we achieved in the past couple of years.