### PR TITLE
Add rustup repository

### DIFF
--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "rustup"
+description = "The Rust toolchain installer"
+bots = ["rustbot"]
+
+[access.teams]
+rustup = "maintain"
+mods = "maintain"
+
+[[branch-protections]]
+pattern = "master"

--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -5,7 +5,6 @@ bots = ["rustbot"]
 
 [access.teams]
 rustup = "maintain"
-mods = "maintain"
 
 [[branch-protections]]
 pattern = "master"

--- a/teams/rustup.toml
+++ b/teams/rustup.toml
@@ -22,3 +22,6 @@ description = "Designing and implementing rustup"
 discord-invite = "https://discord.gg/e6Q3cvu"
 discord-name = "#wg-rustup"
 repo = "https://github.com/rust-lang/rustup"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
The permissions for the rust-lang/rust repository are out-of-date, and instead of manually updating them we want to manage the repository automatically.

Fixes https://github.com/rust-lang/infra-team/issues/80