### PR TITLE
Add est31 to compiler-contributors

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -13,6 +13,7 @@ members = [
   "durin42",
   "ecstatic-morse",
   "eholk",
+  "est31",
   "fee1-dead",
   "flodiebold",
   "jackh726",


### PR DESCRIPTION
As per the T-compiler vote, I'm adding @est31 to the compiler-contributors team in recognition of their amazing work over the last 8!! years.