### PR TITLE
Add tshepang to crates-io-on-call team

### DIFF
--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -11,6 +11,7 @@ members = [
     "justahero",
     "pietroalbini",
     "listochkin",
+    "tshepang",
 ]
 
 [[github]]


### PR DESCRIPTION
As requested in Zulip[^1], @tshepang is being added to the crates-io-on-call team.

cc @Turbo87

[^1]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/on-call.20rotation