### PR TITLE
Add project-group for stable-mir

### DIFF
--- a/people/celinav.toml
+++ b/people/celinav.toml
@@ -1,0 +1,5 @@
+name = "Celina V."
+github = "celinval"
+github-id = 35149715
+email = "celinval@amazon.com"
+zulip-id = 319807

--- a/teams/project-stable-mir.toml
+++ b/teams/project-stable-mir.toml
@@ -1,0 +1,23 @@
+name = "project-stable-mir"
+kind = "project-group"
+subteam-of = "compiler"
+
+[people]
+leads = [
+    "celinval",
+    "pnkfelix"
+]
+members = [
+    "celinval",
+    "oli-obk",
+    "pnkfelix"
+]
+
+[website]
+name = "Stable MIR Project Group"
+description = "Define compiler intermediate representation usable by external tools"
+repo = "https://github.com/rust-lang/project-stable-mir"
+zulip-stream = "project-stable-mir"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
As discussed in the [2022-03-25 T-compiler steering meeting](https://zulip-archive.rust-lang.org/stream/238009-t-compiler/meetings/topic/.5Bsteering.20meeting.5D.202022-03-25.20compiler-team.23488.2C.20.23498.html), this is the project group we are forming to deliver an external definition for stable MIR.

See also https://github.com/rust-lang/compiler-team/issues/498

I have a draft charter here: https://hackmd.io/WBVP4ROORRiJGGpEaLPc6g ; I expect it will go through some further revision with the help of my co-lead.