### PR TITLE
More alumni

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -129,17 +129,12 @@ impl Data {
         self.people.values()
     }
 
-    pub(crate) fn active_members(&self) -> Result<HashSet<&str>, Error> {
-        let mut result = HashSet::new();
-        for team in self.teams.values() {
-            if team.is_alumni_team() {
-                continue;
-            }
-            for member in team.members(self)? {
-                result.insert(member);
-            }
-        }
-        Ok(result)
+    pub(crate) fn active_members(&self) -> HashSet<&str> {
+        self.teams
+            .values()
+            .filter(|team| !team.is_alumni_team())
+            .flat_map(|team| team.members(self))
+            .collect()
     }
 
     pub(crate) fn repos(&self) -> impl Iterator<Item = &Repo> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,7 @@ fn run() -> Result<(), Error> {
             println!("teams:");
             let mut teams: Vec<_> = data
                 .teams()
-                .filter(|team| team.members(&data).unwrap().contains(person.github()))
+                .filter(|team| team.members(&data).contains(person.github()))
                 .collect();
             teams.sort_by_key(|team| team.name());
             if teams.is_empty() {
@@ -301,7 +301,7 @@ fn run() -> Result<(), Error> {
             if !crate::schema::Permissions::available(data.config()).contains(name) {
                 failure::bail!("unknown permission: {}", name);
             }
-            let mut allowed = crate::permissions::allowed_people(&data, name)?
+            let mut allowed = crate::permissions::allowed_people(&data, name)
                 .into_iter()
                 .map(|person| person.github())
                 .collect::<Vec<_>>();
@@ -347,7 +347,7 @@ fn dump_team_members(
     tab_offset: u8,
 ) -> Result<(), Error> {
     let leads = team.leads();
-    let mut members = team.members(data)?.into_iter().collect::<Vec<_>>();
+    let mut members = team.members(data).into_iter().collect::<Vec<_>>();
     members.sort_unstable();
     for member in members {
         if only_leads && !leads.contains(member) {

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -148,25 +148,17 @@ impl Permissions {
     }
 }
 
-pub(crate) fn allowed_people<'a>(
-    data: &'a Data,
-    permission: &str,
-) -> Result<Vec<&'a Person>, Error> {
+pub(crate) fn allowed_people<'a>(data: &'a Data, permission: &str) -> Vec<&'a Person> {
     let mut members_with_perms = HashSet::new();
     for team in data.teams() {
         if team.permissions().has(permission) {
-            for member in team.members(data)? {
-                members_with_perms.insert(member);
-            }
+            members_with_perms.extend(team.members(data));
         }
         if team.leads_permissions().has(permission) {
-            for lead in team.leads() {
-                members_with_perms.insert(lead);
-            }
+            members_with_perms.extend(team.leads());
         }
     }
-    Ok(data
-        .people()
+    data.people()
         .filter(|p| members_with_perms.contains(p.github()) || p.permissions().has(permission))
-        .collect())
+        .collect()
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -251,7 +251,7 @@ impl Team {
             let members_of_archived_teams = data
                 .archived_teams()
                 .filter_map(|t| t.members(data).ok())
-                .flat_map(|members| members.into_iter());
+                .flat_map(|members| members);
 
             members.extend(
                 alumni

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -95,7 +95,7 @@ impl<'a> Generator<'a> {
         for team in self.data.teams() {
             let leads = team.leads();
             let mut members = Vec::new();
-            for github_name in &team.members(self.data)? {
+            for github_name in &team.members(self.data) {
                 if let Some(person) = self.data.person(github_name) {
                     members.push(v1::TeamMember {
                         name: person.name().into(),
@@ -234,7 +234,7 @@ impl<'a> Generator<'a> {
 
     fn generate_permissions(&self) -> Result<(), Error> {
         for perm in &Permissions::available(self.data.config()) {
-            let allowed = crate::permissions::allowed_people(self.data, perm)?;
+            let allowed = crate::permissions::allowed_people(self.data, perm);
             let mut github_users = allowed
                 .iter()
                 .map(|p| p.github().to_string())
@@ -267,7 +267,7 @@ impl<'a> Generator<'a> {
         for team in self.data.teams() {
             if let Some(rfcbot) = team.rfcbot_data() {
                 let mut members = team
-                    .members(self.data)?
+                    .members(self.data)
                     .into_iter()
                     .map(|s| s.to_string())
                     .filter(|member| !rfcbot.exclude_members.contains(member))

--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -7,7 +7,6 @@ name = "alumni"
 leads = []
 members = [
     "Aatch",
-    "Gankra",
     "Kimundi",
     "MajorBreakfast",
     "QuietMisdreavus",
@@ -19,14 +18,11 @@ members = [
     "bkoropoff",
     "booyaa",
     "brson",
-    "dotdash",
-    "dwijnand",
     "edunham",
     "erickt",
     "frewsxcv",
     "gnunicorn",
     "huonw",
-    "jntrnr",
     "jseyfried",
     "levex",
     "niconii",
@@ -36,7 +32,6 @@ members = [
     "tomprince",
     "valgrimm",
     "whitequark",
-    "wycats",
 ]
 # Temporary key that includes all members listed as alumni in the individual
 # teams. This is needed while we migrate away from the alumni team.

--- a/tests/static-api/_expected/v1/people.json
+++ b/tests/static-api/_expected/v1/people.json
@@ -34,6 +34,11 @@
       "name": "Sixth user",
       "email": "user6@example.com",
       "github_id": 6
+    },
+    "user-7": {
+      "name": "Seventh user",
+      "email": "user7@example.com",
+      "github_id": 7
     }
   }
 }

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -5,15 +5,15 @@
     "subteam_of": null,
     "members": [
       {
-        "name": "Fourth user",
-        "github": "user-4",
-        "github_id": 4,
-        "is_lead": false
-      },
-      {
         "name": "Fifth user",
         "github": "user-5",
         "github_id": 5,
+        "is_lead": false
+      },
+      {
+        "name": "Seventh user",
+        "github": "user-7",
+        "github_id": 7,
         "is_lead": false
       }
     ],

--- a/tests/static-api/_expected/v1/teams/alumni.json
+++ b/tests/static-api/_expected/v1/teams/alumni.json
@@ -4,15 +4,15 @@
   "subteam_of": null,
   "members": [
     {
-      "name": "Fourth user",
-      "github": "user-4",
-      "github_id": 4,
-      "is_lead": false
-    },
-    {
       "name": "Fifth user",
       "github": "user-5",
       "github_id": 5,
+      "is_lead": false
+    },
+    {
+      "name": "Seventh user",
+      "github": "user-7",
+      "github_id": 7,
       "is_lead": false
     }
   ],

--- a/tests/static-api/people/user-7.toml
+++ b/tests/static-api/people/user-7.toml
@@ -1,0 +1,5 @@
+name = 'Seventh user'
+github = 'user-7'
+github-id = 7
+email = "user7@example.com"
+

--- a/tests/static-api/teams/alumni.toml
+++ b/tests/static-api/teams/alumni.toml
@@ -3,6 +3,6 @@ name = "alumni"
 [people]
 leads = []
 members = [
-    "user-4",
+    "user-7",
 ]
 include-all-alumni = true


### PR DESCRIPTION
A follow up to #858. This adds members of archived teams that are no longer active anywhere else to the alumni team. It also adds some more validation that the alumni team is correct (and allows us to remove some from the explicit list of alumni since they are reflected elsewhere). Finally, there is some light refactoring to remove unnecessary use of `Result`.