### PR TITLE
Switch from branches to branch-protections

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -176,11 +176,11 @@ bots = ["bors", "highfive", "rustbot", "rust-timer"]
 compiler = "write"
 mods = "maintain"
 
-# The protected branches (optional)
-[[branch]]
-# The name of the branch (required)
-name = "master"
-# Which CI checks to are required for merging into (optional)
+# The branch protections (optional)
+[[branch-protections]]
+# The pattern matching the branches to be protected (required)
+pattern = "master"
+# Which CI checks to are required for merging (optional)
 ci-checks = ["CI"]
 # Whether new commits after a reviewer's approval of a PR 
 # merging into this branch require another review. 

--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -9,5 +9,5 @@ crate-maintainers = 'maintain'
 [access.individuals]
 alexcrichton = 'write'
 
-[[branch]]
-name = 'master'
+[[branch-protections]]
+pattern = 'master'

--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -9,6 +9,6 @@ infra = "write"
 infra-bors = "write"
 mods = "maintain"
 
-[[branch]]
-name = "main"
+[[branch-protections]]
+pattern = "main"
 ci-checks = ["Test"]

--- a/repos/rust-lang/cc-rs.toml
+++ b/repos/rust-lang/cc-rs.toml
@@ -6,5 +6,5 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[branch]]
-name = 'main'
+[[branch-protections]]
+pattern = 'main'

--- a/repos/rust-lang/flate2-rs.toml
+++ b/repos/rust-lang/flate2-rs.toml
@@ -10,5 +10,5 @@ crate-maintainers = 'maintain'
 alexcrichton = 'maintain'
 brson = 'write'
 
-[[branch]]
-name = 'main'
+[[branch-protections]]
+pattern = 'main'

--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -10,5 +10,5 @@ bots = [
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[branch]]
-name = 'master'
+[[branch-protections]]
+pattern = 'master'

--- a/repos/rust-lang/project-exploit-mitigations.toml
+++ b/repos/rust-lang/project-exploit-mitigations.toml
@@ -8,6 +8,6 @@ core = "admin"
 mods = "maintain"
 project-exploit-mitigations = "maintain"
 
-[[branch]]
-name = "main"
+[[branch-protections]]
+pattern = "main"
 dismiss-stale-review = true

--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -7,5 +7,5 @@ bots = ["bors", "rustbot"]
 wg-rls-2 = "write"
 wg-rls-2-triage = "triage"
 
-[[branch]]
-name = "master"
+[[branch-protections]]
+pattern = "master"

--- a/repos/rust-lang/socket2.toml
+++ b/repos/rust-lang/socket2.toml
@@ -13,8 +13,8 @@ Thomasdezeeuw = 'maintain'
 carllerche = 'maintain'
 Darksonn = 'maintain'
 
