### PR TITLE
Add pkg-config repo

### DIFF
--- a/people/sdroege.toml
+++ b/people/sdroege.toml
@@ -1,0 +1,4 @@
+name = "Sebastian Dröge"
+github = "sdroege"
+github-id = 301846
+email = "slomo@coaxion.net"

--- a/repos/rust-lang/pkg-config-rs.toml
+++ b/repos/rust-lang/pkg-config-rs.toml
@@ -1,5 +1,5 @@
 org = "rust-lang"
-name = "pkg-config"
+name = "pkg-config-rs"
 description = "Build library for invoking pkg-config for Rust"
 bots = []
 

--- a/repos/rust-lang/pkg-config.toml
+++ b/repos/rust-lang/pkg-config.toml
@@ -5,3 +5,6 @@ bots = []
 
 [access.teams]
 crate-maintainers = "maintain"
+
+[access.individuals]
+sdroege = "write"

--- a/repos/rust-lang/pkg-config.toml
+++ b/repos/rust-lang/pkg-config.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "pkg-config"
+description = "Build library for invoking pkg-config for Rust"
+bots = []
+
+[access.teams]
+crate-maintainers = "maintain"

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -144,6 +144,7 @@ pub struct Repo {
     pub description: String,
     pub bots: Vec<Bot>,
     pub teams: Vec<RepoTeam>,
+    pub members: Vec<RepoMember>,
     pub branches: Vec<Branch>,
 }
 
@@ -158,6 +159,12 @@ pub enum Bot {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepoTeam {
+    pub name: String,
+    pub permission: RepoPermission,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoMember {
     pub name: String,
     pub permission: RepoPermission,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -673,6 +673,8 @@ pub(crate) enum Bot {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct RepoAccess {
     pub teams: HashMap<String, RepoPermission>,
+    #[serde(default)]
+    pub individuals: HashMap<String, RepoPermission>,
 }
 
 #[derive(serde_derive::Deserialize, Debug)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -67,6 +67,23 @@ impl<'a> Generator<'a> {
                         }
                     })
                     .collect(),
+                members: r
+                    .access
+                    .individuals
+                    .iter()
+                    .map(|(name, permission)| {
+                        let permission = match permission {
+                            RepoPermission::Admin => v1::RepoPermission::Admin,
+                            RepoPermission::Write => v1::RepoPermission::Write,
+                            RepoPermission::Maintain => v1::RepoPermission::Maintain,
+                            RepoPermission::Triage => v1::RepoPermission::Triage,
+                        };
+                        v1::RepoMember {
+                            name: name.clone(),
+                            permission,
+                        }
+                    })
+                    .collect(),
                 branches: r
                     .branches
                     .iter()

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -231,13 +231,19 @@ fn validate_inactive_members(data: &Data, errors: &mut Vec<String>) {
     );
 
     let all_members = data.people().map(|p| p.github()).collect::<HashSet<_>>();
+    // All the individual contributors to any Rust controlled repos
+    let all_ics = data
+        .repos()
+        .flat_map(|r| r.access.individuals.keys())
+        .map(|n| n.as_str())
+        .collect::<HashSet<_>>();
     wrapper(
         all_members.difference(&referenced_members),
         errors,
         |person, _| {
-            if !data.person(person).unwrap().permissions().has_any() {
+            if !data.person(person).unwrap().permissions().has_any() && !all_ics.contains(person) {
                 bail!(
-                    "person `{}` is not a member of any team (active or archived) and has no permissions",
+                    "person `{}` is not a member of any team (active or archived), has no permissions, and is not an individual contributor to any repo",
                     person
                 );
             }
@@ -668,6 +674,17 @@ fn validate_repos(data: &Data, errors: &mut Vec<String>) {
                     repo.org,
                     repo.name,
                     team_name
+                );
+            }
+        }
+
+        for (name, _) in &repo.access.individuals {
+            if data.person(name).is_none() {
+                bail!(
+                    "access for {}/{} is invalid: '{}' is not the name of a person in the team repo",
+                    repo.org,
+                    repo.name,
+                    name
                 );
             }
         }

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -11,6 +11,7 @@
           "permission": "admin"
         }
       ],
+      "members": [],
       "branches": [
         {
           "name": "master",

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -9,6 +9,7 @@
       "permission": "admin"
     }
   ],
+  "members": [],
   "branches": [
     {
       "name": "master",


### PR DESCRIPTION
This adds configuration for the [`pkg-config` repo](https://github.com/rust-lang/pkg-config-rs). This largely mirrors the current config on GitHub with addition of granting the rest of the crate-maintainers team maintainer rights.  

This will also remove @sdroege's maintainer rights which might not be desired. I'll have to add support for adding individuals to repos if that's a requirement here. 

r? @m-ou-se @joshtriplett 