### PR TITLE
team: add a new wg for rust macros

### DIFF
--- a/people/CohenArthur.toml
+++ b/people/CohenArthur.toml
@@ -1,0 +1,5 @@
+name = 'Arthur Cohen'
+github = 'CohenArthur'
+github-id = 43524065
+email = 'cohenarthur.dev@gmail.com'
+zulip-id = 281468

--- a/people/danielhenrymantilla.toml
+++ b/people/danielhenrymantilla.toml
@@ -2,3 +2,4 @@ name = "Daniel Henry-Mantilla"
 email = "daniel.henry.mantilla@gmail.com"
 github = "danielhenrymantilla"
 github-id = 9920355
+zulip-id = 232018

--- a/teams/wg-macros.toml
+++ b/teams/wg-macros.toml
@@ -1,0 +1,28 @@
+name = "wg-macros"
+kind = "working-group"
+subteam-of = "compiler"
+
+[people]
+leads = ["vincenzopalazzo", "eholk"]
+members = [
+  "jhpratt",
+  "Veykril",
+  "CohenArthur",
+  "danielhenrymantilla",
+  "vincenzopalazzo",
+  "eholk",
+]
+alumni = [
+]
+
+[[github]]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
+[website]
+name = "Macros working group"
+description = "Revival and Improving the Rust Macros"
+repo = "https://github.com/rust-lang/wg-macros"
+zulip-stream = "wg-macros"
+
+[[zulip-groups]]
+name = "wg-macros"


### PR DESCRIPTION
This is adding a new team that is the wg-macros
as a followup step after the MCP get merged [1].

[1] https://github.com/rust-lang/compiler-team/issues/637