### PR TITLE
Remove my name from the project

### DIFF
--- a/people/jonas-schievink.toml
+++ b/people/jonas-schievink.toml
@@ -1,5 +1,0 @@
-name = "Jonas Schievink"
-github = "jonas-schievink"
-github-id = 1786438
-email = "jonasschievink@gmail.com"
-zulip-id = 211727

--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -39,7 +39,6 @@ members = [
 alumni = [
     "Centril",
     "LeSeulArtichaut",
-    "jonas-schievink",
     "zackmdavis",
     "matklad",
 ]

--- a/teams/release.toml
+++ b/teams/release.toml
@@ -13,7 +13,6 @@ alumni = [
     "BatmanAoD",
     "Centril",
     "sgrif",
-    "jonas-schievink",
     "XAMPPRocky",
 ]
 

--- a/teams/rust-analyzer.toml
+++ b/teams/rust-analyzer.toml
@@ -12,7 +12,6 @@ members = [
     "HKalbasi",
 ]
 alumni = [
-    "jonas-schievink",
     "edwin0cheng",
     "SomeoneToIgnore",
     "matklad",

--- a/teams/wg-embedded.toml
+++ b/teams/wg-embedded.toml
@@ -38,7 +38,6 @@ alumni = [
     "hannobraun",
     "ithinuel",
     "jcsoo",
-    "jonas-schievink",
     "korken89",
     "laanwj",
     "paoloteti",


### PR DESCRIPTION
I have already left the Rust team earlier this year. This pull request additionally removes me from the "alumni", and deletes the file tying my usernames together.

I would also like to request that the Rust team strip all authorship information from my commits to the projects in the `rust-lang` organization.

I no longer want to be associated with the Rust project in any capacity and deeply regret ever getting involved in it.

The Rust project has repeatedly failed its own volunteers, sabotaged community projects, and suppressed public discussion, while its leadership hides behind "concerns" that are never elaborated on and shields the individuals responsible from consequences.

The cowardly handling of the recent RustConf keynote fiasko is merely the most recent example of this, and it is unlikely to be the last, even if the de-jure leadership structure was changed to incorporate the new Leadership Council. The only way to permanently resolve these issues is to oust the people that are responsible for them, or defending those that are, from the Rust project entirely.

I strongly suggest that all volunteers on the Rust team seriously reconsider if this organization is really worth volunteering for.

Additionally, I urge everyone who knows details about the Rust project's failures that have not been made public to ask themselves: do you not think that people who are considering to get involved in Rust deserve to know what they are getting into, without having to go through the same experience first?