### PR TITLE
Move yaahc to T-libs and T-libs-api alumni, +libs-contributors

### DIFF
--- a/teams/libs-api.toml
+++ b/teams/libs-api.toml
@@ -9,7 +9,6 @@ members = [
     "dtolnay",
     "m-ou-se",
     "joshtriplett",
-    "yaahc",
 ]
 alumni = [
     "KodrAus",
@@ -17,6 +16,7 @@ alumni = [
     "sfackler",
     "withoutboats",
     "SimonSapin",
+    "yaahc",
 ]
 
 [[github]]

--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -15,6 +15,7 @@ members = [
   "thomcc",
   "ChrisDenton",
   "sunfishcode",
+  "yaahc",
 ]
 
 [permissions]

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -6,9 +6,11 @@ members = [
   "Amanieu",
   "m-ou-se",
   "joshtriplett",
-  "yaahc",
   "cuviper",
   "the8472",
+]
+alumni = [
+  "yaahc",
 ]
 
 [[github]]


### PR DESCRIPTION
Last month, @yaahc notified the teams that she is stepping down. She will remain lead of the error handling project group and will continue to participate in reviews for error handling-related work. All of us are grateful for her contributions.

(@rust-lang/libs, @rust-lang/libs-api)