### PR TITLE
Remove the branches field from repos API

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -146,8 +146,6 @@ pub struct Repo {
     pub teams: Vec<RepoTeam>,
     pub members: Vec<RepoMember>,
     pub branch_protections: Vec<BranchProtection>,
-    #[serde(skip_deserializing)]
-    pub branches: Vec<BranchProtection>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -183,8 +181,6 @@ pub enum RepoPermission {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BranchProtection {
     pub pattern: String,
-    #[serde(skip_deserializing)]
-    pub name: String,
     pub ci_checks: Vec<String>,
     pub dismiss_stale_review: bool,
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -41,7 +41,6 @@ impl<'a> Generator<'a> {
                 .iter()
                 .map(|b| v1::BranchProtection {
                     pattern: b.pattern.clone(),
-                    name: b.pattern.clone(),
                     ci_checks: b.ci_checks.clone(),
                     dismiss_stale_review: b.dismiss_stale_review,
                 })
@@ -94,8 +93,7 @@ impl<'a> Generator<'a> {
                         }
                     })
                     .collect(),
-                branch_protections: branch_protections.clone(),
-                branches: branch_protections,
+                branch_protections: branch_protections,
             };
 
             self.add(&format!("v1/repos/{}.json", r.name), &repo)?;

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -15,17 +15,6 @@
       "branch_protections": [
         {
           "pattern": "master",
-          "name": "master",
-          "ci_checks": [
-            "CI"
-          ],
-          "dismiss_stale_review": false
-        }
-      ],
-      "branches": [
-        {
-          "pattern": "master",
-          "name": "master",
           "ci_checks": [
             "CI"
           ],

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -13,17 +13,6 @@
   "branch_protections": [
     {
       "pattern": "master",
-      "name": "master",
-      "ci_checks": [
-        "CI"
-      ],
-      "dismiss_stale_review": false
-    }
-  ],
-  "branches": [
-    {
-      "pattern": "master",
-      "name": "master",
       "ci_checks": [
         "CI"
       ],


### PR DESCRIPTION
**BREAKING CHANGE**

With https://github.com/rust-lang/sync-team/pull/38 merged no one is using these fields any more. Since these are duplicates of other fields, it would be much cleaner to remove these before some other user starts to depend on them. 