### PR TITLE
Add ability to encode and fetch repo information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /tests/static-api/_output
+/build

--- a/repos/team.toml
+++ b/repos/team.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "team"
+description = "Rust teams structure"
+bots = ["bors", "highfive", "rustbot", "rust-timer"]
+
+[access.teams]
+core = "admin"
+mods = "maintain"

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -78,6 +78,12 @@ pub struct Teams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Repos {
+    #[serde(flatten)]
+    pub repos: IndexMap<String, Vec<Repo>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct List {
     pub address: String,
     pub members: Vec<String>,
@@ -129,4 +135,27 @@ pub struct RfcbotTeam {
 pub struct ZulipMapping {
     /// Zulip ID to GitHub ID
     pub users: IndexMap<usize, usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Repo {
+    pub org: String,
+    pub name: String,
+    pub description: String,
+    pub bots: Vec<String>,
+    pub teams: Vec<RepoTeam>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoTeam {
+    pub name: String,
+    pub permission: RepoPermission,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepoPermission {
+    Write,
+    Admin,
+    Maintain,
 }

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -142,8 +142,17 @@ pub struct Repo {
     pub org: String,
     pub name: String,
     pub description: String,
-    pub bots: Vec<String>,
+    pub bots: Vec<Bot>,
     pub teams: Vec<RepoTeam>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Bot {
+    Bors,
+    Highfive,
+    Rustbot,
+    RustTimer,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -23,7 +23,7 @@ impl Data {
         };
 
         data.load_dir("repos", |this, repo: Repo| {
-            // TODO: repo.validate()?;
+            repo.validate()?;
             this.repos
                 .insert((repo.org.clone(), repo.name.clone()), repo);
             Ok(())

--- a/src/data.rs
+++ b/src/data.rs
@@ -48,7 +48,9 @@ impl Data {
         T: for<'de> Deserialize<'de>,
         F: Fn(&mut Self, T) -> Result<(), Error>,
     {
-        for entry in std::fs::read_dir(dir)? {
+        for entry in std::fs::read_dir(dir)
+            .with_context(|e| format!("`load_dir` failed to read directory '{}': {}", dir, e))?
+        {
             let path = entry?.path();
 
             if path.is_file() && path.extension() == Some(OsStr::new("toml")) {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,4 @@
-use crate::schema::{Config, List, Person, Team, ZulipGroup};
+use crate::schema::{Config, List, Person, Repo, Team, ZulipGroup};
 use failure::{Error, ResultExt};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -9,6 +9,7 @@ use std::path::Path;
 pub(crate) struct Data {
     people: HashMap<String, Person>,
     teams: HashMap<String, Team>,
+    repos: HashMap<(String, String), Repo>,
     config: Config,
 }
 
@@ -17,8 +18,16 @@ impl Data {
         let mut data = Data {
             people: HashMap::new(),
             teams: HashMap::new(),
+            repos: HashMap::new(),
             config: load_file(Path::new("config.toml"))?,
         };
+
+        data.load_dir("repos", |this, repo: Repo| {
+            // TODO: repo.validate()?;
+            this.repos
+                .insert((repo.org.clone(), repo.name.clone()), repo);
+            Ok(())
+        })?;
 
         data.load_dir("people", |this, person: Person| {
             person.validate()?;
@@ -106,6 +115,10 @@ impl Data {
             }
         }
         Ok(result)
+    }
+
+    pub(crate) fn repos(&self) -> impl Iterator<Item = &Repo> {
+        self.repos.iter().map(|(_, repo)| repo)
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -644,6 +644,18 @@ pub(crate) struct Repo {
     pub access: RepoAccess,
 }
 
+impl Repo {
+    const VALID_ORGS: &'static [&'static str] = &["rust-lang"];
+
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        if !Self::VALID_ORGS.contains(&self.org.as_str()) {
+            bail!("{} is not a valid repo org", self.org);
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct RepoAccess {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -640,7 +640,7 @@ pub(crate) struct Repo {
     pub org: String,
     pub name: String,
     pub description: String,
-    pub bots: Vec<String>, // TODO: should this be an enum?
+    pub bots: Vec<Bot>,
     pub access: RepoAccess,
 }
 
@@ -654,6 +654,15 @@ impl Repo {
 
         Ok(())
     }
+}
+
+#[derive(serde_derive::Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum Bot {
+    Bors,
+    Highfive,
+    Rustbot,
+    RustTimer,
 }
 
 #[derive(serde_derive::Deserialize, Debug)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,7 @@
 use crate::data::Data;
 pub(crate) use crate::permissions::Permissions;
 use failure::{bail, err_msg, Error};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -632,4 +632,28 @@ fn default_true() -> bool {
 
 fn default_false() -> bool {
     false
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub(crate) struct Repo {
+    pub org: String,
+    pub name: String,
+    pub description: String,
+    pub bots: Vec<String>, // TODO: should this be an enum?
+    pub access: RepoAccess,
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub(crate) struct RepoAccess {
+    pub teams: HashMap<String, RepoPermission>,
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub(crate) enum RepoPermission {
+    Write,
+    Maintain,
+    Admin,
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -1,5 +1,5 @@
 use crate::data::Data;
-use crate::schema::{Permissions, RepoPermission, TeamKind, ZulipGroupMember};
+use crate::schema::{Bot, Permissions, RepoPermission, TeamKind, ZulipGroupMember};
 use failure::Error;
 use indexmap::IndexMap;
 use log::info;
@@ -39,7 +39,16 @@ impl<'a> Generator<'a> {
                 org: r.org.clone(),
                 name: r.name.clone(),
                 description: r.description.clone(),
-                bots: r.bots.clone(),
+                bots: r
+                    .bots
+                    .iter()
+                    .map(|b| match b {
+                        Bot::Bors => v1::Bot::Bors,
+                        Bot::Highfive => v1::Bot::Highfive,
+                        Bot::RustTimer => v1::Bot::RustTimer,
+                        Bot::Rustbot => v1::Bot::Rustbot,
+                    })
+                    .collect(),
                 teams: r
                     .access
                     .teams

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -42,6 +42,7 @@ static CHECKS: &[Check<fn(&Data, &mut Vec<String>)>] = checks![
     validate_discord_team_members_have_discord_ids,
     validate_zulip_group_ids,
     validate_zulip_group_extra_people,
+    validate_repos,
 ];
 
 #[allow(clippy::type_complexity)]
@@ -649,6 +650,23 @@ fn validate_zulip_group_extra_people(data: &Data, errors: &mut Vec<String>) {
             }
             Ok(())
         });
+        Ok(())
+    });
+}
+
+/// Ensure working group names start with `wg-`
+fn validate_repos(data: &Data, errors: &mut Vec<String>) {
+    wrapper(data.repos(), errors, |repo, _| {
+        for (team_name, _) in &repo.access.teams {
+            if data.team(team_name).is_none() {
+                bail!(
+                    "access for {}/{} is invalid: '{}' is not the name of a team",
+                    repo.org,
+                    repo.name,
+                    team_name
+                );
+            }
+        }
         Ok(())
     });
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -654,7 +654,7 @@ fn validate_zulip_group_extra_people(data: &Data, errors: &mut Vec<String>) {
     });
 }
 
-/// Ensure working group names start with `wg-`
+/// Ensure repos reference valid teams
 fn validate_repos(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.repos(), errors, |repo, _| {
         for (team_name, _) in &repo.access.teams {

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -1,0 +1,16 @@
+{
+  "rust-lang": [
+    {
+      "org": "rust-lang",
+      "name": "some_repo",
+      "description": "A repo!",
+      "bots": [],
+      "teams": [
+        {
+          "name": "foo",
+          "permission": "admin"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -1,0 +1,12 @@
+{
+  "org": "rust-lang",
+  "name": "some_repo",
+  "description": "A repo!",
+  "bots": [],
+  "teams": [
+    {
+      "name": "foo",
+      "permission": "admin"
+    }
+  ]
+}

--- a/tests/static-api/repos/some_repo.toml
+++ b/tests/static-api/repos/some_repo.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "some_repo"
+description = "A repo!"
+bots = []
+
+[access.teams]
+foo = "admin"


### PR DESCRIPTION
This is the start of being able to control GitHub repos from the team repo. 

This introduces one new configuration file type ("repo" located in the "repos" folder) as well as two new endpoint types: /v1/repos.json and /v1/repos/$REPO.json.

The ultimate idea is for this to be fed to sync-team so we can move away from having GitHub admins make changes that are not visible to the rest of the project. 

I've only tried to reproduce this repo in the configuration so far. 