### PR TITLE
Add Zulip group for rustdoc

### DIFF
--- a/people/Nemo157.toml
+++ b/people/Nemo157.toml
@@ -3,3 +3,4 @@ github = "Nemo157"
 github-id = 81079
 email = "rust-lang@nemo157.com"
 discord-id = 274907435972427778
+zulip-id = 210267

--- a/people/jsha.toml
+++ b/people/jsha.toml
@@ -2,3 +2,4 @@ name = "Jacob Hoffman-Andrews"
 github = "jsha"
 github-id = 220205
 email = "rust@hoffman-andrews.com"
+zulip-id = 315412

--- a/people/notriddle.toml
+++ b/people/notriddle.toml
@@ -2,3 +2,4 @@ name = "Michael Howell"
 github = "notriddle"
 github-id = 1593513
 email = "notriddle+rust-mod@protonmail.com"
+zulip-id = 210053

--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -38,3 +38,6 @@ zulip-stream = "rustdoc"
 
 [[lists]]
 address = "rustdoc@rust-lang.org"
+
+[[zulip-groups]]
+name = "T-rustdoc"


### PR DESCRIPTION
Adds a Zulip group for rust-doc team to the team repo configuration.

`T-rustdoc` already exists on Zulip, so this is mostly a no-op, but there would be a slight change in membership: 

* @ollie27 would be removed from the user group (as they are now considered an alum)
* @notriddle would be added to the user group

cc @jsha and @Nemo157 whose Zulip ids have been added. 

r? @GuillaumeGomez 