### PR TITLE
Add GitHub team for grammar wg

### DIFF
--- a/teams/wg-grammar.toml
+++ b/teams/wg-grammar.toml
@@ -7,7 +7,6 @@ leads = ["eddyb"]
 members = [
     "eddyb",
     "CAD97",
-   
 ]
 alumni = [
     "Centril",
@@ -17,3 +16,6 @@ alumni = [
 [website]
 name = "Grammar working group"
 description = "Working out the official, formal grammar for Rust and validating it against existing implementations"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Currently the [wg-grammar GitHub team](https://github.com/orgs/rust-lang/teams/wg-grammar) is out of sync with the team repo definition. This will create a team automatically on GitHub that's kept in sync. Once this is merged, we would delete the old team in favor of the newly synced team.

However, if this is merged, this will remove a few people from the GitHub team: @nikomatsakis, @qmx, @ehuss, @petrochenkov. If removing any of these folks is incorrect, we just need to add them to the members list. 

cc @eddyb 