### PR TITLE
Add GitHub team for unsafe-code-guidelines wg

### DIFF
--- a/teams/wg-unsafe-code-guidelines.toml
+++ b/teams/wg-unsafe-code-guidelines.toml
@@ -10,3 +10,6 @@ members = ["nikomatsakis", "avadacatavra", "RalfJung"]
 name = "Unsafe Code Guidelines (UCG) working group"
 description = "Working out the \"Unsafe Code Guidelines\", which define what kind of behavior unsafe code can and cannot do"
 zulip-stream = "t-lang/wg-unsafe-code-guidelines"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Currently the [unsafe code guidelines GitHub team](https://github.com/orgs/rust-lang/teams/wg-unsafe-code-guidelines) is out of sync with the team repo definition. This will create a team automatically on GitHub that's kept in sync. Once this is merged, we would delete the old team in favor of the newly synced team.

However, if this is merged, this will remove a few people from the GitHub team: @comex, @gereeter, @strega-nil, @Mark-Simulacrum, and @ehsanmok. If removing any of these folks is incorrect, we just need to add them to the members list. 

cc @nikomatsakis, @avadacatavra, @RalfJung