### PR TITLE
Let t-miri use perf

### DIFF
--- a/teams/miri.toml
+++ b/teams/miri.toml
@@ -8,6 +8,8 @@ alumni = ["solson"]
 
 [permissions]
 bors.miri.review = true
+bors.rust.try = true
+perf = true
 
 [website]
 name = "Miri"


### PR DESCRIPTION
@jyn514 keeps telling me to submit this
cc @RalfJung @oli-obk 

The Miri team primarily works on a separate repo, but parts of the interpreter live in rust-lang/rust. So it seems like anyone on the team has reason to do perf ~and crater~ runs, and should be trusted to do so responsibly. Of course, this change only affects me currently.