### PR TITLE
Sync the `wg-rls-2` team with github

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,7 @@ allowed-github-orgs = [
     "rust-lang-nursery",
     "rust-dev-tools",
     "rust-embedded",
+    "rust-analyzer",
 ]
 
 permissions-bors-repos = [

--- a/teams/wg-rls-2.toml
+++ b/teams/wg-rls-2.toml
@@ -14,3 +14,6 @@ zulip-stream = "t-compiler/rust-analyzer"
 
 [permissions]
 bors.rust.review = true
+
+[[github]]
+orgs = ["rust-lang", "rust-analyzer"]


### PR DESCRIPTION
Follow up to the repo move of the rust-analyzer repo to rust-lang, we want to now sync the team to github for access.

See https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/rust-analyzer.20transition.20to.20rust-lang for context