### PR TITLE
Move regex team next to the crate-maintainers team on the website.

### DIFF
--- a/teams/regex.toml
+++ b/teams/regex.toml
@@ -10,5 +10,6 @@ orgs = ["rust-lang"]
 
 [website]
 name = "Regex crate team"
+weight = -250
 description = "Developing and maintaining the regex crate"
 repo = "https://github.com/rust-lang/regex"


### PR DESCRIPTION
This moves the regex team to appear right next to crate-maintainers on the website, to make it more obvious that crate-maintainers doesn't cover maintenance of `regex`.