### PR TITLE
Move a few compiler-contributors to alumni status

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -11,7 +11,6 @@ members = [
   "chenyukang",
   "cuviper",
   "durin42",
-  "ecstatic-morse",
   "eholk",
   "est31",
   "fee1-dead",
@@ -24,7 +23,6 @@ members = [
   "nikomatsakis",
   "nnethercote",
   "RalfJung",
-  "scalexm",
   "saethlin",
   "SparrowLii",
   "spastorino",
@@ -32,15 +30,17 @@ members = [
   "tmandry",
   "tmiasko",
   "TaKO8Ki",
-  "varkor",
   "WaffleLapkin",
-  "Xanewok",
 ]
 alumni = [
     "Centril",
     "LeSeulArtichaut",
     "zackmdavis",
     "matklad",
+    "ecstatic-morse",
+    "scalexm",
+    "varkor",
+    "Xanewok",
 ]
 
 [permissions]


### PR DESCRIPTION
Thanks to @ecstatic-morse, @scalexm, @varkor and @Xanewok for all of your contributions! Please don't hesitate to let us know if you would like to move back into active contributor status.

r? @davidtwco 