### PR TITLE
Add compiler-contributors access to dev-desktop

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -4,11 +4,11 @@ kind = "marker-team"
 [people]
 leads = []
 members = [
-    "JoelMarcey",
-    "yaahc",
-    "ouz-a",
     "Dajamante",
+    "JoelMarcey",
     "nellshamrell",
+    "ouz-a",
+    "yaahc",
 ]
 
 [permissions]

--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -4,15 +4,9 @@ kind = "marker-team"
 [people]
 leads = []
 members = [
-    "Mark-Simulacrum",
-    "pietroalbini",
-    "oli-obk",
     "JoelMarcey",
     "yaahc",
     "ouz-a",
-    "bjorn3",
-    "compiler-errors",
-    "fee1-dead",
     "Dajamante",
     "nellshamrell",
 ]

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -39,6 +39,7 @@ alumni = [
 [permissions]
 perf = true
 crater = true
+dev-desktop = true
 bors.rust.review = true
 
 [[github]]


### PR DESCRIPTION
@oli-obk told me to give access to all compiler contributors and to remove members that have access through other teams.

infra: Mark-Simulacrum, pietroalbini
compiler: oli-obk
compiler-contributors: Mark-Simulacrum, bjorn3, compiler-errors, fee1-dead