-[[branch]]
-name = 'master'
+[[branch-protections]]
+pattern = 'master'
 ci-checks = [
     'Rustfmt',
     'Test (beta)',

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -7,7 +7,7 @@ bots = []
 core = "admin"
 mods = "maintain"
 
-[[branch]]
-name = "master"
+[[branch-protections]]
+pattern = "master"
 ci-checks = ["CI"]
 dismiss-stale-review = true

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -145,7 +145,9 @@ pub struct Repo {
     pub bots: Vec<Bot>,
     pub teams: Vec<RepoTeam>,
     pub members: Vec<RepoMember>,
-    pub branches: Vec<Branch>,
+    pub branch_protections: Vec<BranchProtection>,
+    #[serde(skip_deserializing)]
+    pub branches: Vec<BranchProtection>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -179,7 +181,9 @@ pub enum RepoPermission {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Branch {
+pub struct BranchProtection {
+    pub pattern: String,
+    #[serde(skip_deserializing)]
     pub name: String,
     pub ci_checks: Vec<String>,
     pub dismiss_stale_review: bool,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -648,8 +648,8 @@ pub(crate) struct Repo {
     pub description: String,
     pub bots: Vec<Bot>,
     pub access: RepoAccess,
-    #[serde(rename = "branch", default)]
-    pub branches: Vec<Branch>,
+    #[serde(default)]
+    pub branch_protections: Vec<BranchProtection>,
 }
 
 #[derive(serde_derive::Deserialize, Debug, Clone)]
@@ -680,8 +680,8 @@ pub(crate) enum RepoPermission {
 
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
-pub(crate) struct Branch {
-    pub name: String,
+pub(crate) struct BranchProtection {
+    pub pattern: String,
     #[serde(default)]
     pub ci_checks: Vec<String>,
     #[serde(default)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -36,6 +36,16 @@ impl<'a> Generator<'a> {
     fn generate_repos(&self) -> Result<(), Error> {
         let mut repos: IndexMap<String, Vec<v1::Repo>> = IndexMap::new();
         for r in self.data.repos() {
+            let branch_protections: Vec<_> = r
+                .branch_protections
+                .iter()
+                .map(|b| v1::BranchProtection {
+                    pattern: b.pattern.clone(),
+                    name: b.pattern.clone(),
+                    ci_checks: b.ci_checks.clone(),
+                    dismiss_stale_review: b.dismiss_stale_review,
+                })
+                .collect();
             let repo = v1::Repo {
                 org: r.org.clone(),
                 name: r.name.clone(),
@@ -84,15 +94,8 @@ impl<'a> Generator<'a> {
                         }
                     })
                     .collect(),
-                branches: r
-                    .branches
-                    .iter()
-                    .map(|b| v1::Branch {
-                        name: b.name.clone(),
-                        ci_checks: b.ci_checks.clone(),
-                        dismiss_stale_review: b.dismiss_stale_review,
-                    })
-                    .collect(),
+                branch_protections: branch_protections.clone(),
+                branches: branch_protections,
             };
 
             self.add(&format!("v1/repos/{}.json", r.name), &repo)?;

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -12,8 +12,19 @@
         }
       ],
       "members": [],
+      "branch_protections": [
+        {
+          "pattern": "master",
+          "name": "master",
+          "ci_checks": [
+            "CI"
+          ],
+          "dismiss_stale_review": false
+        }
+      ],
       "branches": [
         {
+          "pattern": "master",
           "name": "master",
           "ci_checks": [
             "CI"

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -10,8 +10,19 @@
     }
   ],
   "members": [],
+  "branch_protections": [
+    {
+      "pattern": "master",
+      "name": "master",
+      "ci_checks": [
+        "CI"
+      ],
+      "dismiss_stale_review": false
+    }
+  ],
   "branches": [
     {
+      "pattern": "master",
       "name": "master",
       "ci_checks": [
         "CI"

--- a/tests/static-api/repos/test-org/some_repo.toml
+++ b/tests/static-api/repos/test-org/some_repo.toml
@@ -6,6 +6,6 @@ bots = []
 [access.teams]
 foo = "admin"
 
-[[branch]]
-name = "master"
+[[branch-protections]]
+pattern = "master"
 ci-checks = ["CI"]


### PR DESCRIPTION
#937 has not landed yet because we need to support branch patterns for branch protections in repo configs (i.e., allow a config to protect many branches with the same protection). 

I added support for this in sync-team in sync-team#36. However, there is now an inconsistency in naming within the team repo. This is because we have logically moved from configuring *protected branches* to configuring *branch protection rules*.

This change to the team repo aligns the team repo with this naming. Repo configs no longer specify "branches" but rather "branch protections". 

Concretely, the following changes have been made:
* The repo configs now use "branch-protections" key instead of "branch"
* The repo configs' branch-protections specify a "pattern" and not a name "name" (since this supports * matching and can match against many different branches)
* The API returns both "branches" and "branch-protections" as well as "name"s and "pattern"s. This allows for a smooth transition, but I think we'll eventually want to remove the old names. I believe "sync-team" is the only user of this API so we can get away with a breaking change. 