### PR TITLE
Add GitHub repo for IDEs team

### DIFF
--- a/teams/ides.toml
+++ b/teams/ides.toml
@@ -16,6 +16,9 @@ alumni = [
     "nrc",
 ]
 
+[[github]]
+orgs = ["rust-lang"]
+
 [rfcbot]
 label = "T-IDEs"
 name = "IDEs and editors"


### PR DESCRIPTION
cc @Xanewok 

I'm not sure how active the IDEs team is now, but I am trying to clean up our GitHub teams, and the [IDEs](https://github.com/orgs/rust-lang/teams/ides) team is one of the few remaining that is not controlled by this repo. I believe we either need to merge this PR *or* archive the IDEs team description in this repo. Either way, we can then delete the IDEs GitHub team.  