### PR TITLE
Add docs-rs to the devtools team mailing list.

### DIFF
--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -29,6 +29,7 @@ address = "tools-all@rust-lang.org"
 extra-teams = [
     "cargo",
     "clippy",
+    "docs-rs",
     "ides",
     "rustdoc",
     "rustfmt",


### PR DESCRIPTION
This adds the docs-rs team to the `tools-all@rust-lang.org` mailing list. This is the only team missing from the list, and I assume it was an oversight.

cc @syphar FYI. This list gets almost no traffic, but I wanted to make sure everyone in devtools can be reached.

cc @Manishearth if you want to review.
