### PR TITLE
Disallow an archived team from having current members

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -280,18 +280,9 @@ impl Team {
                 .teams()
                 .chain(data.archived_teams())
                 .flat_map(|t| t.alumni())
-                .map(|a| a.as_str());
-            let mut members_of_archived_teams = HashSet::new();
-
-            for t in data.archived_teams() {
-                members_of_archived_teams.extend(t.members(data)?);
-            }
-
-            members.extend(
-                alumni
-                    .chain(members_of_archived_teams)
-                    .filter(|person| !active_members.contains(person)),
-            )
+                .map(|a| a.as_str())
+                .filter(|person| !active_members.contains(person));
+            members.extend(alumni);
         }
         Ok(members)
     }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -25,6 +25,7 @@ static CHECKS: &[Check<fn(&Data, &mut Vec<String>)>] = checks![
     validate_team_leads,
     validate_team_members,
     validate_alumni,
+    validate_archived_teams,
     validate_inactive_members,
     validate_list_email_addresses,
     validate_list_extra_people,
@@ -264,6 +265,15 @@ fn validate_alumni(data: &Data, errors: &mut Vec<String>) {
         );
         Ok(())
     });
+}
+
+fn validate_archived_teams(data: &Data, errors: &mut Vec<String>) {
+    wrapper(data.archived_teams(), errors, |team, _| {
+        if !team.members(data)?.is_empty() {
+            bail!("archived team '{}' must not have current members; please move members to that team's alumni", team.name());
+        }
+        Ok(())
+    })
 }
 
 /// Ensure every person is part of at least one team (active or archived)

--- a/teams/archive/docs.toml
+++ b/teams/archive/docs.toml
@@ -1,8 +1,9 @@
 name = "docs"
 
 [people]
