### PR TITLE
Add repository for `bors` implementation written in Rust

### DIFF
--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -1,0 +1,13 @@
+org = "rust-lang"
+name = "bors"
+
+description = "Rust implementation of bors used for various Rust components (e.g. the compiler)."
+bots = ["bors", "highfive"]
+
+[access.teams]
+infra = "write"
+mods = "maintain"
+
+[[branch]]
+name = "main"
+ci-checks = ["CI"]


### PR DESCRIPTION
This repository should contain the attempted rewrite of `homu` in Rust. I'm not sure if we want to use the `bors` bot for merging in this repository, but I guess why not, it's better to dogfood :laughing: