### PR TITLE
Update rustdoc zulip stream name

### DIFF
--- a/teams/rustdoc-contributors.toml
+++ b/teams/rustdoc-contributors.toml
@@ -19,4 +19,4 @@ extra-teams = ["rustdoc"]
 [website]
 name = "Rustdoc team contributors"
 description = "Contributing to Rustdoc on a regular basis"
-zulip-stream = "rustdoc"
+zulip-stream = "t-rustdoc"

--- a/teams/rustdoc.toml
+++ b/teams/rustdoc.toml
@@ -36,7 +36,7 @@ ping = "rust-lang/rustdoc"
 [website]
 name = "Rustdoc team"
 description = "Developing and managing the Rustdoc documentation tool"
-zulip-stream = "rustdoc"
+zulip-stream = "t-rustdoc"
 repo = "https://github.com/rust-lang/rust"
 
 [[lists]]


### PR DESCRIPTION
Fixes the link on rust-lang.org 404ing.

See https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Renaming.20this.20stream.20to.20t-rustdoc.3F and https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/stream.20events/near/391770881