### PR TITLE
Add jdno and rylev to the infra team

### DIFF
--- a/people/jdno.toml
+++ b/people/jdno.toml
@@ -1,0 +1,6 @@
+name = 'Jan David Nose'
+github = 'jdno'
+github-id = 865550
+email = 'jandavidnose@rustfoundation.org'
+discord-id = 953562944472510494
+zulip-id = 534108

--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -6,6 +6,7 @@ members = [
     "Mark-Simulacrum",
     "aidanhs",
     "pietroalbini",
+    "jdno",
 ]
 
 [[lists]]

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -9,6 +9,8 @@ members = [
     "kennytm",
     "pietroalbini",
     "shepmaster",
+    "jdno",
+    "rylev",
 ]
 alumni = [
     "sgrif",


### PR DESCRIPTION
I'm thrilled to welcome two new members of the infra team!

* @jdno is the foundation's infrastructure engineer, and will help the team with the maintenance and development of our infra as part of his day job! He will also join the infra-admins "team".
* @rylev has been doing a lot of work improving our team automation lately, and will continue improving it as part of the team.

I'll write a blog post announcing the changes in the coming weeks.