### PR TITLE
Backfill all currently listed alumni's teams

### DIFF
--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -5,15 +5,7 @@ name = "alumni"
 
 [people]
 leads = []
-members = [
-    "alercah",
-    "birkenfeld",
-    "gnunicorn",
-    "peschkaj",
-    "rpjohnst",
-    "valgrimm",
-    "whitequark",
-]
+members = []
 # Temporary key that includes all members listed as alumni in the individual
 # teams. This is needed while we migrate away from the alumni team.
 include-all-alumni = true

--- a/teams/archive/docs-peers.toml
+++ b/teams/archive/docs-peers.toml
@@ -1,0 +1,13 @@
+name = "docs-peers"
+subteam-of = "docs"
+
+[people]
+leads = []
+members = []
+alumni = [
+    "alercah",
+]
+
+[website]
+name = "Documentation peers"
+description = "Oversight of specific documentation, and coordination with the docs team"

--- a/teams/archive/docs.toml
+++ b/teams/archive/docs.toml
@@ -10,6 +10,7 @@ alumni = [
     "GuillaumeGomez",
     "rylev",
     "celaus",
+    "peschkaj",
 ]
 
 [permissions]

--- a/teams/archive/lang-shepherds.toml
+++ b/teams/archive/lang-shepherds.toml
@@ -1,0 +1,10 @@
+name = "lang-shepherds"
+subteam-of = "lang"
+
+[people]
+leads = []
+members = []
+alumni = [
+    "rpjohnst",
+    "whitequark",
+]

--- a/teams/archive/reference.toml
+++ b/teams/archive/reference.toml
@@ -1,0 +1,14 @@
+name = "reference"
+subteam-of = "lang"
+
+[people]
+leads = []
+members = []
+alumni = [
+    "alercah",
+]
+
+[website]
+name = "Reference team"
+description = "Developing and writing the Rust reference"
+zulip-stream = "t-lang/wg-reference"

--- a/teams/archive/wg-governance.toml
+++ b/teams/archive/wg-governance.toml
@@ -1,0 +1,20 @@
+name = "wg-governance"
+subteam-of = "core"
+kind = "working-group"
+
+[people]
+leads = []
+members = []
+alumni = [
+    "gnunicorn",
+    "valgrimm"
+]
+
+[[lists]]
+address = "governance@rust-lang.org"
+
+[website]
+name = "Governance working group"
+description = "Managing and improving Rust team governance"
+repo = "https://github.com/rust-lang/wg-governance"
+zulip-stream = "wg-governance"

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -24,6 +24,7 @@ alumni = [
     "mcarton",
     "phansch",
     "camsteffen",
+    "birkenfeld",
 ]
 
 [permissions]


### PR DESCRIPTION
Based on the code from #1125 to extract former team membership from commit history.

This PR fills in team membership for all contributors currently listed in the deprecated alumni.toml, per Ryan's recommendation in https://github.com/rust-lang/team/pull/1126#pullrequestreview-1754881281 to bring back deleted teams in archived form.

The new archived teams added in this PR need to be filled in with other former members beyond this, but I will handle that separately. For now this PR is enough to bring the deprecated alumni team down to 0 members, and begin removing code related to it.

The only change to the website will be for birkenfeld, who will begin to appear under Clippy alumni at https://www.rust-lang.org/governance/teams/dev-tools#clippy. The other teams are archived teams, which do not get reflected on the website. All archived team members and birkenfeld will continue to appear in the overall alumni list at https://www.rust-lang.org/governance/teams/alumni.