### PR TITLE
crate-maintainers += dtolnay

### DIFF
--- a/teams/crate-maintainers.toml
+++ b/teams/crate-maintainers.toml
@@ -13,6 +13,7 @@ members = [
   "workingjubilee",
   "ChrisDenton",
   "Byron",
+  "dtolnay",
 ]
 
 [permissions]


### PR DESCRIPTION
I am interested in helping with `log` pull requests, which I had been able to do in the past before the switch to crate-maintainers. According to `git log --author=dtolnay --grep='Merge pull request'` in the log repo, there are 33 past PRs merged by me.