### PR TITLE
Switch triagebot team to maintain role

### DIFF
--- a/repos/rust-lang/triagebot.toml
+++ b/repos/rust-lang/triagebot.toml
@@ -4,8 +4,8 @@ description = 'Automation/tooling for Rust spaces'
 bots = ["rustbot"]
 
 [access.teams]
-infra = "write"
-triagebot = "write"
+infra = "maintain"
+triagebot = "maintain"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
This upgrades the triagebot team's permission role from `write` to `maintain` so that they are able to merge PRs. GitHub's default branch protection behavior is to only allow people with the `maintain` role to merge PRs. The permission differences are:

* Edit a repository's description
* Enable wikis and restrict wiki editors
* Enable project boards
* Configure pull request merges
* Configure a publishing source for GitHub Pages
* Push to protected branches
* Create tags that match a tag protection rule
* Create and edit repository social cards
* Enable GitHub Discussions in a repository

None of which I think are all that important to restrict (at least for this particular repo).

We could change it so that sync-team automatically includes people with the "write" role to be allowed to merge PRs. Or alternatively, to have a specific opt-in (like `allow-write-role=true`). However, I am not feeling inclined to hack on sync-team right now, and it would change permissions for backtrace-rs (adds alexcrichton), flate2 (adds brson), and impl-trait-utils (adds wg-async), which I don't want to fuss with.

Another option is to drop the branch protection, but at least I feel more comfortable with it enabled since it requires everything to go through a PR which is more publicly visible.

Also, just in general, it looks like we have been giving out `maintain` to almost all repos anyways.
