### PR TITLE
Allow assigning PRs to members of the project stable MIR

### DIFF
--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -15,6 +15,7 @@ leadership-council = "maintain"
 libs = "maintain"
 release = "maintain"
 triagebot = "maintain"
+project-stable-mir = "maintain"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
These members were granted r+ permission here: https://github.com/rust-lang/team/pull/1110

However, trying to assign a PR to them will trigger a rustbot error. I think the problem is that we also need to add the team as repo maintainers.