### PR TITLE
Add rfcbot as a bot.

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -155,6 +155,7 @@ pub enum Bot {
     Highfive,
     Rustbot,
     RustTimer,
+    Rfcbot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn run() -> Result<(), Error> {
             let mut teams = HashMap::new();
             let mut bots = Vec::new();
 
-            const BOTS: &[&str] = &["bors", "rust-highfive", "rust-timer", "rustbot"];
+            const BOTS: &[&str] = &["bors", "rust-highfive", "rust-timer", "rustbot", "rfcbot"];
             let switch = |bot| {
                 if bot == "rust-highfive" {
                     "highfive".to_owned()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -686,6 +686,7 @@ pub(crate) enum Bot {
     Highfive,
     Rustbot,
     RustTimer,
+    Rfcbot,
 }
 
 #[derive(serde_derive::Deserialize, Debug)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -57,6 +57,7 @@ impl<'a> Generator<'a> {
                         Bot::Highfive => v1::Bot::Highfive,
                         Bot::RustTimer => v1::Bot::RustTimer,
                         Bot::Rustbot => v1::Bot::Rustbot,
+                        Bot::Rfcbot => v1::Bot::Rfcbot,
                     })
                     .collect(),
                 teams: r


### PR DESCRIPTION
This adds rfcbot as a bot so that it can receive the correct permissions to be able to add labels to a repo.