### PR TITLE
Add rustbot to project-stable-mir repository

### DIFF
--- a/repos/rust-lang/project-stable-mir.toml
+++ b/repos/rust-lang/project-stable-mir.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "project-stable-mir"
+description = "Define compiler intermediate representation usable by external tools"
+bots = ["rustbot"]
+
+[access.teams]
+project-stable-mir = "write"
+
+[[branch-protections]]
+pattern = "main"


### PR DESCRIPTION
We have been using the issues in the repository to track the work distribution, and we would like to enable rustbot.

We have already added a triagebot.toml file to the repository. Is there anything else that needs to be done?