### PR TITLE
Add rustbot and rfcbot to the unsafe-code-guidelines repo

### DIFF
--- a/repos/rust-lang/unsafe-code-guidelines.toml
+++ b/repos/rust-lang/unsafe-code-guidelines.toml
@@ -1,7 +1,7 @@
 org = 'rust-lang'
 name = 'unsafe-code-guidelines'
 description = "Forum for discussion about what unsafe code can and can't do"
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 opsem = 'maintain'

--- a/repos/rust-lang/unsafe-code-guidelines.toml
+++ b/repos/rust-lang/unsafe-code-guidelines.toml
@@ -1,7 +1,7 @@
 org = 'rust-lang'
 name = 'unsafe-code-guidelines'
 description = "Forum for discussion about what unsafe code can and can't do"
-bots = ["rustbot"]
+bots = ["rustbot","rfcbot"]
 
 [access.teams]
 opsem = 'maintain'


### PR DESCRIPTION
Based on the discussion on zulip in:  <https://rust-lang.zulipchat.com/#narrow/stream/136281-t-opsem/topic/Meeting.202023-05-23>.