### PR TITLE
Add wesleywiser to interim-leadership-chat (missing in original commit)

### DIFF
--- a/teams/interim-leadership-chat.toml
+++ b/teams/interim-leadership-chat.toml
@@ -21,6 +21,7 @@ members = [
     "technetos",
     "tmandry",
     "Turbo87",
+    "wesleywiser",
     "yaahc",
 ]
 


### PR DESCRIPTION
Wesley Wiser is a member of leadership chat, but the original commit
missed them.
