### PR TITLE
add repo for the trait system refactor initiative

### DIFF
--- a/repos/rust-lang/trait-solver-refactor-initiaitive.toml
+++ b/repos/rust-lang/trait-solver-refactor-initiaitive.toml
@@ -1,8 +1,0 @@
-org = "rust-lang"
-name = "trait-solver-refactor-initiative"
-description = "The Rustc Trait Solver Refactor Initiative"
-bots = []
-
-[access.teams]
-project-trait-system-refactor = "maintain"
-

--- a/repos/rust-lang/trait-solver-refactor-initiaitive.toml
+++ b/repos/rust-lang/trait-solver-refactor-initiaitive.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "trait-solver-refactor-initiative"
+description = "The Rustc Trait Solver Refactor Initiative"
+bots = []
+
+[access.teams]
+project-trait-system-refactor = "maintain"
+

--- a/repos/rust-lang/trait-system-refactor-initiaitive.toml
+++ b/repos/rust-lang/trait-system-refactor-initiaitive.toml
@@ -4,4 +4,4 @@ description = "The Rustc Trait System Refactor Initiative"
 bots = []
 
 [access.teams]
-project-trait-system-refactor = "maintain"
+initiative-trait-system-refactor = "maintain"

--- a/repos/rust-lang/trait-system-refactor-initiaitive.toml
+++ b/repos/rust-lang/trait-system-refactor-initiaitive.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "trait-system-refactor-initiative"
+description = "The Rustc Trait System Refactor Initiative"
+bots = []
+
+[access.teams]
+project-trait-system-refactor = "maintain"


### PR DESCRIPTION
cc @rust-lang/initiative-trait-system-refactor

this should supersede both https://github.com/lcnr/solver-woes/issues and https://github.com/compiler-errors/next-solver-hir-issues/issues and I also want a place to store all the design decisions made before stabilization.