### PR TITLE
Add style team repository

### DIFF
--- a/repos/rust-lang/style-team.toml
+++ b/repos/rust-lang/style-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "style-team"
+description = "Home of the Rust style team"
+bots = ["rustbot"]
+
+[access.teams]
+style = "maintain"


### PR DESCRIPTION
cc @rust-lang/style

This lets the team repository manage permissions and properties of the
style-team repository, including enabling triagebot (rustbot).
