### PR TITLE
Even more libs contributors

### DIFF
--- a/people/Darksonn.toml
+++ b/people/Darksonn.toml
@@ -1,0 +1,4 @@
+name = 'Alice Ryhl'
+github = 'Darksonn'
+github-id = 928074
+email = 'alice@ryhl.io'

--- a/people/Thomasdezeeuw.toml
+++ b/people/Thomasdezeeuw.toml
@@ -1,0 +1,4 @@
+name = 'Thomas de Zeeuw'
+github = 'Thomasdezeeuw'
+github-id = 3159064
+email = 'thomasdezeeuw@gmail.com'

--- a/people/carllerche.toml
+++ b/people/carllerche.toml
@@ -1,0 +1,4 @@
+name = 'Carl Lerche'
+github = 'carllerche'
+github-id = 6180
+email = 'me@carllerche.com'

--- a/people/chansuke.toml
+++ b/people/chansuke.toml
@@ -1,0 +1,4 @@
+name = 'chansuke'
+github = 'chansuke'
+github-id = 501052
+email = 'moonset20@gmail.com'

--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -1,0 +1,13 @@
+org = 'rust-lang'
+name = 'backtrace-rs'
+description = 'Backtraces in Rust'
+bots = []
+
+[access.teams]
+libs-contributors = 'write'
+
+[access.individuals]
+alexcrichton = 'write'
+
+[[branch]]
+name = 'master'

--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -4,7 +4,7 @@ description = 'Backtraces in Rust'
 bots = []
 
 [access.teams]
-libs-contributors = 'write'
+libs-contributors = 'maintain'
 
 [access.individuals]
 alexcrichton = 'write'

--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -4,7 +4,7 @@ description = 'Backtraces in Rust'
 bots = []
 
 [access.teams]
-libs-contributors = 'maintain'
+crate-maintainers = 'maintain'
 
 [access.individuals]
 alexcrichton = 'write'

--- a/repos/rust-lang/flate2-rs.toml
+++ b/repos/rust-lang/flate2-rs.toml
@@ -4,7 +4,7 @@ description = 'DEFLATE, gzip, and zlib bindings for Rust'
 bots = []
 
 [access.teams]
-libs-contributors = 'maintain'
+crate-maintainers = 'maintain'
 
 [access.individuals]
 alexcrichton = 'maintain'

--- a/repos/rust-lang/flate2-rs.toml
+++ b/repos/rust-lang/flate2-rs.toml
@@ -1,0 +1,14 @@
+org = 'rust-lang'
+name = 'flate2-rs'
+description = 'DEFLATE, gzip, and zlib bindings for Rust'
+bots = []
+
+[access.teams]
+libs-contributors = 'maintain'
+
+[access.individuals]
+alexcrichton = 'maintain'
+brson = 'write'
+
+[[branch]]
+name = 'main'

--- a/repos/rust-lang/getopts.toml
+++ b/repos/rust-lang/getopts.toml
@@ -4,4 +4,4 @@ description = 'The getopts repo maintained by the rust-lang project'
 bots = []
 
 [access.teams]
-libs-contributors = 'maintain'
+crate-maintainers = 'maintain'

--- a/repos/rust-lang/getopts.toml
+++ b/repos/rust-lang/getopts.toml
@@ -1,0 +1,7 @@
+org = 'rust-lang'
+name = 'getopts'
+description = 'The getopts repo maintained by the rust-lang project'
+bots = []
+
+[access.teams]
+libs-contributors = 'maintain'

--- a/repos/rust-lang/socket2.toml
+++ b/repos/rust-lang/socket2.toml
@@ -1,0 +1,25 @@
+org = 'rust-lang'
+name = 'socket2'
+description = 'Advanced configuration options for sockets.'
+bots = []
+
+[access.teams]
+libs-contributors = 'maintain'
+
+[access.individuals]
+chansuke = 'triage'
+sfackler = 'maintain'
+Thomasdezeeuw = 'maintain'
+carllerche = 'maintain'
+Darksonn = 'maintain'
+
+[[branch]]
+name = 'master'
+ci-checks = [
+    'Rustfmt',
+    'Test (beta)',
+    'Test (macos)',
+    'Test (nightly)',
+    'Test (stable)',
+    'Test (windows)',
+]

--- a/repos/rust-lang/socket2.toml
+++ b/repos/rust-lang/socket2.toml
@@ -4,7 +4,7 @@ description = 'Advanced configuration options for sockets.'
 bots = []
 
 [access.teams]
