### PR TITLE
repo: propose to add a repo for store macro wg webpage

### DIFF
--- a/repos/rust-lang/wg-macros.toml
+++ b/repos/rust-lang/wg-macros.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "wg-macros"
+description = "Home of the Rust Macros Working Gruop"
+bots = ["rustbot"]
+
+[access.teams]
+wg-macros = "maintain"
+
+[[branch-protections]]
+pattern = "main"


### PR DESCRIPTION
This commit proposes to have a WG webpage for the macros team 
in order to have a way to put all the information about the wg.

cc @rust-lang/compiler @rust-lang/wg-macros