### PR TITLE
Give stable-mir r+ access for their code

### DIFF
--- a/teams/project-stable-mir.toml
+++ b/teams/project-stable-mir.toml
@@ -23,3 +23,6 @@ zulip-stream = "project-stable-mir"
 
 [[github]]
 orgs = ["rust-lang"]
+
+[permissions]
+bors.rust.review = true


### PR DESCRIPTION
We want to give the stable-mir project the ability to r+ stable mir PRs in the compiler since that area is under their purview. 

r? @davidtwco 