### PR TITLE
Simplify validation of alumni team

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -232,39 +232,14 @@ fn validate_team_members(data: &Data, errors: &mut Vec<String>) {
     });
 }
 
-/// Ensure alumni are not active
+/// Alumni team must consist only of automatically populated alumni from the other teams
 fn validate_alumni(data: &Data, errors: &mut Vec<String>) {
-    let active_members = match data.active_members() {
-        Ok(ms) => ms,
-        Err(e) => {
-            errors.push(e.to_string());
-            return;
-        }
+    let Some(alumni_team) = data.team("alumni") else {
+        return;
     };
-    wrapper(data.team("alumni").iter(), errors, |alumni_team, errors| {
-        let mut explicit_members: HashSet<_> = alumni_team.explicit_members().iter().collect();
-        // Ensure alumni team members are not active
-        wrapper(alumni_team.members(data)?.iter(), errors, |member, _| {
-            if active_members.contains(member) {
-                bail!("alumni team includes active member '{}'", member)
-            }
-            Ok(())
-        });
-        // Ensure all explicitly named members of the alumni team are not also implicitly members
-        wrapper(
-            data.teams()
-                .filter(|t| t.name() != "alumni")
-                .flat_map(|t| t.alumni().iter().map(move |m| (t.name(), m))),
-            errors,
-            |(team, member), _| {
-                if explicit_members.remove(member) {
-                    bail!("alumni team explicitly includes member '{}' who was specified as an alumni already in '{}'", member, team)
-                }
-                Ok(())
-            },
-        );
-        Ok(())
-    });
+    if !alumni_team.explicit_members().is_empty() {
+        errors.push("'alumni' team must not have explicit members; move them to the appropriate team's alumni entry".to_owned());
+    }
 }
 
 fn validate_archived_teams(data: &Data, errors: &mut Vec<String>) {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -235,6 +235,7 @@ fn validate_team_members(data: &Data, errors: &mut Vec<String>) {
 /// Alumni team must consist only of automatically populated alumni from the other teams
 fn validate_alumni(data: &Data, errors: &mut Vec<String>) {
     let Some(alumni_team) = data.team("alumni") else {
+        errors.push("cannot find an 'alumni' team".to_owned());
         return;
     };
     if !alumni_team.explicit_members().is_empty() {

--- a/tests/static-api/_expected/v1/people.json
+++ b/tests/static-api/_expected/v1/people.json
@@ -34,11 +34,6 @@
       "name": "Sixth user",
       "email": "user6@example.com",
       "github_id": 6
-    },
-    "user-7": {
-      "name": "Seventh user",
-      "email": "user7@example.com",
-      "github_id": 7
     }
   }
 }

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -9,12 +9,6 @@
         "github": "user-5",
         "github_id": 5,
         "is_lead": false
-      },
-      {
-        "name": "Seventh user",
-        "github": "user-7",
-        "github_id": 7,
-        "is_lead": false
       }
     ],
     "alumni": [],

--- a/tests/static-api/_expected/v1/teams/alumni.json
+++ b/tests/static-api/_expected/v1/teams/alumni.json
@@ -8,12 +8,6 @@
       "github": "user-5",
       "github_id": 5,
       "is_lead": false
-    },
-    {
-      "name": "Seventh user",
-      "github": "user-7",
-      "github_id": 7,
-      "is_lead": false
     }
   ],
   "alumni": [],

--- a/tests/static-api/people/user-7.toml
+++ b/tests/static-api/people/user-7.toml
@@ -1,5 +1,0 @@
-name = 'Seventh user'
-github = 'user-7'
-github-id = 7
-email = "user7@example.com"
-

--- a/tests/static-api/teams/alumni.toml
+++ b/tests/static-api/teams/alumni.toml
@@ -2,7 +2,5 @@ name = "alumni"
 
 [people]
 leads = []
-members = [
-    "user-7",
-]
+members = []
 include-all-alumni = true


### PR DESCRIPTION
The alumni team used to allow explicit members as long as they were neither an active nor alumni of any other team.

Following #1134, explicit members of the alumni team are no longer allowed at all.