### PR TITLE
Add T-lang Zulip group

### DIFF
--- a/people/oli-obk.toml
+++ b/people/oli-obk.toml
@@ -3,3 +3,4 @@ github = "oli-obk"
 github-id = 332036
 email = "rustc-contact@oli-obk.de"
 discord-id = 282164774379192320
+zulip-id = 124288

--- a/people/scottmcm.toml
+++ b/people/scottmcm.toml
@@ -3,3 +3,4 @@ github = "scottmcm"
 github-id = 18526288
 email = "smcmurray@acm.org"
 discord-id = 446765297286774784
+zulip-id = 125270

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -46,3 +46,6 @@ address = "language-design-team@rust-lang.org"
 [[discord-roles]]
 name = "lang-team"
 color = "#2ecc71"
+
+[[zulip-groups]]
+name = "T-lang"


### PR DESCRIPTION
Controls the `T-lang` Zulip group from the team repo.

Also adds Zulip info for @oli-obk and @scottmcm 