### PR TITLE
Add Alice Cecile as a triage team member

### DIFF
--- a/people/alice-i-cecile.toml
+++ b/people/alice-i-cecile.toml
@@ -1,0 +1,4 @@
+name = "Alice Cecile"
+github = "alice-i-cecile"
+github-id = 3579909
+email = "alice.i.cecile@gmail.com"

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -15,6 +15,7 @@ members = [
     "crlf0710",
     "Muirrum",
     "camelid",
+    "alice-i-cecile",
 ]
 
 [website]


### PR DESCRIPTION
As suggested by @Dylan-DPC in this [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/242269-t-release.2Ftriage/topic/New.20members/near/305355296).

~~I'm not entirely sure how to add myself to a specific subteam, so I'm leaving this in draft for the moment.~~