### PR TITLE
add Zoxc to alumni of parallel rustc WG

### DIFF
--- a/teams/wg-parallel-rustc.toml
+++ b/teams/wg-parallel-rustc.toml
@@ -12,6 +12,7 @@ members = [
     "Kobzol",
 ]
 alumni = [
+    "Zoxc",
     "nikomatsakis",
     "Mark-Simulacrum",
     "alexcrichton",


### PR DESCRIPTION
@Zoxc is the original initiator and key contributor of parallel rustc front-end, and is currently helping the working group as well, which is very grateful!