### PR TITLE
Automatically add compiler-contributors to the private decision making stream

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -57,3 +57,12 @@ extra-teams = ["compiler"]
 name = "Compiler team contributors"
 repo = "http://github.com/rust-lang/compiler-team"
 description = "Contributing to the Rust compiler on a regular basis"
+
+[[zulip-groups]]
+name = "T-compiler"
+
+[[zulip-groups]]
+name = "T-compiler/meeting"
+
+[[zulip-groups]]
+name = "T-compiler/contrib-private"

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -80,13 +80,12 @@ name = "T-compiler"
 name = "T-compiler/meeting"
 extra-people = [
     "aturon",
-    "Mark-Simulacrum",
-    "spastorino",
     "varkor",
     "arielb1",
     "cramertj",
-    "bjorn3",
     "Xanewok",
     "nellshamrell",
-    "jackh726"
 ]
+
+[[zulip-groups]]
+name = "T-compiler/contrib-private"

--- a/teams/types.toml
+++ b/teams/types.toml
@@ -38,6 +38,9 @@ name = "T-types"
 name = "T-types/meetings"
 extra-people = ["eholk"]
 
+[[zulip-groups]] 
+name = "T-types/private"
+
 [permissions]
 bors.chalk.review = true
 bors.rust.review = true


### PR DESCRIPTION
unblocks https://github.com/rust-lang/compiler-team/issues/649

Also

* does the same for @rust-lang/types 
* also removes extra-people that are already compiler-contributors