### PR TITLE
Add `social-media`

### DIFF
--- a/teams/social-media.toml
+++ b/teams/social-media.toml
@@ -1,0 +1,9 @@
+name = "social-media"
+subteam-of = "leadership-council"
+
+[people]
+leads = ["m-ou-se"]
+members = ["m-ou-se"]
+
+[[lists]]
+address = "social@rust-lang.org"


### PR DESCRIPTION
We need an email address for the social media account(s). This adds the `social@rust-lang.org` mailing list.