### PR TITLE
Add triagebot team with access to triagebot repo

### DIFF
--- a/repos/rust-lang/triagebot.toml
+++ b/repos/rust-lang/triagebot.toml
@@ -1,0 +1,11 @@
+org = 'rust-lang'
+name = 'triagebot'
+description = 'Automation/tooling for Rust spaces'
+bots = ["rustbot"]
+
+[access.teams]
+infra = "write"
+triagebot = "write"
+
+[[branch-protections]]
+pattern = "master"

--- a/teams/triagebot.toml
+++ b/teams/triagebot.toml
@@ -1,0 +1,25 @@
+name = "triagebot"
+subteam-of = "infra"
+
+[people]
+leads = ["Mark-Simulacrum"]
+members = [
+    "Mark-Simulacrum",
+    "ehuss",
+    "spastorino",
+]
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "Triagebot team"
+description = "Maintaining and improving the rust-lang/triagebot tooling"
+email = "triagebot@rust-lang.org"
+zulip-stream = "triagebot"
+
+[[lists]]
+address = "triagebot@rust-lang.org"
+
+[[zulip-groups]]
+name = "T-triagebot"


### PR DESCRIPTION
cc @ehuss @spastorino -- you've both done a bunch of work here, we'll need to discuss with infra making the subteam but I think regardless we'll grant access (just perhaps with a marker team). I don't expect the team to do much in the way of coordination (meetings etc).