### PR TITLE
The team repo actually doesn't use any bots

### DIFF
--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "team"
 description = "Rust teams structure"
-bots = ["bors", "highfive", "rustbot", "rust-timer"]
+bots = []
 
 [access.teams]
 core = "admin"


### PR DESCRIPTION
This was originally added just because the team repo happened to already allow permissions for these bots, but that is not needed. 