### PR TITLE
Add T-infra Zulip group

### DIFF
--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -48,6 +48,9 @@ address = "infra-team@rust-lang.org"
 [[lists]]
 address = "craterbot@rust-lang.org"
 
+[[zulip-groups]]
+name = "T-infra"
+
 [[discord-roles]]
 name = "infra-team"
 color = "#ff5454"


### PR DESCRIPTION
Following https://github.com/rust-lang/sync-team/pull/3 we now sync Zulip user groups with the Team repo. As a first real world test of this, I'd like to sync the infra team. 