### PR TITLE
config file for rustc-apfloat crate

### DIFF
--- a/repos/rust-lang/rustc-apfloat.toml
+++ b/repos/rust-lang/rustc-apfloat.toml
@@ -15,5 +15,12 @@ eddyb = 'maintain'
 pnkfelix = 'maintain'
 wesleywiser = 'maintain'
 
+# ... however, the CI for the teams repo will not accept this config without
+# *some* access.teams section. So we'll give compiler/compiler-contributors
+# the least-privileged access for the short term, solely to placate the CI.
+[access.teams]
+compiler = 'read'
+compiler-contributors = 'read'
+
 # Likewise, eventually we may want a branch protections section, but we will
 # tackle that later.

--- a/repos/rust-lang/rustc-apfloat.toml
+++ b/repos/rust-lang/rustc-apfloat.toml
@@ -1,0 +1,19 @@
+org = 'rust-lang'
+name = 'rustc-apfloat'
+description = 'Rust port of C++ llvm::APFloat library'
+
+# For the initial setup, we are not including bors in our list of bots, because
+# we do not have any Continuous Integration setup yet for the rustc-apfloat
+# crate. We will tackle that later.
+bots = ["rustbot", "rfcbot"]
+
+# For the initial setup, we are just giving {eddyb, wesleywiser, pnkfelix}
+# maintainer permissions. Later we will figure out what permissions to give to
+# the rest of T-compiler, compiler-contributors, et cetera.
+[access.individuals]
+eddyb = 'maintain'
+pnkfelix = 'maintain'
+wesleywiser = 'maintain'
+
+# Likewise, eventually we may want a branch protections section, but we will
+# tackle that later.

--- a/repos/rust-lang/rustc-apfloat.toml
+++ b/repos/rust-lang/rustc-apfloat.toml
@@ -7,20 +7,9 @@ description = 'Rust port of C++ llvm::APFloat library'
 # crate. We will tackle that later.
 bots = ["rustbot", "rfcbot"]
 
-# For the initial setup, we are just giving {eddyb, wesleywiser, pnkfelix}
-# maintainer permissions. Later we will figure out what permissions to give to
-# the rest of T-compiler, compiler-contributors, et cetera.
-[access.individuals]
-eddyb = 'maintain'
-pnkfelix = 'maintain'
-wesleywiser = 'maintain'
-
-# ... however, the CI for the teams repo will not accept this config without
-# *some* access.teams section. So we'll give compiler/compiler-contributors
-# the least-privileged access for the short term, solely to placate the CI.
 [access.teams]
-compiler = 'read'
-compiler-contributors = 'read'
+compiler = 'maintain'
+compiler-contributors = 'maintain'
 
 # Likewise, eventually we may want a branch protections section, but we will
 # tackle that later.


### PR DESCRIPTION
eddyb will be transferring their factored out rustc-apfloat crate, https://github.com/LykenSol/rustc_apfloat, into the rust-lang/ organization (see https://github.com/rust-lang/rust/issues/55993 for background).

This is an initial team configuration for us to get the crate up and running under rust-lang/ organization.

However, eddyb has expressed an explicit wish for the source code to be transferred (i.e. *moved*, not *copied*, ha ha), in order to ensure that e.g. stray links to the old repository are handled properly within github.

So, the process I'm planning here is:
 * [ ] get necessary parties to sign off on this config file
 * [x]  poke @Mark-Simulacrum or @pietroalbini so that they can transfer https://github.com/LykenSol/rustc_apfloat into the rust-lang organization
 * [ ] then we'll merge this PR and that should update the permissions accordingly.