### PR TITLE
Give types team members access to perf, crater and dev-desktops.

### DIFF
--- a/people/aliemjay.toml
+++ b/people/aliemjay.toml
@@ -2,3 +2,4 @@ name = "Ali MJ Al-Nasrawy"
 github = "aliemjay"
 github-id = 28497461
 email = "alimjalnasrawy@gmail.com"
+zulip-id = 430838

--- a/teams/types.toml
+++ b/teams/types.toml
@@ -40,7 +40,6 @@ extra-people = ["eholk"]
 [permissions]
 bors.chalk.review = true
 bors.rust.review = true
-bors.rust.try = true
 perf = true
 crater = true
 dev-desktop = true

--- a/teams/types.toml
+++ b/teams/types.toml
@@ -39,3 +39,7 @@ extra-people = ["eholk"]
 
 [permissions]
 bors.chalk.review = true
+bors.rust.try = true
+perf = true
+crater = true
+dev-desktop = true

--- a/teams/types.toml
+++ b/teams/types.toml
@@ -39,6 +39,7 @@ extra-people = ["eholk"]
 
 [permissions]
 bors.chalk.review = true
+bors.rust.review = true
 bors.rust.try = true
 perf = true
 crater = true


### PR DESCRIPTION
Not all our members are compiler-contributors, compiler or other similar team members.

In https://github.com/rust-lang/rust/pull/109388#issuecomment-1476049002 @aliemjay was unable to run perf.