### PR TITLE
Improve error messages when checking synced Zulip user groups

### DIFF
--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -96,11 +96,13 @@ struct ZulipUsers {
 }
 
 /// A single Zulip user
-#[derive(Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Deserialize, PartialEq, Eq, Hash)]
 pub(crate) struct ZulipUser {
     #[serde(rename = "delivery_email")]
     pub(crate) email: String,
     pub(crate) user_id: usize,
+    #[serde(rename = "full_name")]
+    pub(crate) name: String,
 }
 
 /// A collection of Zulip user groups


### PR DESCRIPTION
This makes it a bit easier to know what's going on when things are not in sync. 