### PR TITLE
crates.io: Switch from Discord to Zulip

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -38,8 +38,7 @@ ping = "rust-lang/crates-io"
 [website]
 name = "Crates.io team"
 description = "Managing operations, development, and official policies for crates.io"
-discord-invite = "https://discord.gg/Rbq8W5K"
-discord-name = "#crates-io-team"
+zulip-stream = "t-crates-io"
 
 [[lists]]
 address = "crates-io@rust-lang.org"


### PR DESCRIPTION
We're already using `[[zulip-groups]]` in the file and have moved our private channels over. This PR should update the website to also link to Zulip instead of Discord.