### PR TITLE
Add the Android team to the project

### DIFF
--- a/people/chriswailes.toml
+++ b/people/chriswailes.toml
@@ -1,0 +1,3 @@
+name = 'Chris Wailes'
+github = 'chriswailes'
+github-id = 530751

--- a/people/maurer.toml
+++ b/people/maurer.toml
@@ -1,0 +1,3 @@
+name = 'Matthew Maurer'
+github = 'maurer'
+github-id = 136037

--- a/people/mgeisler.toml
+++ b/people/mgeisler.toml
@@ -1,0 +1,3 @@
+name = 'Martin Geisler'
+github = 'mgeisler'
+github-id = 89623

--- a/people/stephenhines.toml
+++ b/people/stephenhines.toml
@@ -1,0 +1,3 @@
+name = 'Stephen Hines'
+github = 'stephenhines'
+github-id = 17790020

--- a/teams/android.toml
+++ b/teams/android.toml
@@ -1,0 +1,11 @@
+name = "android"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "chriswailes",
+    "maurer",
+    "mgeisler",
+    "stephenhines",
+]


### PR DESCRIPTION
These user names are synchronized with the names the Android Platform Support document.