-libs-contributors = 'maintain'
+crate-maintainers = 'maintain'
 
 [access.individuals]
 chansuke = 'triage'

--- a/src/github.rs
+++ b/src/github.rs
@@ -211,6 +211,22 @@ impl GitHubApi {
         Ok(resp.error_for_status()?.json()?)
     }
 
+    pub(crate) fn repo_collaborators(
+        &self,
+        org: &str,
+        repo: &str,
+    ) -> Result<Vec<RepoCollaborator>, Error> {
+        let resp = self
+            .prepare(
+                true,
+                Method::GET,
+                &format!("repos/{org}/{repo}/collaborators?affiliation=direct"),
+            )?
+            .send()?;
+
+        Ok(resp.error_for_status()?.json()?)
+    }
+
     pub(crate) fn protected_branches(&self, org: &str, repo: &str) -> Result<Vec<Branch>, Error> {
         let resp = self
             .prepare(
@@ -305,4 +321,35 @@ pub(crate) struct StatusChecks {
 #[derive(serde::Deserialize, Debug)]
 pub(crate) struct RequiredReviews {
     pub(crate) dismiss_stale_reviews: bool,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(crate) struct RepoCollaborator {
+    #[serde(alias = "login")]
+    pub(crate) name: String,
+    pub(crate) permissions: Permissions,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(crate) struct Permissions {
+    triage: bool,
+    push: bool,
+    maintain: bool,
+    admin: bool,
+}
+
+impl Permissions {
+    pub(crate) fn highest(&self) -> &str {
+        if self.admin {
+            "admin"
+        } else if self.maintain {
+            "maintain"
+        } else if self.push {
+            "write"
+        } else if self.triage {
+            "triage"
+        } else {
+            "read"
+        }
+    }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -274,7 +274,7 @@ pub(crate) struct GitHubMember {
 
 #[derive(serde::Deserialize, Debug)]
 pub(crate) struct Repo {
-    pub(crate) description: String,
+    pub(crate) description: Option<String>,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ fn run() -> Result<(), Error> {
             #[serde(rename_all = "kebab-case")]
             struct AccessToAdd {
                 teams: HashMap<String, String>,
+                individuals: HashMap<String, String>,
             }
             #[derive(serde::Serialize, Debug)]
             #[serde(rename_all = "kebab-case")]
@@ -219,6 +220,12 @@ fn run() -> Result<(), Error> {
                 }
             }
 
+            let individuals = github
+                .repo_collaborators(&org, &name)?
+                .into_iter()
+                .map(|c| (c.name, c.permissions.highest().to_owned()))
+                .collect();
+
             let mut branches = Vec::new();
             for branch in github.protected_branches(&org, &name)? {
                 let protection = github.branch_protection(&org, &name, &branch.name)?;
@@ -236,7 +243,7 @@ fn run() -> Result<(), Error> {
                 name: &name,
                 description: &repo.description,
                 bots,
-                access: AccessToAdd { teams },
+                access: AccessToAdd { teams, individuals },
                 branch: branches,
             };
             let file = format!("repos/{org}/{name}.toml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,9 @@ fn run() -> Result<(), Error> {
             #[derive(serde::Serialize, Debug)]
             #[serde(rename_all = "kebab-case")]
             struct AccessToAdd {
+                #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
                 teams: HashMap<String, String>,
+                #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
                 individuals: HashMap<String, String>,
             }
             #[derive(serde::Serialize, Debug)]
@@ -241,7 +243,9 @@ fn run() -> Result<(), Error> {
             let repo = RepoToAdd {
                 org: &org,
                 name: &name,
-                description: &repo.description,
+                description: &repo.description.unwrap_or_else(|| {
+                    format!("The {name} repo maintained by the rust-lang project")
+                }),
                 bots,
                 access: AccessToAdd { teams, individuals },
                 branch: branches,


### PR DESCRIPTION
This finishes adding repo configurations for all of the repos indicated [in this list here](https://github.com/rust-lang/team/pull/861#issuecomment-1286670330). 

This adds @Darksonn @Thomasdezeeuw @carllerche @chansuke to the team repo, because they are individual contributors to the socket2 crate. 

This also includes some small improvements to the `add-repo` utility which I've been using to quickly add these configs. 

r? @m-ou-se 
cc @thomcc 