### PR TITLE
Add branches to repo definitions

### DIFF
--- a/repos/team.toml
+++ b/repos/team.toml
@@ -6,3 +6,7 @@ bots = ["bors", "highfive", "rustbot", "rust-timer"]
 [access.teams]
 core = "admin"
 mods = "maintain"
+
+[[branch]]
+name = "master"
+ci-checks = ["CI"]

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -144,6 +144,7 @@ pub struct Repo {
     pub description: String,
     pub bots: Vec<Bot>,
     pub teams: Vec<RepoTeam>,
+    pub branches: Vec<Branch>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -167,4 +168,11 @@ pub enum RepoPermission {
     Write,
     Admin,
     Maintain,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Branch {
+    pub name: String,
+    pub ci_checks: Vec<String>,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -642,6 +642,8 @@ pub(crate) struct Repo {
     pub description: String,
     pub bots: Vec<Bot>,
     pub access: RepoAccess,
+    #[serde(default)]
+    pub branch: Vec<Branch>,
 }
 
 impl Repo {
@@ -677,4 +679,12 @@ pub(crate) enum RepoPermission {
     Write,
     Maintain,
     Admin,
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub(crate) struct Branch {
+    pub name: String,
+    #[serde(default)]
+    pub ci_checks: Vec<String>,
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -65,11 +65,22 @@ impl<'a> Generator<'a> {
                         }
                     })
                     .collect(),
+                branches: r
+                    .branch
+                    .iter()
+                    .map(|b| v1::Branch {
+                        name: b.name.clone(),
+                        ci_checks: b.ci_checks.clone(),
+                    })
+                    .collect(),
             };
 
             self.add(&format!("v1/repos/{}.json", r.name), &repo)?;
             repos.entry(r.org.clone()).or_default().push(repo);
         }
+        repos
+            .values_mut()
+            .for_each(|r| r.sort_by(|r1, r2| r1.name.cmp(&r2.name)));
 
         self.add("v1/repos.json", &v1::Repos { repos })?;
         Ok(())

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -10,6 +10,14 @@
           "name": "foo",
           "permission": "admin"
         }
+      ],
+      "branches": [
+        {
+          "name": "master",
+          "ci_checks": [
+            "CI"
+          ]
+        }
       ]
     }
   ]

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -8,5 +8,13 @@
       "name": "foo",
       "permission": "admin"
     }
+  ],
+  "branches": [
+    {
+      "name": "master",
+      "ci_checks": [
+        "CI"
+      ]
+    }
   ]
 }

--- a/tests/static-api/repos/some_repo.toml
+++ b/tests/static-api/repos/some_repo.toml
@@ -5,3 +5,7 @@ bots = []
 
 [access.teams]
 foo = "admin"
+
+[[branch]]
+name = "master"
+ci-checks = ["CI"]


### PR DESCRIPTION
This adds support for protected branches to the repo definitions. The definitions look like this:

```toml
# the use of "branch" instead of protected branch makes this 
# feature more general than just protecting branches
[[branch]] 
# Should we require the user specify at least one branch with 
# a `default` field set to true for the default branch?
name = "master" 
# This field is optional. I believe GitHub will accept these even
# if the job does not exist
ci-checks = ["CI"] 
```

No other fields than the ones above are supported. I believe all other branch options that rust-lang/team has set should be the default. They are:
* Require a pull request before merging
* Require 1 approval (no exceptions for admins or any specific teams or people)
* Dismiss stale pull request approvals when new commits are pushed
* All other options are the GitHub default

When this is merged the following can be added to sync-team:
* Ensuring the branch exists
* Ensuring the proper branch protection options are set for the branch
* Removing all other branch protections 
