### PR TITLE
Add forge repo permissions.

### DIFF
--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -1,0 +1,20 @@
+org = 'rust-lang'
+name = 'rust-forge'
+description = 'Information useful to people contributing to Rust'
+bots = ["rustbot"]
+
+[access.teams]
+community = "maintain"
+compiler = "maintain"
+compiler-contributors = "maintain"
+crates-io = "maintain"
+docs-rs = "maintain"
+infra = "maintain"
+lang = "maintain"
+leadership-council = "maintain"
+libs = "maintain"
+release = "maintain"
+triagebot = "maintain"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
I would like to set up the forge so that a broader set of people have permission to help merge PRs. My thinking is to set up auto-assignment via rustbot so that individual teams will be responsible for their respective areas. Additionally, I can help with overall management of the repo itself (like dealing with mdbook or blacksmith). I think giving a broad set of people permission to help and encourage participation, avoiding things getting stuck, and to avoid putting the review responsibility on a small number of people.

I don't know if this would need sign off from the council or not. I see this as mainly being under the purview of the infrastructure team (and we can formalize that if needed).

cc https://github.com/rust-lang/leadership-council/issues/47
