### PR TITLE
add asquared31415 to cloud compute

### DIFF
--- a/people/asquared31415.toml
+++ b/people/asquared31415.toml
@@ -1,0 +1,3 @@
+name = 'asquared31415'
+github = 'asquared31415'
+github-id = 34665709

--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -8,6 +8,7 @@ leads = []
 # For example, T-compiler and T-infra both have `dev-desktop = true`
 members = [
     "albertlarsan68",
+    "asquared31415",
     "Dajamante",
     "jhpratt",
     "JoelMarcey",


### PR DESCRIPTION
@compiler-errors suggested I use the cloud desktops for working on rustc.  A lot of my work is on UI tests which are very resource intensive and benefit greatly from being able to be run in parallel.  Additionally, the only local machine I have is x86_64 which means that I cannot test the aarch64 tests at all.

cc @oli-obk 