### PR TITLE
Move CraftSpider to rustdoc team alumnis

### DIFF
--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -8,7 +8,6 @@ members = [
     "Manishearth",
     "Nemo157",
     "camelid",
-    "CraftSpider",
     "jsha",
     "notriddle",
     "aDotInTheVoid",
@@ -17,6 +16,7 @@ alumni = [
     "jyn514",
     "kinnison",
     "ollie27",
+    "CraftSpider",
 ]
 
 [[github]]


### PR DESCRIPTION
@CraftSpider hasn't been very active in the last months. After discussing it with them and the team, they agreed to being moved to alumnis for the time being. Thanks **a lot** for all your work. We'd love to have you back on board in the future!

cc @rust-lang/rustdoc 