### PR TITLE
Add a wg-prioritization/alerts Zulip user group

### DIFF
--- a/teams/wg-prioritization.toml
+++ b/teams/wg-prioritization.toml
@@ -46,3 +46,6 @@ orgs = ["rust-lang"]
 
 [[zulip-groups]]
 name = "WG-prioritization"
+
+[[zulip-groups]]
+name = "WG-prioritization/alerts"

--- a/teams/wg-prioritization.toml
+++ b/teams/wg-prioritization.toml
@@ -49,3 +49,12 @@ name = "WG-prioritization"
 
 [[zulip-groups]]
 name = "WG-prioritization/alerts"
+excluded-people = [
+    "lcnr",
+    "Dylan-DPC",
+    "camelid",
+    "pnkfelix",
+    "hkmatsumoto",
+    "inquisitivecrystal",
+    "TaKO8Ki",
+]


### PR DESCRIPTION
This adds automatic syncing of the `wg-prioritization/alerts' Zulip user group with the membership of the wg-prioritization working group.

The user group is not currently very well synced with the working group. When this merges the following will happen:

These folks will join the user group: @camelid, @Dylan-DPC, @hkmatsumoto, @inquisitivecrystal, @lcnr, @pnkfelix, @TaKO8Ki.

The following folks will be removed (both of whom are not in the team repo, and so I don't know their GitHub handles): Xu Ran, Chris Dolby. 

r? @apiraino @wesleywiser 