### PR TITLE
Add `lang-team@` as an alias

### DIFF
--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -41,6 +41,9 @@ address = "lang-private@rust-lang.org"
 address = "lang@rust-lang.org"
 
 [[lists]]
+address = "lang-team@rust-lang.org"
+
+[[lists]]
 address = "language-design-team@rust-lang.org"
 
 [[discord-roles]]


### PR DESCRIPTION
Multiple times, people have gotten confused that `lang@` reaches us but
`lang-team@` does not. (This includes people *on* the team.) Add it as
an alias.
