### PR TITLE
Add Zulip config for async working group

### DIFF
--- a/people/hawkw.toml
+++ b/people/hawkw.toml
@@ -1,0 +1,5 @@
+name = "Eliza Weisman"
+email = 'eliza@buoyant.io'
+github = 'hawkw'
+github-id = 2796466
+zulip-id = 307286

--- a/people/hawkw.toml
+++ b/people/hawkw.toml
@@ -1,5 +1,0 @@
-name = "Eliza Weisman"
-email = 'eliza@buoyant.io'
-github = 'hawkw'
-github-id = 2796466
-zulip-id = 307286

--- a/people/taiki-e.toml
+++ b/people/taiki-e.toml
@@ -1,3 +1,4 @@
 name = 'Taiki Endo'
 github = 'taiki-e'
 github-id = 43724913
+zulip-id = 213313

--- a/teams/wg-async.toml
+++ b/teams/wg-async.toml
@@ -42,3 +42,12 @@ name = "Async working group"
 description = "Pursuing core language and library support for async-await"
 repo = "https://github.com/rust-lang/wg-async"
 zulip-stream = "wg-async"
+
+[[zulip-groups]]
+name = "WG-async"
+
+[[zulip-groups]]
+name = "WG-async-sprint-planning"
+extra-people = [
+  "hawkw"
+]

--- a/teams/wg-async.toml
+++ b/teams/wg-async.toml
@@ -48,6 +48,3 @@ name = "WG-async"
 
 [[zulip-groups]]
 name = "WG-async-sprint-planning"
-extra-people = [
-  "hawkw"
-]


### PR DESCRIPTION
This adds the `WG-async` and `WG-async-sprint-planning` Zulip user groups so that they are automatically synced.

The `WG-async` is set to just the members of the working group. This would remove @hawkw, @csmoe, @gilescope, @Aaron1011, @cramertj, @betamos, @LucioFranco, @Nemo157, @nellshamrell, @Stupremee, and @withoutboats as these folks are not members of the working group. If the #WG-async user group is being used for more than just members, we can easily add folks back using the `extra-members` feature.

The `WG-async-sprint-planning` is set to the members of the working group plus @hawkw whose info has been added to the repo. This also adds @yoshuawuyts and @taiki-e to this user group as they had not yet been added.

r? @nikomatsakis @tmandry 