### PR TITLE
Remove kw-fn

### DIFF
--- a/people/kw-fn.toml
+++ b/people/kw-fn.toml
@@ -1,5 +1,0 @@
-name = 'oliver'
-github = 'kw-fn'
-github-id = 16816606
-zulip-id = 281739
-email = "oliver@ftml.net"

--- a/teams/project-error-handling.toml
+++ b/teams/project-error-handling.toml
@@ -8,7 +8,6 @@ members = [
     "yaahc",
     "BurntSushi",
     "seanchen1991",
-    "kw-fn",
     "nagashi",
     "JDuchniewicz",
     "mystor",


### PR DESCRIPTION
The GitHub user `kw-fn` has deleted their account.  This should get CI working again.

cc @yaahc 