### PR TITLE
Add a crates.io on-call team

### DIFF
--- a/people/Xylakant.toml
+++ b/people/Xylakant.toml
@@ -1,0 +1,4 @@
+name = 'Felix Gilcher'
+email = "felix.gilcher@asquera.de"
+github = 'Xylakant'
+github-id = 337823

--- a/people/justahero.toml
+++ b/people/justahero.toml
@@ -1,0 +1,3 @@
+name = 'Sebastian Ziebell'
+github = 'justahero'
+github-id = 1305185

--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -1,0 +1,15 @@
+name = "crates-io-on-call"
+subteam-of = "crates-io"
+
+[people]
+leads = []
+members = [
+    "skade",
+    "Xylakant",
+    "justahero",
+    "jonas-schievink",
+    "pietroalbini",
+]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Adds a crates.io on call team which until now has been manually configured [on GitHub](https://github.com/orgs/rust-lang/teams/crates-io-on-call).

This adds @justahero and @Xylakant to the team repo.

cc @jtgeibel and @Turbo87 since this adds the on-call team as a subteam of the crates.io team