### PR TITLE
Add mailing list for release + subteams

### DIFF
--- a/teams/release.toml
+++ b/teams/release.toml
@@ -39,5 +39,9 @@ zulip-stream = "t-release"
 [[lists]]
 address = "release@rust-lang.org"
 
+[[lists]]
+address = "release-and-subteams@rust-lang.org"
+include-subteam-members = true
+
 [[zulip-groups]]
 name = "T-release"


### PR DESCRIPTION
This will be used for the governance RFC approval and representative selection.