### PR TITLE
Add compiler team Zulip group

### DIFF
--- a/people/cjgillot.toml
+++ b/people/cjgillot.toml
@@ -2,3 +2,4 @@ name = 'Camille Gillot'
 github = 'cjgillot'
 github-id = 1822483
 email = "gillot.camille@gmail.com"
+zulip-id = 248906

--- a/people/davidtwco.toml
+++ b/people/davidtwco.toml
@@ -2,3 +2,4 @@ name = "David Wood"
 github = "davidtwco"
 github-id = 1295100
 email = "david@davidtw.co"
+zulip-id = 116107

--- a/people/eddyb.toml
+++ b/people/eddyb.toml
@@ -3,3 +3,4 @@ github = "eddyb"
 github-id = 77424
 email = "eddyb@lyken.rs"
 discord-id = 391665108490649601
+zulip-id = 119009

--- a/people/michaelwoerister.toml
+++ b/people/michaelwoerister.toml
@@ -3,3 +3,4 @@ github = "michaelwoerister"
 github-id = 1825894
 irc = "mw"
 email = "michaelwoerister@gmail.com"
+zulip-id = 124287

--- a/people/nagisa.toml
+++ b/people/nagisa.toml
@@ -4,3 +4,4 @@ github-id = 679122
 irc = "nagisa"
 email = "simonas+t-compiler@kazlauskas.me"
 discord-id = 119181581033275392
+zulip-id = 123586

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -66,3 +66,6 @@ extra-people = [
     "arielb1",
     "jseyfried",
 ]
+
+[[zulip-groups]]
+name = "T-compiler"


### PR DESCRIPTION
This adds a Zulip user group for the compiler team. `T-compiler` already exists on Zulip, so the group will not be created, but there will be several changes in membership of that group:

The following people will no longer be on the `T-compiler` Zulip group:
* @arielb1
* @cramertj
* @varkor

Additionally, @cjgillot will be added to the user group.

Also, @michaelwoerister, @eddyb, @davidtwco, and @nagisa - please note I added your Zulip ID. 

r? @wesleywiser @pnkfelix  
