### PR TITLE
remove jntrnr from interim-leadership-chat.toml

### DIFF
--- a/teams/interim-leadership-chat.toml
+++ b/teams/interim-leadership-chat.toml
@@ -7,7 +7,6 @@ leads = []
 members = [
     "badboy",
     "cuviper",
-    "jntrnr",
     "joshtriplett",
     "jtgeibel",
     "khionu",


### PR DESCRIPTION
Per https://github.com/rust-lang/team/pull/1001, jntrnr has stepped back from leadership roles. :(