### PR TITLE
Add more crates.io related zulip IDs

### DIFF
--- a/people/JohnTitor.toml
+++ b/people/JohnTitor.toml
@@ -3,6 +3,7 @@ github = "JohnTitor"
 github-id = 25030997
 email = "huyuumi.dev@gmail.com"
 discord-id = 362122860673892353
+zulip-id = 217081
 
 [permissions]
 bors.semverver.review = true

--- a/people/Turbo87.toml
+++ b/people/Turbo87.toml
@@ -3,3 +3,4 @@ github = "Turbo87"
 github-id = 141300
 email = "tobias.bieniek@gmail.com"
 discord-id = 313625269405745155
+zulip-id = 282338

--- a/people/Xylakant.toml
+++ b/people/Xylakant.toml
@@ -1,3 +1,4 @@
 name = 'Felix Gilcher'
 github = 'Xylakant'
 github-id = 337823
+zulip-id = 534379

--- a/people/jonas-schievink.toml
+++ b/people/jonas-schievink.toml
@@ -3,3 +3,4 @@ github = "jonas-schievink"
 github-id = 1786438
 email = "jonasschievink@gmail.com"
 irc = "jschievink"
+zulip-id = 211727

--- a/people/jtgeibel.toml
+++ b/people/jtgeibel.toml
@@ -3,3 +3,4 @@ github = "jtgeibel"
 github-id = 22186
 email = "jtgeibel@gmail.com"
 discord-id = 451522714101088258
+zulip-id = 257369

--- a/people/justahero.toml
+++ b/people/justahero.toml
@@ -1,3 +1,4 @@
 name = 'Sebastian Ziebell'
 github = 'justahero'
 github-id = 1305185
+zulip-id = 529812

--- a/people/listochkin.toml
+++ b/people/listochkin.toml
@@ -1,3 +1,4 @@
 name = 'Андрей Листочкин (Andrei Listochkin)'
 github = 'listochkin'
 github-id = 405222
+zulip-id = 499958

--- a/people/locks.toml
+++ b/people/locks.toml
@@ -3,3 +3,4 @@ github = "locks"
 github-id = 32344
 email = "rokusu@gmail.com"
 discord-id = 83124738867597312
+zulip-id = 459395

--- a/people/pichfl.toml
+++ b/people/pichfl.toml
@@ -3,3 +3,4 @@ github = 'pichfl'
 github-id = 194641
 email = 'fp@ylk.gd'
 discord-id = 412702990072283138
+zulip-id = 527401

--- a/people/skade.toml
+++ b/people/skade.toml
@@ -3,3 +3,4 @@ github = "skade"
 github-id = 47542
 email = "flo@andersground.net"
 discord-id = 433394056073183253
+zulip-id = 215333

--- a/people/smarnach.toml
+++ b/people/smarnach.toml
@@ -3,3 +3,4 @@ github = "smarnach"
 github-id = 249196
 email = "sven@marnach.net"
 discord-id = 491002025950183434
+zulip-id = 219929

--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -16,3 +16,6 @@ members = [
 
 [[github]]
 orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "T-crates-io-on-call"

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -54,3 +54,6 @@ extra-people = [
     "carols10cents",
     "jtgeibel",
 ]
+
+[[zulip-groups]]
+name = "T-crates-io"


### PR DESCRIPTION
The crates.io team is slowly working on migrating to Zulip for our official communications. 

I want to be able to point to this repo to say "these are the IDs that should have access to the private crates.io streams on zulip", so I'm adding the Zulip IDs that I can find. This includes people on the crates.io team and the crates.io on-call team.

To find your Zulip ID, go to "Personal Settings" -> "Profile" and click the "Preview profile" button, you should see "User ID" there.

## People whose Zulip IDs I found - Please check and comment if yours is incorrect!

- [x] @Turbo87 
- [x] @jonas-schievink 
- [x] @jtgeibel 
- [x] @listochkin
- [x] @locks
- [x] @skade 
- [x] @smarnach
- [x] @JohnTitor
- [x] @pichfl
- [x] @justahero
- [x] @Xylakant

## People on the teams who already have their Zulip ID in their teams profile (no action needed)

- me
- Pietro