### PR TITLE
move wg-polonius to t-types

### DIFF
--- a/teams/wg-polonius.toml
+++ b/teams/wg-polonius.toml
@@ -1,4 +1,5 @@
 name = "wg-polonius"
+# Really should be "types", but the team repo doesn't handle that right now
 subteam-of = "compiler"
 kind = "working-group"
 
@@ -10,7 +11,7 @@ members = ["lqd", "nikomatsakis", "amandasystems", "matthewjasper", "ecstatic-mo
 name = "Polonius working group"
 description = "Working on an experimental new borrow-checker implementation"
 repo = "https://rust-lang.github.io/compiler-team/working-groups/polonius/"
-zulip-stream = "t-compiler/wg-polonius"
+zulip-stream = "t-types/polonius"
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
As described in the [initial t-types announcement/plans](https://blog.rust-lang.org/2023/01/20/types-announcement.html#the-types-team):

> Another relevant working group is the [polonius working group](https://rust-lang.github.io/compiler-team/working-groups/polonius/), which primarily works on the design and implementation of the [Polonius](https://github.com/rust-lang/polonius) borrow-checking library. While the working group itself will remain, it is now also under the purview of the types team.

This PR moves the WG under t-types rather than t-compiler. Note that the move is limited in what the team repo and website support (much like t-types' structure itself): [subteams currently can't have working groups](https://github.com/rust-lang/team/actions/runs/6122552119/job/16618573188#step:5:11). 

It's not a big deal:
1. we can still have the WG as a child of t-compiler in the team repository -- this is still ultimately true transitively :) -- and document that it's a t-types WG. This is what this PR does.
2. or, have the wg be a team. @fmease has recently made changes to allow subteams to have their own subteams. 

Let me know what you think @nikomatsakis and @jackh726. It feels the WG structure has merit in this case, compared to making it a t-types subteam. It seems fine to me to document that this is a t-types WG, but still attach it to t-compiler in the existing data structure of the team repo and website UI.

(This ultimately feels fixable, but I'm not sure it's absolutely necessary right now)