### PR TITLE
Add zulip-groups to rustc-dev-guide team

### DIFF
--- a/people/JohnTitor.toml
+++ b/people/JohnTitor.toml
@@ -3,6 +3,7 @@ github = "JohnTitor"
 github-id = 25030997
 email = "huyuumi.dev@gmail.com"
 discord-id = 362122860673892353
+zulip-id = 217081
 
 [permissions]
 bors.semverver.review = true

--- a/people/igaray.toml
+++ b/people/igaray.toml
@@ -2,3 +2,4 @@ name = 'Iñaki Garay'
 github = 'igaray'
 github-id = 167193
 email = 'igarai@gmail.com'
+zulip-id = 209053

--- a/people/pierwill.toml
+++ b/people/pierwill.toml
@@ -2,3 +2,4 @@ name = 'pierwill'
 github = 'pierwill'
 github-id = 19642016
 email = 'rust@pierwill.com'
+zulip-id = 316352

--- a/people/tshepang.toml
+++ b/people/tshepang.toml
@@ -2,3 +2,4 @@ name = 'Tshepang Mbambo'
 github = 'tshepang'
 github-id = 588486
 email = 'tshepang@gmail.com'
+zulip-id = 119529

--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -3,19 +3,17 @@ subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["spastorino", "JohnTitor"]
+leads = ["JohnTitor", "spastorino"]
 members = [
-    "spastorino",
-    "amanjeev",
-    "togiberlin",
     "JohnTitor",
-    "chrissimpkins",
     "camelid",
     "igaray",
     "pierwill",
+    "spastorino",
     "tshepang",
 ]
-alumni = ["LeSeulArtichaut", "jyn514", "mark-i-m", "Nashenas88", "rylev",]
+alumni = ["LeSeulArtichaut", "Nashenas88", "amanjeev", "chrissimpkins", "jyn514", "mark-i-m", "rylev", "togiberlin"]
+    
 
 [[github]]
 orgs = ["rust-lang"]
@@ -25,3 +23,6 @@ name = "Rustc Dev Guide working group"
 description = "Making the compiler easier to learn by maintaining and improving the Rustc Dev Guide"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/rustc-dev-guide/"
 zulip-stream = "t-compiler/wg-rustc-dev-guide"
+
+[[zulip-groups]]
+name = "WG-rustc-dev-guide"


### PR DESCRIPTION
We would need to check that all of us still want to belong to the team and add each one's zulip-ids. Can you guys please confirm by clicking your box and answering with your zulip-id, so I can fill it in the PR?.

Check https://github.com/rust-lang/team/issues/826 for instructions

cc

* [x]  @amanjeev
* [x]  @togiberlin
* [x]  @JohnTitor
* [x]  @chrissimpkins
* [x]  @camelid
* [x]  @igaray
* [x]  @pierwill
* [x]  @tshepang