### PR TITLE
Remove bors from bors repo

### DIFF
--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "bors"
 
 description = "Rust implementation of bors used for various Rust components (e.g. the compiler)."
-bots = ["bors", "highfive"]
+bots = ["triagebot"]
 
 [access.teams]
 infra = "write"

--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "bors"
 
 description = "Rust implementation of bors used for various Rust components (e.g. the compiler)."
-bots = ["triagebot"]
+bots = ["rustbot"]
 
 [access.teams]
 infra = "write"


### PR DESCRIPTION
This prevented merging PRs with the GitHub UI; using bors to merge PRs to bors doesn't make sense long-term since it can prevent fixing bors.