### PR TITLE
Add GitHub info for wg-nll

### DIFF
--- a/teams/wg-nll.toml
+++ b/teams/wg-nll.toml
@@ -11,3 +11,6 @@ name = "Non-Lexical Lifetimes (NLL) working group"
 description = "Implementing the new MIR-based borrow checker and non-lexical lifetimes in Rust"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/nll/"
 zulip-stream = "t-compiler/wg-nll"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
The [types team](https://github.com/rust-lang/rfcs/pull/3254) is the likely successor of the work.

Note: I also added a `[[github]]` annotation to the wg defintion in the unlikely case that the wg is revived, since until now the permissions have been manually curated on GitHub.

cc @nikomatsakis @pnkfelix 