### PR TITLE
Give t-libs dev-desktop permissions

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -19,6 +19,7 @@ members = [
     "WaffleLapkin",
     "JulianKnodt",
     "vincenzopalazzo",
+    "thomcc",
 ]
 
 [permissions]

--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -19,7 +19,6 @@ members = [
     "WaffleLapkin",
     "JulianKnodt",
     "vincenzopalazzo",
-    "thomcc",
 ]
 
 [permissions]

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -23,6 +23,7 @@ orgs = ["rust-lang", "rust-lang-nursery"]
 [permissions]
 perf = true
 crater = true
+dev-desktop = true
 bors.hashbrown.review = true
 bors.libc.review = true
 bors.rust.review = true


### PR DESCRIPTION
~~I'd like to give myself dev-desktop permissions. I'm on several teams so hopefully this isn't a problem, even though none of them already have it (although it's a bit surprising that this is true for t-libs).~~ Edit: I've changed this to grant dev-desktop to t-libs broadly.

I haven't asked anywhere if this is okay, so let me know if I'm skipping some process.