### PR TITLE
Update and split "arm" team.

### DIFF
--- a/people/jacobbramley.toml
+++ b/people/jacobbramley.toml
@@ -1,3 +1,4 @@
 name = 'Jacob Bramley'
 github = 'jacobbramley'
 github-id = 5206553
+zulip-id = 399135

--- a/teams/arm-maintainers.toml
+++ b/teams/arm-maintainers.toml
@@ -1,0 +1,10 @@
+name = "arm-maintainers"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "adamgemmell",
+    "jacobbramley",
+    "JamieCunliffe",
+]

--- a/teams/arm.toml
+++ b/teams/arm.toml
@@ -4,11 +4,11 @@ kind = "marker-team"
 [people]
 leads = []
 members = [
-    "JamieCunliffe",
     "Stammark",
     "joaopaulocarreiro",
     "raw-bin",
-    "jacobbramley",
-    "adamgemmell",
     "hug-dev",
+]
+included-teams = [
+    "arm-maintainers"
 ]


### PR DESCRIPTION
This adds an "arm-maintainers" team, which we can refer to in rust-lang/rust#116004.

`cargo run -- dump-team arm` is unaffected.