### PR TITLE
demote ZMD to alumni contributor

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -31,11 +31,11 @@ members = [
   "varkor",
   "WaffleLapkin",
   "Xanewok",
-  "zackmdavis",
 ]
 alumni = [
     "Centril",
     "LeSeulArtichaut",
+    "zackmdavis",
 ]
 
 [permissions]

--- a/teams/wg-rustfix.toml
+++ b/teams/wg-rustfix.toml
@@ -11,7 +11,6 @@ members = [
     "oli-obk",
     "phansch",
     "pietroalbini",
-    "zackmdavis",
 ]
 
 [website]


### PR DESCRIPTION
Unfortunately, due to competing life demands, I only have [one commit](https://github.com/rust-lang/rust/commit/14eb94fe7a3ca3a92d5d7e42744d105c0fc6d527) in the compiler in the last three years. :cry: :cold_sweat:  According to the text of [RFC 2689](https://github.com/rust-lang/rfcs/blob/master/text/2689-compiler-team-contributors.md), I should have been demoted to alumni status some time ago. I'm assuming this PR is the correct way to do that?