### PR TITLE
add perf permission for parallel-rustc wg

### DIFF
--- a/teams/wg-parallel-rustc.toml
+++ b/teams/wg-parallel-rustc.toml
@@ -20,6 +20,7 @@ alumni = [
 ]
 
 [permissions]
+bors.rust.try = true
 perf = true
 
 [website]

--- a/teams/wg-parallel-rustc.toml
+++ b/teams/wg-parallel-rustc.toml
@@ -19,6 +19,9 @@ alumni = [
     "spastorino",
 ]
 
+[permissions]
+perf = true
+
 [website]
 name = "Parallel rustc working group"
 description = "Making parallel compilation the default for rustc"


### PR DESCRIPTION
The work of the parallel compiler is very dependent on the perf tool, I hope to obtain the permission to use the tool