-leads = ["steveklabnik"]
-members = [
+leads = []
+members = []
+alumni = [
     "steveklabnik",
     "GuillaumeGomez",
     "rylev",

--- a/teams/archive/ecosystem.toml
+++ b/teams/archive/ecosystem.toml
@@ -2,7 +2,8 @@ name = "ecosystem"
 
 [people]
 leads = []
-members = [
+members = []
+alumni = [
     "KodrAus",
     "withoutboats",
     "sfackler",

--- a/teams/archive/ides.toml
+++ b/teams/archive/ides.toml
@@ -2,18 +2,17 @@ name = "ides"
 subteam-of = "devtools"
 
 [people]
-leads = ["Xanewok"]
-members = [
+leads = []
+members = []
+alumni = [
+    "LucasBullen",
+    "Xanewok",
     "alexheretic",
     "autozimu",
     "jasonwilliams",
-    "LucasBullen",
-    "vlad20012",
-    "Xanewok",
-]
-alumni = [
-    "nrc",
     "matklad",
+    "nrc",
+    "vlad20012",
 ]
 
 [[github]]

--- a/teams/archive/interim-leadership-chat.toml
+++ b/teams/archive/interim-leadership-chat.toml
@@ -4,7 +4,8 @@ name = "interim-leadership-chat"
 
 [people]
 leads = []
-members = [
+members = []
+alumni = [
     "badboy",
     "cuviper",
     "jtgeibel",

--- a/teams/archive/production.toml
+++ b/teams/archive/production.toml
@@ -1,8 +1,9 @@
 name = "production"
 
 [people]
-leads = ["aidanhs"]
-members = [
+leads = []
+members = []
+alumni = [
     "aidanhs",
     "aturon",
     "celaus",

--- a/teams/archive/project-foundation.toml
+++ b/teams/archive/project-foundation.toml
@@ -3,21 +3,17 @@ kind = "project-group"
 subteam-of = "core"
 
 [people]
-leads = [
-    "ashleygwilliams",
-    "nikomatsakis",
-]
-members = [
-    "ashleygwilliams",
-    "nikomatsakis",
-    "pietroalbini",
-    "skade",
-]
+leads = []
+members = []
 alumni = [
     "Manishearth",
+    "ashleygwilliams",
     "joshtriplett",
     "nellshamrell",
+    "nikomatsakis",
+    "pietroalbini",
     "rylev",
+    "skade",
 ]
 
 [website]

--- a/teams/archive/wg-meta.toml
+++ b/teams/archive/wg-meta.toml
@@ -3,8 +3,9 @@ subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["nikomatsakis", "davidtwco", "spastorino"]
-members = ["nikomatsakis", "davidtwco", "spastorino"]
+leads = []
+members = []
+alumni = ["nikomatsakis", "davidtwco", "spastorino"]
 
 [website]
 name = "Meta working group"

--- a/teams/archive/wg-net-async.toml
+++ b/teams/archive/wg-net-async.toml
@@ -3,8 +3,9 @@ subteam-of = "wg-net"
 kind = "working-group"
 
 [people]
-leads = ["cramertj", "MajorBreakfast"]
-members = ["cramertj", "MajorBreakfast"]
+leads = []
+members = []
+alumni = ["cramertj", "MajorBreakfast"]
 
 [website]
 name = "Async foundations working group"

--- a/teams/archive/wg-net-embedded.toml
+++ b/teams/archive/wg-net-embedded.toml
@@ -3,8 +3,9 @@ subteam-of = "wg-net"
 kind = "working-group"
 
 [people]
-leads = ["Nemo157", "levex"]
-members = [
+leads = []
+members = []
+alumni = [
     "Nemo157",
     "levex",
 ]

--- a/teams/archive/wg-net-web.toml
+++ b/teams/archive/wg-net-web.toml
@@ -3,8 +3,9 @@ subteam-of = "wg-net"
 kind = "working-group"
 
 [people]
-leads = ["aturon", "yoshuawuyts"]
-members = ["aturon", "yoshuawuyts"]
+leads = []
+members = []
+alumni = ["aturon", "yoshuawuyts"]
 
 [website]
 name = "Web foundations working group"

--- a/teams/archive/wg-net.toml
+++ b/teams/archive/wg-net.toml
@@ -2,8 +2,9 @@ name = "wg-net"
 kind = "working-group"
 
 [people]
-leads = ["withoutboats", "cramertj"]
-members = [
+leads = []
+members = []
+alumni = [
     "withoutboats",
     "cramertj",
 ]

--- a/teams/archive/wg-nll.toml
+++ b/teams/archive/wg-nll.toml
@@ -3,8 +3,9 @@ subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["nikomatsakis", "pnkfelix"]
-members = ["nikomatsakis", "pnkfelix", "davidtwco", "spastorino", "matthewjasper", "lqd"]
+leads = []
+members = []
+alumni = ["nikomatsakis", "pnkfelix", "davidtwco", "spastorino", "matthewjasper", "lqd"]
 
 [website]
 name = "Non-Lexical Lifetimes (NLL) working group"

--- a/teams/archive/wg-rustfix.toml
+++ b/teams/archive/wg-rustfix.toml
@@ -4,7 +4,8 @@ kind = "working-group"
 
 [people]
 leads = []
-members = [
+members = []
+alumni = [
     "Manishearth",
     "estebank",
     "killercup",

--- a/teams/archive/wg-traits.toml
+++ b/teams/archive/wg-traits.toml
@@ -4,16 +4,8 @@ subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["nikomatsakis", "jackh726"]
-members = [
-    "Aaron1011",
-    "jackh726",
-    "lcnr",
-    "matthewjasper",
-    "nikomatsakis",
-    "oli-obk",
-    "spastorino",
-]
+leads = []
+members = []
 alumni = [
     "AzureMarker",
     "basil-cow",
@@ -26,6 +18,13 @@ alumni = [
     "tmandry",
     "yaahc",
     "zaharidichev",
+    "Aaron1011",
+    "jackh726",
+    "lcnr",
+    "matthewjasper",
+    "nikomatsakis",
+    "oli-obk",
+    "spastorino",
 ]
 
 [website]

--- a/teams/archive/wg-unsafe-code-guidelines.toml
+++ b/teams/archive/wg-unsafe-code-guidelines.toml
@@ -3,9 +3,17 @@ subteam-of = "lang"
 kind = "working-group"
 
 [people]
-leads = ["nikomatsakis", "RalfJung"]
-members = ["nikomatsakis", "RalfJung", "comex", "digama0", "JakobDegen", "CAD97"]
-alumni = ["avadacatavra"]
+leads = []
+members = []
+alumni = [
+    "avadacatavra",
+    "nikomatsakis",
+    "RalfJung",
+    "comex",
+    "digama0",
+    "JakobDegen",
+    "CAD97",
+]
 
 [website]
 name = "Unsafe Code Guidelines (UCG) working group"


### PR DESCRIPTION
Noticed while beginning to work on https://github.com/rust-lang/team/pull/1126#discussion_r1409043589. It does not seem useful to preserve a distinction between "current member of an archived team" vs "former member of an archived team". All members of an archived team are former members.