### PR TITLE
Create alias for Google Workspace admin

### DIFF
--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -37,3 +37,6 @@ address = "dmarc-rua@rust-lang.org"
 
 [[lists]]
 address = "docker-hub-rustci@rust-lang.org"
+
+[[lists]]
+address = "google-admin@rust-lang.org"


### PR DESCRIPTION
The infra-team is working on SSO for infrastructure services, which will be implemented using a Google Workspace. Setting this up requires a new alias.

cc @pietroalbini 