### PR TITLE
Add apiraino to compiler contributors

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -4,6 +4,7 @@ subteam-of = "compiler"
 [people]
 leads = []
 members = [
+  "apiraino",
   "b-naber",
   "bjorn3",
   "BoxyUwU",


### PR DESCRIPTION
@apiraino's contributions to prioritizing issues and putting together our weekly triage agendas have a huge impact on the compiler team. 

Congrats @apiraino and well earned! 🎉 

r? @davidtwco 