### PR TITLE
create the *lang-ops* team

### DIFF
--- a/teams/lang-ops.toml
+++ b/teams/lang-ops.toml
@@ -1,0 +1,18 @@
+name = "lang-ops"
+subteam-of = "lang"
+
+[people]
+leads = ["TC"]
+members = [
+    "TC",
+]
+alumni = [
+]
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "lang-ops team"
+description = "Operations for the lang team: preparing agenda, issue triage, scheduling and documenting meetings"
+zulip-stream = "t-lang/ops"

--- a/teams/lang-ops.toml
+++ b/teams/lang-ops.toml
@@ -2,9 +2,9 @@ name = "lang-ops"
 subteam-of = "lang"
 
 [people]
-leads = ["TC"]
+leads = ["traviscross"]
 members = [
-    "TC",
+    "traviscross",
 ]
 alumni = [
 ]


### PR DESCRIPTION
This team is chartered to prepare meeting agendas, help with issue triage, schedule and document meetings, and generally perform the other "operations" that make the lang team function.

Currently its sole membership is TC but the hope is that it will grow!

cc @rust-lang/lang 