### PR TITLE
Add option to lists for including all subteam members

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -87,6 +87,8 @@ access-level = "everyone"
 # It's useful if you want to create the list with a different set of members
 # It's optional, and the default is `true`.
 include-team-members = true
+# Include all members of the team's subteams (optional - default `false`)
+include-subteam-members = false
 # Include the following extra people in the mailing list. Their email address
 # will be fetched from their TOML in people/ (optional).
 extra-people = [

--- a/src/data.rs
+++ b/src/data.rs
@@ -120,6 +120,14 @@ impl Data {
         self.teams.values()
     }
 
+    pub(crate) fn subteams_of<'a>(
+        &'a self,
+        team_name: &'a str,
+    ) -> impl Iterator<Item = &Team> + 'a {
+        self.teams()
+            .filter(move |t| t.subteam_of().map(|t| t == team_name).unwrap_or_default())
+    }
+
     pub(crate) fn person(&self, name: &str) -> Option<&Person> {
         self.people.get(name)
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -124,10 +124,9 @@ impl Data {
         &'a self,
         team_name: &'a str,
     ) -> impl Iterator<Item = &Team> + 'a {
-        self.teams().filter(move |t| {
-            t.top_level_team(self)
-                .map(|t| t == team_name)
-                .unwrap_or_default()
+        self.team(team_name).into_iter().flat_map(move |team| {
+            self.teams()
+                .filter(move |maybe_subteam| team.is_parent_of(self, maybe_subteam))
         })
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -124,8 +124,11 @@ impl Data {
         &'a self,
         team_name: &'a str,
     ) -> impl Iterator<Item = &Team> + 'a {
-        self.teams()
-            .filter(move |t| t.subteam_of().map(|t| t == team_name).unwrap_or_default())
+        self.teams().filter(move |t| {
+            t.top_level_team(self)
+                .map(|t| t == team_name)
+                .unwrap_or_default()
+        })
     }
 
     pub(crate) fn person(&self, name: &str) -> Option<&Person> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -279,6 +279,11 @@ impl Team {
             } else {
                 HashSet::new()
             };
+            if raw_list.include_subteam_members {
+                for subteam in data.subteams_of(&self.name) {
+                    members.extend(subteam.members(data));
+                }
+            }
             for person in &raw_list.extra_people {
                 members.insert(person.as_str());
             }
@@ -563,6 +568,8 @@ pub(crate) struct TeamList {
     pub(crate) address: String,
     #[serde(default = "default_true")]
     pub(crate) include_team_members: bool,
+    #[serde(default)]
+    pub(crate) include_subteam_members: bool,
     #[serde(default)]
     pub(crate) extra_people: Vec<String>,
     #[serde(default)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -189,6 +189,20 @@ impl Team {
         self.subteam_of.as_deref()
     }
 
+    // The team's top-level team.
+    //
+    // Return's `None` if the team is itself a top-level team
+    pub(crate) fn top_level_team<'a>(&'a self, data: &'a Data) -> Option<&str> {
+        let parent = data.team(self.subteam_of()?)?;
+        if parent.subteam_of().is_some() {
+            // If the parent is itself a subteam, recurse
+            parent.top_level_team(data)
+        } else {
+            // Else the parent is the top-level team
+            Some(&parent.name)
+        }
+    }
+
     pub(crate) fn leads(&self) -> HashSet<&str> {
         self.people.leads.iter().map(|s| s.as_str()).collect()
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -189,18 +189,24 @@ impl Team {
         self.subteam_of.as_deref()
     }
 
-    // The team's top-level team.
-    //
-    // Return's `None` if the team is itself a top-level team
-    pub(crate) fn top_level_team<'a>(&'a self, data: &'a Data) -> Option<&str> {
-        let parent = data.team(self.subteam_of()?)?;
-        if parent.subteam_of().is_some() {
-            // If the parent is itself a subteam, recurse
-            parent.top_level_team(data)
-        } else {
-            // Else the parent is the top-level team
-            Some(&parent.name)
+    // Return's whether the provided team is a subteam of this team
+    pub(crate) fn is_parent_of<'a>(&'a self, data: &'a Data, subteam: &Team) -> bool {
+        let mut subteam = Some(subteam);
+        while let Some(s) = subteam {
+            // Get subteam's parent
+            let Some(parent) = s.subteam_of() else {
+                // The current subteam is a top level team.
+                // Therefore this team cannot be its parent.
+                return false;
+            };
+            // If the parent is this team, return true
+            if parent == self.name {
+                return true;
+            }
+            // Otherwise try the test again with the parent
+            subteam = data.team(parent);
         }
+        false
     }
 
     pub(crate) fn leads(&self) -> HashSet<&str> {

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -67,6 +67,10 @@ extra-people = [
     "jseyfried",
 ]
 
+[[lists]]
+address = "all-compiler-teams@rust-lang.org"
+include-subteam-members = true
+
 [[zulip-groups]]
 name = "T-compiler"
 

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -68,7 +68,7 @@ extra-people = [
 ]
 
 [[lists]]
-address = "all-compiler-teams@rust-lang.org"
+address = "compiler-and-subteams@rust-lang.org"
 include-subteam-members = true
 
 [[zulip-groups]]


### PR DESCRIPTION
This provides a way to get in touch with a team's members *and* the members of that team's subteams.