### PR TITLE
Add the leadership-council repo.

### DIFF
--- a/repos/rust-lang/leadership-council.toml
+++ b/repos/rust-lang/leadership-council.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "leadership-council"
+description = "Home of the Rust Leadership Council"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+leadership-council = "maintain"


### PR DESCRIPTION
This adds a repository for the Leadership Council. The immediate use for this will be for storing public documents related to the council itself. 