### PR TITLE
Allow extending teams from other teams

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -55,6 +55,9 @@ members = [
 alumni = [
     "buildbot",
 ]
+# Optional, name of other teams whose members will be included as members of this team.
+# Defaults to empty.
+included-teams = []
 # Optional, include all members of all other teams.
 # Defaults to false.
 include-all-team-members = false

--- a/src/data.rs
+++ b/src/data.rs
@@ -138,12 +138,12 @@ impl Data {
         self.people.values()
     }
 
-    pub(crate) fn active_members(&self) -> HashSet<&str> {
-        self.teams
-            .values()
-            .filter(|team| !team.is_alumni_team())
-            .flat_map(|team| team.members(self))
-            .collect()
+    pub(crate) fn active_members(&self) -> Result<HashSet<&str>, Error> {
+        let mut active = HashSet::new();
+        for team in self.teams.values().filter(|team| !team.is_alumni_team()) {
+            active.extend(team.members(self)?)
+        }
+        Ok(active)
     }
 
     pub(crate) fn repos(&self) -> impl Iterator<Item = &Repo> {

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -119,17 +119,21 @@ impl Permissions {
     }
 }
 
-pub(crate) fn allowed_people<'a>(data: &'a Data, permission: &str) -> Vec<&'a Person> {
+pub(crate) fn allowed_people<'a>(
+    data: &'a Data,
+    permission: &str,
+) -> Result<Vec<&'a Person>, Error> {
     let mut members_with_perms = HashSet::new();
     for team in data.teams() {
         if team.permissions().has(permission) {
-            members_with_perms.extend(team.members(data));
+            members_with_perms.extend(team.members(data)?);
         }
         if team.leads_permissions().has(permission) {
             members_with_perms.extend(team.leads());
         }
     }
