### PR TITLE
Add spec subteam.

### DIFF
--- a/people/JoelMarcey.toml
+++ b/people/JoelMarcey.toml
@@ -2,3 +2,4 @@ name = 'Joel Marcey'
 github = 'JoelMarcey'
 github-id = 3757713
 email = 'jimarcey@gmail.com'
+zulip-id = 422148

--- a/teams/spec.toml
+++ b/teams/spec.toml
@@ -1,0 +1,28 @@
+name = "spec"
+subteam-of = "lang"
+
+[people]
+leads = ["pnkfelix", "m-ou-se"]
+members = [
+    "pnkfelix",
+    "m-ou-se",
+    "JoelMarcey",
+    "ehuss",
+]
+alumni = []
+
+[website]
+name = "Specification team"
+description = "Creating and maintaining the specification for the Rust language"
+zulip-stream = "t-spec"
+
+[rfcbot]
+label = "T-spec"
+name = "Spec"
+ping = "rust-lang/spec"
+
+[[github]]
+orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "T-spec"


### PR DESCRIPTION
This adds the new spec team. See https://github.com/rust-lang/blog.rust-lang.org/pull/1166