### PR TITLE
ward off people who already have access

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -3,6 +3,9 @@ kind = "marker-team"
 
 [people]
 leads = []
+# Note: if you are a member of a Rust team that has permissions.dev-desktop set
+# to true in its team toml file, then you do not need to be added to this list.
+# For example, T-compiler and T-infra both have `dev-desktop = true`
 members = [
     "Mark-Simulacrum",
     "pietroalbini",


### PR DESCRIPTION
As suggested by @simulacrum in https://github.com/rust-lang/team/pull/867#issuecomment-1286909457, add comment warding off people who already have access.