### PR TITLE
Update Embedded WG memberships

### DIFF
--- a/people/Dirbaio.toml
+++ b/people/Dirbaio.toml
@@ -1,0 +1,4 @@
+name = 'Dario Nieuwenhuis'
+github = 'Dirbaio'
+github-id = 1247578
+email = "dirbaio@dirbaio.net"

--- a/people/eldruin.toml
+++ b/people/eldruin.toml
@@ -1,4 +1,4 @@
 name = 'Diego Barrios Romero'
 github = 'eldruin'
 github-id = 43125
-email = false
+email = "eldruin@gmail.com"

--- a/people/romancardenas.toml
+++ b/people/romancardenas.toml
@@ -1,0 +1,4 @@
+name = 'Román Cárdenas'
+github = 'romancardenas'
+github-id = 12596603
+email = false

--- a/teams/wg-embedded-hal.toml
+++ b/teams/wg-embedded-hal.toml
@@ -5,6 +5,7 @@ kind = "working-group"
 [people]
 leads = []
 members = [
+    "Dirbaio",
     "eldruin",
     "ryankurte",
     "therealprof",

--- a/teams/wg-embedded-riscv.toml
+++ b/teams/wg-embedded-riscv.toml
@@ -5,9 +5,10 @@ kind = "working-group"
 [people]
 leads = []
 members = [
-    "almindor",
     "Disasm",
+    "almindor",
     "dkhayes117",
+    "romancardenas",
 ]
 
 [website]

--- a/teams/wg-embedded.toml
+++ b/teams/wg-embedded.toml
@@ -4,6 +4,7 @@ kind = "working-group"
 [people]
 leads = ["adamgreig", "japaric", "therealprof"]
 members = [
+    "Dirbaio",
     "Disasm",
     "Emilgardis",
     "adamgreig",
@@ -21,6 +22,7 @@ members = [
     "posborne",
     "raw-bin",
     "reitermarkus",
+    "romancardenas",
     "ryankurte",
     "thalesfragoso",
     "thejpster",


### PR DESCRIPTION
As has just been noted our embedded team representation wasn't up-to-date regarding the actual status. Also a few members didn't have their emails recorded so the Leadership council mail didn't get through.