### PR TITLE
Update the branch name on libc repo

### DIFF
--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -11,4 +11,4 @@ bots = [
 crate-maintainers = 'maintain'
 
 [[branch-protections]]
-pattern = 'master'
+pattern = 'main'


### PR DESCRIPTION
The default branch is now `main`: https://github.com/rust-lang/libc
