### PR TITLE
Fix naming of rustc_apfloat repo

### DIFF
--- a/repos/rust-lang/rustc_apfloat.toml
+++ b/repos/rust-lang/rustc_apfloat.toml
@@ -1,9 +1,9 @@
 org = 'rust-lang'
-name = 'rustc-apfloat'
+name = 'rustc_apfloat'
 description = 'Rust port of C++ llvm::APFloat library'
 
 # For the initial setup, we are not including bors in our list of bots, because
-# we do not have any Continuous Integration setup yet for the rustc-apfloat
+# we do not have any Continuous Integration setup yet for the rustc_apfloat
 # crate. We will tackle that later.
 bots = ["rustbot", "rfcbot"]
 


### PR DESCRIPTION
I'm not sure if it will cause any problems to do this renaming but currently both repos exist

<img width="682" alt="image" src="https://github.com/rust-lang/team/assets/831192/fa77a1c8-d987-4346-ab09-34fee46c2e02">
