### PR TITLE
Delay running the sync-team tool so that GitHub pages has time to fully deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Start the synchronization tool
         run: |
+          sleep 5 # give GitHub pages enough time to fully deploy
           aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
           cat output.json | python3 -m json.tool
         env:


### PR DESCRIPTION
The SLA for how much time it takes for GitHub pages to deploy is 10 minutes. However, hopefully it will be faster than that in reality. 

Alternatively, we could try to modify the deploy.rs script to figure out if the deploy has succeeded (perhaps using [this API endpoint](https://docs.github.com/en/rest/pages#get-latest-pages-build)). However, this comes with its own set of issues including the need for a GitHub access key and the fact that it's simply more code that could break.  