### PR TITLE
Remove master branch protection on compiler-builtins

### DIFF
--- a/repos/rust-lang/compiler-builtins.toml
+++ b/repos/rust-lang/compiler-builtins.toml
@@ -5,6 +5,3 @@ bots = []
 
 [access.teams]
 crate-maintainers = 'maintain'
-
-[[branch]]
-name = 'master'


### PR DESCRIPTION
This crate is fairly low volume and only has a single maintainer (me). Currently I have no way of publishing a release because PRs also require an approval from someone other than the author.