### PR TITLE
Add rust-analyzer repo

### DIFF
--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "rust-analyzer"
+description = "A Rust compiler front-end for IDEs"
+bots = ["bors", "rustbot"]
+
+[access.teams]
+wg-rls-2 = "write"
+wg-rls-2-triage = "triage"
+
+[[branch]]
+name = "master"

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -168,6 +168,7 @@ pub enum RepoPermission {
     Write,
     Admin,
     Maintain,
+    Triage,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/check_synced.rs
+++ b/src/check_synced.rs
@@ -59,7 +59,7 @@ fn check_zulip(data: &Data) -> Result<(), failure::Error> {
                     };
                     if !remote_members.remove(&i) {
                         error!(
-                            "Zulip user '{:?}' is in the team repo for '{}' but not in the remote Zulip user group",
+                            "Zulip user '{}' is in the team repo for '{}' but not in the remote Zulip user group",
                             name_from_id(i),
                             local_group.name()
                         )
@@ -67,7 +67,7 @@ fn check_zulip(data: &Data) -> Result<(), failure::Error> {
                 }
                 for remote_member_id in remote_members {
                     error!(
-                        "Zulip user '{:?}' is in the remote Zulip user group '{}' but not in the team repo",
+                        "Zulip user '{}' is in the remote Zulip user group '{}' but not in the team repo",
                         name_from_id(*remote_member_id),
                         local_group.name()
                     )

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -678,6 +678,7 @@ pub(crate) struct RepoAccess {
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) enum RepoPermission {
+    Triage,
     Write,
     Maintain,
     Admin,

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -59,6 +59,7 @@ impl<'a> Generator<'a> {
                             RepoPermission::Admin => v1::RepoPermission::Admin,
                             RepoPermission::Write => v1::RepoPermission::Write,
                             RepoPermission::Maintain => v1::RepoPermission::Maintain,
+                            RepoPermission::Triage => v1::RepoPermission::Triage,
                         };
                         v1::RepoTeam {
                             name: name.clone(),


### PR DESCRIPTION
This adds configuration for controlling the [rust-lang/rust-analyzer](https://github.com/rust-lang/rust-analyzer) repo. 

Not only do we want all repos to be controlled through this mechanism long term, but this will also make it a bit easier to change the wg-rls-2 name to rust-analyzer. 

r? @jonas-schievink @matklad 