### PR TITLE
Add the Rust Style Team

### DIFF
--- a/teams/style.toml
+++ b/teams/style.toml
@@ -1,0 +1,38 @@
+name = "style"
+subteam-of = "lang"
+
+[people]
+leads = ["calebcartwright"]
+members = [
+    "calebcartwright",
+    "compiler-errors",
+    "joshtriplett",
+    "yaahc",
+]
+
+[[github]]
+orgs = ["rust-lang"]
+
+[permissions]
+# Primarily for documentation stored in rust-lang/rust
+bors.rust.review = true
+
+[rfcbot]
+label = "T-style"
+name = "Style"
+ping = "rust-lang/style"
+
+[website]
+name = "Style team"
+description = "Defining and evolving the default Rust coding style"
+zulip-stream = "t-style"
+
+[[zulip-groups]]
+name = "T-style"
+
+[[lists]]
+address = "style@rust-lang.org"
+
+[[lists]]
+address = "style-team@rust-lang.org"
+


### PR DESCRIPTION
https://github.com/rust-lang/rfcs/pull/3309 has now been merged.

Also need to create the `T-style` and `I-style-nominated` labels.