### PR TITLE
Updates to lang, and establish lang-advisors

### DIFF
--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -9,7 +9,7 @@ members = [
     "jackh726",
     "JakobDegen",
     "RalfJung",
-    "simulacrum",
+    "Mark-Simulacrum",
     "wesleywiser",
 ]
 

--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -26,5 +26,9 @@ orgs = ["rust-lang"]
 name = "Language Advisors team"
 description = "Advising on the development of the Rust language"
 
+[[lists]]
+address = "lang-advisors@rust-lang.org"
+extra-teams = ["lang"]
+
 [[zulip-groups]]
 name = "T-lang-advisors"

--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -18,6 +18,7 @@ members = [
 [permissions]
 perf = true
 crater = true
+bors.rust.try = true
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -1,0 +1,30 @@
+name = "lang-advisors"
+subteam-of = "lang"
+
+[people]
+members = [
+    "alexcrichton",
+    "Amanieu",
+    "cramertj",
+    "jackh726",
+    "JakobDegen",
+    "RalfJung",
+    "simulacrum",
+    "wesleywiser",
+]
+
+# Granting these permissions because an advisor can use these to help when
+# reviewing a proposed change.
+[permissions]
+perf = true
+crater = true
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "Language Advisors team"
+description = "Advising on the development of the Rust language"
+
+[[zulip-groups]]
+name = "T-lang-advisors"

--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -2,6 +2,7 @@ name = "lang-advisors"
 subteam-of = "lang"
 
 [people]
+leads = []
 members = [
     "alexcrichton",
     "Amanieu",

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -47,9 +47,5 @@ address = "lang-team@rust-lang.org"
 [[lists]]
 address = "language-design-team@rust-lang.org"
 
-[[discord-roles]]
-name = "lang-team"
-color = "#2ecc71"
-
 [[zulip-groups]]
 name = "T-lang"

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -3,14 +3,15 @@ name = "lang"
 [people]
 leads = ["nikomatsakis", "joshtriplett"]
 members = [
-    "cramertj",
     "joshtriplett",
     "nikomatsakis",
     "pnkfelix",
     "scottmcm",
+    "tmandry",
 ]
 alumni = [
     "Centril",
+    "cramertj",
     "nrc",
     "withoutboats",
 ]


### PR DESCRIPTION
This adds the lang advisors team as established by
https://github.com/rust-lang/rfcs/pull/3327 . All of the individual
people this commits adds have been approved by the entire lang team, and
all have confirmed that they want to be added. Welcome to @alexcrichton,
@Amanieu, @jackh726, @JakobDegen, @RalfJung, @simulacrum, and
@wesleywiser! Welcome as well to @cramertj who is moving from lang to
lang-advisors, and thank you for all you've done for the lang team!

This also adds Tyler Mandry (@tmandry) to the lang team. Welcome to the
team, Tyler!

We plan to make an Inside Rust blog post soon.
