### PR TITLE
Move compiler-errors from compiler contributors to the compiler team

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -8,7 +8,6 @@ members = [
   "bjorn3",
   "BoxyUwU",
   "chenyukang",
-  "compiler-errors",
   "cuviper",
   "durin42",
   "ecstatic-morse",

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -5,6 +5,7 @@ leads = ["wesleywiser", "pnkfelix"]
 members = [
     "Aaron1011",
     "cjgillot",
+    "compiler-errors",
     "davidtwco",
     "eddyb",
     "estebank",


### PR DESCRIPTION
that's a lot of compilers 😆 

As per the T-compiler vote: 

Welcome to the compiler team @compiler-errors 