### PR TITLE
Add option for excluding people from a Zulip user group

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -115,10 +115,6 @@ include-team-members = true
 extra-people = [
     "alexcrichton",
 ]
-# Include the following email addresses in the Zulip group (optional).
-extra-emails = [
-    "noreply@rust-lang.org",
-]
 # Include the following Zulip ids in the Zulip group (optional).
 extra-zulip-ids = [
     1234
@@ -127,6 +123,10 @@ extra-zulip-ids = [
 # (optional).
 extra-teams = [
     "bots-nursery",
+]
+# Exclude the following people in the Zulip group (optional).
+excluded-people = [
+    "rylev",
 ]
 ```
 


### PR DESCRIPTION
This PR does the following:
* Removes the `extra-emails` field from Zulip user group configurations. This was unused and we don't want to encourage the use of email instead of Zulip ids as this is a more direct link.
* Adds an `excluded_people` field to the Zulip user group configuration. Sometimes it might make sense to exclude a certain member from a user group. They may not be on Zulip or the user group might be a subset of the included folks. 

This can be used for the async working group configuration which has a Zulip group that is a subset of the working group and for #805 to exclude one member who is not on Zulip. 