### PR TITLE
Give dev-desktop perms to clippy

### DIFF
--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -28,6 +28,7 @@ alumni = [
 perf = true
 bors.clippy.review = true
 bors.rust.review = true
+dev-desktop = true
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
Clippy needs to work upstream with rustc for syncs, and in general is still a heavy compile phase. This would be useful for the clippy team.