### PR TITLE
Remove old unused rust-community Google Groups

### DIFF
--- a/teams/community.toml
+++ b/teams/community.toml
@@ -35,9 +35,6 @@ extra-teams = [
     "community-survey",
     "community-localization",
 ]
-extra-emails = [
-    "rust-community@googlegroups.com",
-]
 
 [[lists]]
 address = "community-team@rust-lang.org"
@@ -46,9 +43,6 @@ extra-teams = [
     "community-events",
     "community-survey",
     "community-localization",
-]
-extra-emails = [
-    "rust-community@googlegroups.com",
 ]
 
 [[lists]]


### PR DESCRIPTION
The community@ list itself is handled by our infrastructure.