### PR TITLE
Protect main branch of leadership Council repo

### DIFF
--- a/repos/rust-lang/leadership-council.toml
+++ b/repos/rust-lang/leadership-council.toml
@@ -5,3 +5,6 @@ bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 leadership-council = "maintain"
+
+[[branch-protections]]
+pattern = "main"


### PR DESCRIPTION
This should prevent things like accidentally pushing directly to main.

r? @ehuss 