### PR TITLE
Move ollie27 to alumni

### DIFF
--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -5,7 +5,6 @@ subteam-of = "devtools"
 leads = ["GuillaumeGomez"]
 members = [
     "GuillaumeGomez",
-    "ollie27",
     "Manishearth",
     "Nemo157",
     "camelid",
@@ -16,6 +15,7 @@ members = [
 alumni = [
     "jyn514",
     "kinnison",
+    "ollie27",
 ]
 
 [[github]]


### PR DESCRIPTION
This moves @ollie27 from the rustdoc team to alumni status to reflect the fact that they haven't been actively involved with the project for some time now.

@ollie27 - Thanks a lot for your contributions and invaluable reviews on rustdoc! Thanks to you, rustdoc got much better. You're more than welcome to come back whenever you have time to contribute again! :)

cc @rust-lang/rustdoc 