### PR TITLE
Permit subteams to have subteams

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -186,10 +186,11 @@ impl Team {
 
     // Return's whether the provided team is a subteam of this team
     pub(crate) fn is_parent_of<'a>(&'a self, data: &'a Data, subteam: &Team) -> bool {
+        let mut visited = Vec::new();
         let mut subteam = Some(subteam);
-        while let Some(s) = subteam {
+        while let Some(team) = subteam {
             // Get subteam's parent
-            let Some(parent) = s.subteam_of() else {
+            let Some(parent) = team.subteam_of() else {
                 // The current subteam is a top level team.
                 // Therefore this team cannot be its parent.
                 return false;
@@ -198,7 +199,16 @@ impl Team {
             if parent == self.name {
                 return true;
             }
+
+            visited.push(team.name.as_str());
+
             // Otherwise try the test again with the parent
+            // unless we have already visited it.
+
+            if visited.contains(&parent) {
+                // We have found a cycle, give up.
+                return false;
+            }
             subteam = data.team(parent);
         }
         false


### PR DESCRIPTION
This would allow us to create the team *rustdoc-contributors* (#1040).

Let me know if I should add a test anywhere.
Should we enforce a depth limit?

<details><summary>Outdated information</summary>

According to https://github.com/rust-lang/team/pull/1040#issuecomment-1672989957, nothing should be negatively affected except for the website. I've built its server locally with a patched `rust_team_data` package (part of this repo) and a patched `rust_team_data` static API (that contains the new team) and the only consequence is that *rustdoc-contributors* doesn't show up anywhere on the website (it doesn't crash the server or anything like that). Therefore, updating the website is not a hard blocker.

I've opened rust-lang/www.rust-lang.org#1854 proposing to add proper website support for subsubteams (etc.). I plan on implementing it (or GuillaumeGomez will).

</details>