### PR TITLE
Add Zulip user group for wg-const-eval

### DIFF
--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -18,3 +18,6 @@ repo = "https://github.com/rust-lang/const-eval"
 
 [[github]]
 orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "WG-const-eval"

--- a/teams/wg-const-eval.toml
+++ b/teams/wg-const-eval.toml
@@ -10,6 +10,9 @@ members = [
     "lcnr",
     "fee1-dead",
 ]
+alumni = [
+    "ecstatic-morse"
+]
 
 [website]
 name = "Compile-time Function Evaluation Working Group"


### PR DESCRIPTION
This adds a Zulip user group for wg-const-eval.

It also adds @ecstatic-morse to the alumni group (which was missed when they stepped down). 

@ecstatic-morse and @Centril will be removed from the Zulip user group since they are not in the working group. 

r? @oli-obk @RalfJung 