### PR TITLE
Add Zulip ids for missing users

### DIFF
--- a/people/KodrAus.toml
+++ b/people/KodrAus.toml
@@ -2,3 +2,4 @@ name = "Ashley Mannix"
 github = "KodrAus"
 github-id = 6721458
 email = "kodraus@hey.com"
+zulip-id = 204346

--- a/people/rylev.toml
+++ b/people/rylev.toml
@@ -3,3 +3,4 @@ github = "rylev"
 github-id = 1327285
 email = "me@ryanlevick.com"
 discord-id = 401012249436749834
+zulip-id = 224872

--- a/people/tarcieri.toml
+++ b/people/tarcieri.toml
@@ -3,3 +3,4 @@ email = "tony@iqlusion.io"
 github = "tarcieri"
 github-id = 797
 irc = "bascule"
+zulip-id = 132721

--- a/people/the8472.toml
+++ b/people/the8472.toml
@@ -2,3 +2,4 @@ name = 'The 8472'
 github = 'the8472'
 github-id = 1065730
 email = 'the8472.rs@infinite-source.de'
+zulip-id = 330154

--- a/people/thomcc.toml
+++ b/people/thomcc.toml
@@ -2,3 +2,4 @@ name = 'Thom Chiovoloni'
 github = 'thomcc'
 github-id = 860665
 email = 'chiovolonit@gmail.com'
+zulip-id = 209168


### PR DESCRIPTION
These are the remaining users who should be reflected in one of the Zulip user groups but are not because we did not have their Zulip user id. 

cc @tarcieri @KodrAus @thomcc @the8472