### PR TITLE
Update the RISC-V team name according to the guidelines

### DIFF
--- a/teams/wg-embedded-riscv.toml
+++ b/teams/wg-embedded-riscv.toml
@@ -14,8 +14,8 @@ members = [
 ]
 
 [website]
-name = "Embedded RISCV team"
-description = "Develops and maintains the core of the embedded RISCV crate ecosystem"
+name = "Embedded RISC-V team"
+description = "Develops and maintains the core of the embedded RISC-V crate ecosystem"
 
 [[github]]
 orgs = ["rust-embedded"]


### PR DESCRIPTION
According to https://riscv.org/about/risc-v-branding-guidelines/
> The “RISC-V” trade name is a registered trademark of RISC-V International.  All uses of the name RISC-V must be consistent with these guidelines. The name must always be written in block letters with a hyphen between the C and V of RISC-V.