### PR TITLE
Add vim and emacs marker teams

### DIFF
--- a/people/MicahChalmer.toml
+++ b/people/MicahChalmer.toml
@@ -1,0 +1,3 @@
+name = "Micah Chalmer"
+github = "MicahChalmer"
+github-id = 698400

--- a/people/brotzeit.toml
+++ b/people/brotzeit.toml
@@ -1,2 +1,3 @@
+name = "brotzeit"
 github = "brotzeit"
 github-id = 25367303

--- a/people/brotzeit.toml
+++ b/people/brotzeit.toml
@@ -1,0 +1,2 @@
+github = "brotzeit"
+github-id = 25367303

--- a/people/chris-morgan.toml
+++ b/people/chris-morgan.toml
@@ -1,0 +1,3 @@
+name = "Chris Morgan"
+github = "chris-morgan"
+github-id = 392868

--- a/people/da-x.toml
+++ b/people/da-x.toml
@@ -1,0 +1,3 @@
+name = "Dan Aloni"
+github = "da-x"
+github-id = 321273

--- a/teams/emacs.toml
+++ b/teams/emacs.toml
@@ -1,11 +1,13 @@
-name = "vim"
+name = "emacs"
 kind = "marker-team"
 
 [people]
 leads = []
 members = [
-    "da-x",
-    "chris-morgan"
+    "pnkfelix",
+    "MicahChalmer",
+    "tromey",
+    "brotzeit"
 ]
 
 [[github]]

--- a/teams/vim.toml
+++ b/teams/vim.toml
@@ -1,0 +1,12 @@
+name = "rust.vim"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "da-x",
+    "chris-morgan"
+]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
This adds vim and emacs marker teams that mirror the teams in GitHub: [rust.vim](https://github.com/orgs/rust-lang/teams/rust-vim) and [rust-mode](https://github.com/orgs/rust-lang/teams/rust-mode). This is part of the effort to ensure we don't have any teams on GitHub that are not controlled by this repo. Here are some things we may want to consider perform merging:
* The use of marker teams is a bit odd. One could argue this should be a subteam of the IDEs team, but I'm not sure if that team is actually active right now. However, whether IDEs is active or not might not actually matter. cc @Xanewok 
* I've named the teams "vim" and "emacs" respectively instead of using the "rust.vim" and "rust-mode" names employed on GitHub. The new names are more understandable I believe, but they might be more general than we actually need. 
* This PR adds @MicahChalmer, @brotzeit, @chris-morgan, and @da-x to the team repo. However, the use of marker teams means that they are still not "officially" a part of the Rust project.