### PR TITLE
Add a crates.io on-call team

### DIFF
--- a/people/Xylakant.toml
+++ b/people/Xylakant.toml
@@ -1,0 +1,3 @@
+name = 'Felix Gilcher'
+github = 'Xylakant'
+github-id = 337823

--- a/people/justahero.toml
+++ b/people/justahero.toml
@@ -1,0 +1,3 @@
+name = 'Sebastian Ziebell'
+github = 'justahero'
+github-id = 1305185

--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -1,0 +1,17 @@
+name = "crates-io-on-call"
+# Note: This team is composed of contractors and thus not part of the Rust project.
+# Therefore, we label this as a marker team and not a subteam of crates.io
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "skade",
+    "Xylakant",
+    "justahero",
+    "jonas-schievink",
+    "pietroalbini",
+]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Supersedes #750 

This marks the crates.io on-call team as a marker team since people should not be considered members of the project if they are just members of this team.  