### PR TITLE
Add Twitter marker team

### DIFF
--- a/teams/twitter.toml
+++ b/teams/twitter.toml
@@ -1,0 +1,12 @@
+name = "twitter"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "m-ou-se",
+    "joshtriplett",
+    "rylev",
+    "badboy",
+    "pietroalbini"
+]

--- a/teams/twitter.toml
+++ b/teams/twitter.toml
@@ -8,5 +8,5 @@ members = [
     "joshtriplett",
     "rylev",
     "badboy",
-    "pietroalbini"
+    "pietroalbini",
 ]


### PR DESCRIPTION
Adds @m-ou-se, @joshtriplett, @badboy, @pietroalbini, and myself to a new Twitter marker team which will be referenced in forge as the list of folks with access to https://twitter.com/rustlang. 

This list was decided by who has used that account to tweet in the last few months. Please let me know if I should add or remove anyone.

See https://github.com/rust-lang/rust-forge/pull/641 for more details.