### PR TITLE
add Rustc Trait System Rewrite Initiative

### DIFF
--- a/teams/project-trait-system-rewrite.toml
+++ b/teams/project-trait-system-rewrite.toml
@@ -1,0 +1,24 @@
+name = "project-trait-system-rewrite"
+kind = "project-group"
+subteam-of = "types"
+
+[people]
+leads = [
+    "lcnr",
+]
+members = [
+    "BoxyUwU",
+    "cjgillot",
+    "compiler-errors",
+    "spastorino",
+    "lcnr",
+]
+
+[website]
+name = "Rustc Trait System Rewrite Initiative"
+description = "Rewriting the trait system of rustc"
+repo = "https://github.com/rust-lang/types-team"
+
+[[github]]
+orgs = ["rust-lang"]
+team-name = "initiative-trait-system-rewrite"


### PR DESCRIPTION
cc https://github.com/rust-lang/types-team/issues/58

I've added every one who is already a part of an existing team and mentioned that they're interested in https://github.com/rust-lang/types-team/issues/58 to the initiative for now: @BoxyUwU @cjgillot @compiler-errors @spastorino.

Not sure if opening a new repository for the initiative is too useful as it would only 2-4 documents and in my experience initiative repos are somewhat hard to discover. I don't know, maybe we discover that a repo is really useful '^^ can still make a new one at that point

@rust-lang/types for review/approval
