### PR TITLE
Add Exploit Mitigations Project Group

### DIFF
--- a/people/rcvalle.toml
+++ b/people/rcvalle.toml
@@ -1,0 +1,5 @@
+name = "Ramon de C Valle"
+github = "rcvalle"
+github-id = 3988004
+email = false
+zulip-id = 295814

--- a/teams/project-exploit-mitigations.toml
+++ b/teams/project-exploit-mitigations.toml
@@ -1,0 +1,24 @@
+name = "project-exploit-mitigations"
+kind = "project-group"
+subteam-of = "compiler"
+
+[people]
+leads = [
+    "rcvalle",
+]
+members = [
+    "cuviper",
+    "rcvalle",
+]
+
+[website]
+name = "Exploit Mitigations Project Group"
+description = "Maintaining and improving the existing, implementing, and researching new exploit mitigations for the Rust compiler"
+repo = "https://github.com/rust-lang/project-exploit-mitigations"
+zulip-stream = "project-exploit-mitigations"
+
+[[github]]
+orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "project-exploit-mitigations"


### PR DESCRIPTION
This PR adds the Exploit Mitigations Project Group (see rust-lang/compiler-team#545).