### PR TITLE
Update parallel-rustc WG's member list

### DIFF
--- a/people/Kobzol.toml
+++ b/people/Kobzol.toml
@@ -1,3 +1,4 @@
 name = 'Jakub Beránek'
 github = 'Kobzol'
 github-id = 4539057
+zulip-id = 266526

--- a/people/SparrowLii.toml
+++ b/people/SparrowLii.toml
@@ -1,0 +1,5 @@
+name = 'Sparrow Li'
+github = 'SparrowLii'
+github-id = 68270294
+email = "liyuan179@huawei.com"
+zulip-id = 353056

--- a/teams/wg-parallel-rustc.toml
+++ b/teams/wg-parallel-rustc.toml
@@ -3,8 +3,21 @@ subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["Mark-Simulacrum", "nikomatsakis"]
-members = ["nikomatsakis", "Mark-Simulacrum", "alexcrichton", "cuviper", "spastorino"]
+leads = ["cjgillot"]
+members = [
+    "cjgillot",
+    "SparrowLii",
+    "nnethercote",
+    "bjorn3",
+    "Kobzol",
+]
+alumni = [
+    "nikomatsakis",
+    "Mark-Simulacrum",
+    "alexcrichton",
+    "cuviper",
+    "spastorino",
+]
 
 [website]
 name = "Parallel rustc working group"


### PR DESCRIPTION
As the parallel-rustc working group is restructured([MCP](https://github.com/rust-lang/compiler-team/issues/567) here), we should update the membership list accordingly.

cc @pnkfelix @cjgillot 

cc @nnethercote @bjorn3 @Kobzol 