### PR TITLE
Add Edition 2024 project group.

### DIFF
--- a/teams/project-edition-2024.toml
+++ b/teams/project-edition-2024.toml
@@ -1,0 +1,17 @@
+name = "project-edition-2024"
+kind = "project-group"
+subteam-of = "leadership-council"
+
+[people]
+leads = [
+    "bstrie",
+    "ehuss"
+]
+members = [
+    "bstrie",
+    "ehuss",
+    "m-ou-se",
+]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
The leadership council has approved the formation of the edition 2024 project group with @bstrie and myself as leads. I have also provisionally included @m-ou-se, though I recognize she might not be able to devote much time.

There was a discussion previously about how to formally slot this group in the hierarchy, possibly putting it under the launching pad. However, since the launching pad team hasn't been created yet, this is just placed under the council directly.
