### PR TITLE
Add a new `sync-team-confirmation` permission

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -44,6 +44,7 @@ permissions-bools = [
     "perf",
     "crater",
     "dev-desktop",
+    "sync-team-confirmation",
 ]
 
 permissions-crates-io-ops-bot-apps = [

--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -8,6 +8,9 @@ members = [
     "jdno",
 ]
 
+[permissions]
+sync-team-confirmation = true
+
 [[lists]]
 address = "admin@rust-lang.org"
 


### PR DESCRIPTION
This PR adds the `sync-team-confirmation` permission, which will allow `infra-admins` to confirm team repo changes before applying them [(context)](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/sync-team/near/341084416).