### PR TITLE
Add LoongArch group

### DIFF
--- a/people/heiher.toml
+++ b/people/heiher.toml
@@ -1,0 +1,5 @@
+name = 'WANG Rui'
+github = 'heiher'
+github-id = 1407733
+email = 'wangrui@loongson.cn'
+zulip-id = 612250

--- a/people/xen0n.toml
+++ b/people/xen0n.toml
@@ -1,0 +1,5 @@
+name = 'WANG Xuerui'
+github = 'xen0n'
+github-id = 1175567
+email = 'git@xen0n.name'
+zulip-id = 507183

--- a/people/xiangzhai.toml
+++ b/people/xiangzhai.toml
@@ -1,0 +1,4 @@
+name = 'ZHAI Xiang'
+github = 'xiangzhai'
+github-id = 851100
+email = 'zhaixiang@loongson.cn'

--- a/people/xry111.toml
+++ b/people/xry111.toml
@@ -1,0 +1,4 @@
+name = 'Xi Ruoyao'
+github = 'xry111'
+github-id = 8733039
+email = 'xry111@xry111.site'

--- a/teams/loongarch.toml
+++ b/teams/loongarch.toml
@@ -1,0 +1,11 @@
+name = "loongarch"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "heiher",
+    "xiangzhai",
+    "xen0n",
+    "xry111",
+]


### PR DESCRIPTION
I would like to request the creation of a LoongArch group after the [initial support for LoongArch](https://github.com/rust-lang/rust/pull/96971) is merged. We are currently preparing to promote the loongarch64-unknown-linux-gnu target to tier 2, and I believe that creating a group at this time would be helpful to the community.

r? @pietroalbini @rylev 