### PR TITLE
move myself from compiler to compiler contributors

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -22,6 +22,7 @@ members = [
   "Nadrieril",
   "Nilstrieb",
   "nikic",
+  "nikomatsakis",
   "nnethercote",
   "RalfJung",
   "scalexm",

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -15,13 +15,13 @@ members = [
     "oli-obk",
     "petrochenkov",
     "pnkfelix",
-    "nikomatsakis",
     "matthewjasper",
     "wesleywiser",
 ]
 alumni = [
     "cramertj",
     "dotdash",
+    "nikomatsakis",
     "nrc",
     "varkor",
     "Zoxc",


### PR DESCRIPTION
I won't lie, it makes me a bit sad to step back from @rust-lang/compiler, but the reality is that I haven't been actively involved in compiler development for some time, so I think contributors is a better fit. It's so exciting to see how vibrant and active the team has become! 💜 you all.



r? @pnkfelix @wesleywiser 