### PR TITLE
Move some rustfmt members to alumni

### DIFF
--- a/teams/rustfmt.toml
+++ b/teams/rustfmt.toml
@@ -2,15 +2,15 @@ name = "rustfmt"
 subteam-of = "devtools"
 
 [people]
-leads = ["topecongiro", "calebcartwright"]
+leads = ["calebcartwright"]
 members = [
-    "scampi",
-    "topecongiro",
     "calebcartwright",
     "ytmimi",
 ]
 alumni = [
     "nrc",
+    "scampi",
+    "topecongiro",
 ]
 
 [[github]]


### PR DESCRIPTION
This moves some folks on the rustfmt team to alumni status to reflect the fact that they haven't been actively involved with the project for a couple years now.

@topecongiro @scampi - Thank you so much for your invaluable contributions! rustfmt wouldn't be anywhere near where it is today were it not for your tireless, and often thankless, efforts over the prior years. As I mentioned in our offline communications, you're more than welcome come back whenever!

cc @Manishearth 