### PR TITLE
Add zulip-groups annotation for Cargo Team

### DIFF
--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -37,3 +37,6 @@ zulip-stream = "t-cargo"
 
 [[lists]]
 address = "cargo@rust-lang.org"
+
+[[zulip-groups]]
+name = "T-cargo"


### PR DESCRIPTION
This creates and syncs a `T-cargo` Zulip group, which is like

<img width="350" alt="image" src="https://user-images.githubusercontent.com/14314532/186412262-8eddbf79-a4d0-4d7a-83dd-6776280c6c1b.png">


Refs: 

- https://github.com/rust-lang/team/pull/809#issuecomment-1225514064
- [TOML schema reference](https://github.com/rust-lang/team/blob/master/docs/toml-schema.md)


cc @rust-lang/cargo 