### PR TITLE
add docs-rs-reviewers team for review assignment

### DIFF
--- a/teams/docs-rs-reviewers.toml
+++ b/teams/docs-rs-reviewers.toml
@@ -1,0 +1,13 @@
+name = "docs-rs-reviewers"
+subteam-of = "docs-rs"
+
+[people]
+leads = []
+members = [
+    "GuillaumeGomez",
+    "Nemo157",
+    "syphar",
+]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
related docs.rs PR is: https://github.com/rust-lang/docs.rs/pull/2283 

I want to automatically a github team as reviewer for pull requests, and not everyone in the docs.rs team regularly reviews. 

