### PR TITLE
Give cjgillot access to the cloud dev environment.

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -15,6 +15,7 @@ members = [
     "fee1-dead",
     "Dajamante",
     "nellshamrell",
+    "cjgillot",
 ]
 
 [permissions]


### PR DESCRIPTION
My current contributions are done using a 10-yo personal laptop, which is a bit slow for running the rustc test suite.
Having access to a professional-grade environment would really help.