### PR TITLE
Add bors-kindergarten repo

### DIFF
--- a/repos/rust-lang/bors-kindergarten.toml
+++ b/repos/rust-lang/bors-kindergarten.toml
@@ -1,0 +1,9 @@
+org = "rust-lang"
+name = "bors-kindergarten"
+description = "Experimental repository for testing the behavior of the new bors implementation."
+bots = ["rustbot"]
+
+[access.teams]
+infra = "write"
+infra-bors = "write"
+mods = "maintain"


### PR DESCRIPTION
This repo should serve for testing of the new bors bot.