### PR TITLE
Clean up the Clippy team

### DIFF
--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -5,18 +5,22 @@ subteam-of = "devtools"
 leads = ["Manishearth", "flip1995"]
 members = [
     "llogiq",
-    "killercup",
     "Manishearth",
     "matthiaskrgr",
-    "phansch",
-    "mikerite",
     "flip1995",
-    "mcarton",
     "camsteffen",
     "giraffate",
     "xFrednet",
 ]
-alumni = ["ebroto", "yaahc", "oli-obk"]
+alumni = [
+    "ebroto",
+    "yaahc",
+    "oli-obk",
+    "killercup",
+    "mcarton",
+    "mikerite",
+    "phansch",
+]
 
 [permissions]
 perf = true


### PR DESCRIPTION
This moves inactive (regarding reviews) members of the Clippy team to alumni, so they can enjoy the well deserved (temporary) retirement.

Thanks to @mcarton and @killercup for the work you did for Clippy back in the early days! Enjoy your well deserved retirement.

Also thanks to @phansch for helping with reviews in recent years. Once you're ready to invest time into Clippy again, let us know and we will welcome you back.

Thanks to @mikerite for his ongoing involvement in Clippy and comments and thoughts on Clippy PRs. I also removed you from the team in this PR, mostly to get the reviewer and r+ rights synced. If you want to pick up reviewing Clippy PRs again, let us know and we can add you back to the team and reviewer rotation.

This was discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/cleaning.20up.20GitHub.20perms/near/278950596). But let's also wait on the sign off of @mcarton, @mikerite and @Manishearth  before merging this.

cc @rylev 