### PR TITLE
Manage the cargo repo via teams

### DIFF
--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "cargo"
+description = "The Rust package manager"
+bots = ["bors", "rustbot"]
+
+[access.teams]
+cargo = "write"
+
+[[branch]]
+name = "master"


### PR DESCRIPTION
This should set up the rust-lang/cargo repo to be managed by the team sync. The main motivation here is to demote the Cargo team's access from Maintain to Write to remove the "Merge" button on PRs. I do not think any of us need any of the extra permissions afforded by the Maintain level. IIUC, this configuration should create a branch protection that only allows bors to push to master. 

I also believe this should still allow creating branches. If not, then this might interfere with the release process which creates a tag and branch.
