### PR TITLE
Add infra-admins to rust-lang-deprecated

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,7 @@ allowed-github-orgs = [
     "rust-lang",
     "rust-lang-ci",
     "rust-lang-nursery",
+    "rust-lang-deprecated",
     "rust-dev-tools",
     "rust-embedded",
     "rust-analyzer",

--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -8,6 +8,9 @@ members = [
     "jdno",
 ]
 
+[[github]]
+orgs = ["rust-lang-deprecated"]
+
 [permissions]
 sync-team-confirmation = true
 


### PR DESCRIPTION
This allows infra-admins to glance at the state of the deprecated org without having to log into the owner bot account.