-    data.people()
+    Ok(data
+        .people()
         .filter(|p| members_with_perms.contains(p.github()) || p.permissions().has(permission))
-        .collect()
+        .collect())
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -114,7 +114,7 @@ impl<'a> Generator<'a> {
         for team in self.data.teams() {
             let leads = team.leads();
             let mut members = Vec::new();
-            for github_name in &team.members(self.data) {
+            for github_name in &team.members(self.data)? {
                 if let Some(person) = self.data.person(github_name) {
                     members.push(v1::TeamMember {
                         name: person.name().into(),
@@ -257,7 +257,7 @@ impl<'a> Generator<'a> {
 
     fn generate_permissions(&self) -> Result<(), Error> {
         for perm in &Permissions::available(self.data.config()) {
-            let allowed = crate::permissions::allowed_people(self.data, perm);
+            let allowed = crate::permissions::allowed_people(self.data, perm)?;
             let mut github_users = allowed
                 .iter()
                 .map(|p| p.github().to_string())
@@ -290,7 +290,7 @@ impl<'a> Generator<'a> {
         for team in self.data.teams() {
             if let Some(rfcbot) = team.rfcbot_data() {
                 let mut members = team
-                    .members(self.data)
+                    .members(self.data)?
                     .into_iter()
                     .map(|s| s.to_string())
                     .filter(|member| !rfcbot.exclude_members.contains(member))

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -120,7 +120,15 @@ pub(crate) fn validate(data: &Data, strict: bool, skip: &[&str]) -> Result<(), E
 
 /// Ensure working group names start with `wg-`
 fn validate_name_prefixes(data: &Data, errors: &mut Vec<String>) {
-    fn ensure_prefix(team: &Team, kind: TeamKind, prefix: &str) -> Result<(), Error> {
+    fn ensure_prefix(
+        team: &Team,
+        kind: TeamKind,
+        prefix: &str,
+        exceptions: &[&str],
+    ) -> Result<(), Error> {
+        if exceptions.contains(&team.name()) {
+            return Ok(());
+        }
         if team.kind() == kind && !team.name().starts_with(prefix) {
             bail!(
                 "{} `{}`'s name doesn't start with `{}`",
@@ -140,8 +148,13 @@ fn validate_name_prefixes(data: &Data, errors: &mut Vec<String>) {
         Ok(())
     }
     wrapper(data.teams(), errors, |team, _| {
-        ensure_prefix(team, TeamKind::WorkingGroup, "wg-")?;
-        ensure_prefix(team, TeamKind::ProjectGroup, "project-")?;
+        ensure_prefix(team, TeamKind::WorkingGroup, "wg-", &["wg-leads"])?;
+        ensure_prefix(
+            team,
+            TeamKind::ProjectGroup,
+            "project-",
+            &["project-group-leads"],
+        )?;
         Ok(())
     });
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -175,7 +175,7 @@ fn validate_subteam_of(data: &Data, errors: &mut Vec<String>) {
 /// Ensure team leaders are part of the teams they lead
 fn validate_team_leads(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, |team, errors| {
-        let members = team.members(data);
+        let members = team.members(data)?;
         wrapper(team.leads().iter(), errors, |lead, _| {
             if !members.contains(lead) {
                 bail!(
@@ -193,7 +193,7 @@ fn validate_team_leads(data: &Data, errors: &mut Vec<String>) {
 /// Ensure team members are people
 fn validate_team_members(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, |team, errors| {
-        wrapper(team.members(data).iter(), errors, |member, _| {
+        wrapper(team.members(data)?.iter(), errors, |member, _| {
             if data.person(member).is_none() {
                 bail!(
                     "person `{}` is member of team `{}` but doesn't exist",
@@ -209,11 +209,17 @@ fn validate_team_members(data: &Data, errors: &mut Vec<String>) {
 
 /// Ensure alumni are not active
 fn validate_alumni(data: &Data, errors: &mut Vec<String>) {
-    let active_members = data.active_members();
+    let active_members = match data.active_members() {
+        Ok(ms) => ms,
+        Err(e) => {
+            errors.push(e.to_string());
+            return;
+        }
+    };
     wrapper(data.team("alumni").iter(), errors, |alumni_team, errors| {
         let mut explicit_members: HashSet<_> = alumni_team.explicit_members().iter().collect();
         // Ensure alumni team members are not active
-        wrapper(alumni_team.members(data).iter(), errors, |member, _| {
+        wrapper(alumni_team.members(data)?.iter(), errors, |member, _| {
             if active_members.contains(member) {
                 bail!("alumni team includes active member '{}'", member)
             }
@@ -243,7 +249,7 @@ fn validate_inactive_members(data: &Data, errors: &mut Vec<String>) {
         data.teams().chain(data.archived_teams()),
         errors,
         |team, _| {
-            let members = team.members(data);
+            let members = team.members(data)?;
             for member in members {
                 referenced_members.insert(member);
             }
@@ -287,7 +293,7 @@ fn validate_list_email_addresses(data: &Data, errors: &mut Vec<String>) {
         if team.lists(data)?.is_empty() {
             return Ok(());
         }
-        wrapper(team.members(data).iter(), errors, |member, _| {
+        wrapper(team.members(data)?.iter(), errors, |member, _| {
             if let Some(member) = data.person(member) {
                 if let Email::Missing = member.email() {
                     bail!(
@@ -374,7 +380,7 @@ fn validate_people_addresses(data: &Data, errors: &mut Vec<String>) {
 /// Ensure members of teams with permissions don't explicitly have those permissions
 fn validate_duplicate_permissions(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, |team, errors| {
-        wrapper(team.members(data).iter(), errors, |member, _| {
+        wrapper(team.members(data)?.iter(), errors, |member, _| {
             if let Some(person) = data.person(member) {
                 for permission in &Permissions::available(data.config()) {
                     if team.permissions().has(permission)
@@ -431,7 +437,7 @@ fn validate_rfcbot_exclude_members(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, move |team, errors| {
         if let Some(rfcbot) = team.rfcbot_data() {
             let mut exclude = HashSet::new();
-            let members = team.members(data);
+            let members = team.members(data)?;
             wrapper(rfcbot.exclude_members.iter(), errors, move |member, _| {
                 if !exclude.insert(member) {
                     bail!(
@@ -548,7 +554,7 @@ fn validate_project_groups_have_parent_teams(data: &Data, errors: &mut Vec<Strin
 fn validate_discord_team_members_have_discord_ids(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, |team, _| {
         if team.discord_roles().is_some() && team.name() != "all" {
-            let team_members = team.members(data);
+            let team_members = team.members(data)?;
             if team_members.len() != team.discord_ids(data)?.len() {
                 let members: String = team_members
                     .into_iter()
@@ -620,7 +626,7 @@ fn validate_zulip_group_ids(data: &Data, errors: &mut Vec<String>) {
         if groups.is_empty() || groups.iter().all(|g| !g.includes_team_members()) {
             return Ok(());
         }
-        wrapper(team.members(data).iter(), errors, |member, _| {
+        wrapper(team.members(data)?.iter(), errors, |member, _| {
             if let Some(member) = data.person(member) {
                 if member.zulip_id().is_none() {
                     bail!(

--- a/teams/inside-rust-reviewers.toml
+++ b/teams/inside-rust-reviewers.toml
@@ -4,8 +4,7 @@ kind = "marker-team"
 [people]
 leads = []
 members = []
-include-team-leads = true
-include-project-group-leads = true
+included-teams = ["leadership-council", "leads", "project-group-leads"]
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/project-group-leads.toml
+++ b/teams/project-group-leads.toml
@@ -1,0 +1,10 @@
+name = "project-group-leads"
+kind = "marker-team"
+
+[people]
+leads = []
+members = []
+include-project-group-leads = true
+
+[[github]]
+orgs = ["rust-lang"]

--- a/teams/wg-leads.toml
+++ b/teams/wg-leads.toml
@@ -1,11 +1,11 @@
 name = "wg-leads"
-kind = "working-group"
+kind = "marker-team"
 
 [people]
 leads = []
 members = []
+included-teams = ["project-group-leads"]
 include-wg-leads = true
-include-project-group-leads = true
 
 [[lists]]
 address = "wg-leads@rust-lang.org"


### PR DESCRIPTION
This PR allows extending team membership by the membership of another team. Concretely this PR changes the following:

* `Team::members`, `Data::active_members`, and `Permissions::allowed_people` now all return a `Result` since getting all members can fail if an included team does not exist.
* Added `Team::contains_person` to test whether a team contains a person as a member
* Made `wg-leads` a marker team instead of a working group
* Created a `project-group-leads` marker team
* Removed the use of the various special "include-*" options from all teams except for the special marker teams that those options exist for. All other teams that also want to include those members, can use `included-teams` instead.

And lastly, the entire point of this PR:
* Made the inside-rust-reviewers include the leadership council