### PR TITLE
Update devtools team membership

### DIFF
--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -2,8 +2,8 @@ name = "devtools"
 
 [people]
 leads = ["Manishearth"]
-members = ["Manishearth", "fitzgen", "GuillaumeGomez", "oli-obk", "rbtcollins", "ehuss", "calebcartwright"]
-alumni = ["nrc", "killercup", "Xanewok", "kinnison"]
+members = ["Manishearth", "GuillaumeGomez", "oli-obk", "rbtcollins", "ehuss", "calebcartwright"]
+alumni = ["nrc", "killercup", "Xanewok", "kinnison", "fitzgen"]
 
 [rfcbot]
 label = "T-dev-tools"

--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -2,7 +2,7 @@ name = "devtools"
 
 [people]
 leads = ["Manishearth"]
-members = ["Manishearth", "Xanewok", "fitzgen", "GuillaumeGomez", "oli-obk", "kinnison", "ehuss"]
+members = ["Manishearth", "fitzgen", "GuillaumeGomez", "oli-obk", "rbtcollins", "ehuss", "calebcartwright"]
 alumni = ["nrc", "killercup"]
 
 [rfcbot]

--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -3,7 +3,7 @@ name = "devtools"
 [people]
 leads = ["Manishearth"]
 members = ["Manishearth", "fitzgen", "GuillaumeGomez", "oli-obk", "rbtcollins", "ehuss", "calebcartwright"]
-alumni = ["nrc", "killercup"]
+alumni = ["nrc", "killercup", "Xanewok", "kinnison"]
 
 [rfcbot]
 label = "T-dev-tools"


### PR DESCRIPTION
This updates the devtools team membership to better reflect who is currently active.

* Remove Xanewok. They haven't been active for a while.
* Swap kinnison with rbtcollins (cc #1008)
* Add calebcartwright. They have been active with devtools activities, and also represent the rustfmt team.

cc @rust-lang/devtools @rbtcollins @calebcartwright 