### PR TITLE
Add fee1-dead to cloud desktops

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -12,6 +12,7 @@ members = [
     "ouz-a",
     "bjorn3",
     "compiler-errors",
+    "fee1-dead",
 ]
 
 [permissions]


### PR DESCRIPTION
@fee1-dead currently has only single digit cores available and is working on https://github.com/rust-lang/rust/pull/96077 which requires frequent reruns of the entire test suite.

cc @JoelMarcey 