### PR TITLE
Add `perf` `@rust-timer` bot permission for Cargo team

### DIFF
--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -24,6 +24,7 @@ alumni = [
 [permissions]
 bors.rust.review = true
 bors.cargo.review = true
+crater = true
 perf = true
 
 [[github]]

--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -24,6 +24,7 @@ alumni = [
 [permissions]
 bors.rust.review = true
 bors.cargo.review = true
+perf = true
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]


### PR DESCRIPTION
Was [doing this](https://github.com/rust-lang/rust/pull/117962#issuecomment-1816651066) and found that Cargo team doesn't have the permission.

It might not be necessary so feel free to close this PR.
