### PR TITLE
Add community team alumni

### DIFF
--- a/teams/community-localization.toml
+++ b/teams/community-localization.toml
@@ -9,6 +9,7 @@ members = [
     "vertexclique"
 ]
 alumni = [
+    "sebasmagri",
     "XAMPPRocky",
 ]
 

--- a/teams/community-survey.toml
+++ b/teams/community-survey.toml
@@ -4,7 +4,13 @@ subteam-of = "community"
 [people]
 leads = ["rylev"]
 members = ["rylev", "graciegregory", "Kobzol", "apiraino"]
-alumni = ["nikomatsakis", "nrc", "yaahc"]
+alumni = [
+    "Manishearth",
+    "nikomatsakis",
+    "nrc",
+    "sophiajt",
+    "yaahc",
+]
 
 [website]
 name = "Survey team"

--- a/teams/community.toml
+++ b/teams/community.toml
@@ -18,6 +18,10 @@ alumni = [
     "shadows-withal",
     "ashleygwilliams",
     "skade",
+    "bstrie",
+    "carols10cents",
+    "sophiajt",
+    "steveklabnik",
 ]
 
 [[github]]


### PR DESCRIPTION
Citations:

**`community-localization`**
https://github.com/rust-lang/team/pull/22

**`community-survey`**
https://github.com/rust-lang/www.rust-lang.org/pull/271/commits/e34026e146c9de391988e69ec6302884118cacac, see src/data/teams/community/teams/survey.yml. Note for now I am only backfilling alumni who already have a profile in the people directory of this repo from some other team membership, i.e. not mgattozzi in this case. We can pursue those cases separately but I figure it would require pinging and getting explicit approval from such contributors to be added into a dataset / website they are not already in, as it's not free: for example they'd become obligated to update this data in the event of name changes.

**`community`**
https://github.com/rust-lang/prev.rust-lang.org/pull/155 + https://github.com/rust-lang/prev.rust-lang.org/pull/328 + https://github.com/rust-lang/prev.rust-lang.org/pull/458

See also relevant discussion in https://github.com/rust-lang/prev.rust-lang.org/pull/1098. The old community team rosters are really "Community team (including subteams)". Based on this, I have avoided importing alumni from the prev.rust-lang.org community team roster for whom both of the following are true:

1. currently already alumni or active members of a current community subteam; and

2. not listed as a community team members post-split of the community team into subteams in 895daaf5e1759973c641f448e076d47d44d156d5, in which the community team changes were sourced from https://github.com/rust-lang/www.rust-lang.org/pull/271.

This applies to:

- arshiamufti (community-rustbridge)
- celaus (community-events)
- flaki (community-events)
- mattgathu (community-events, community-rustbridge)
- spacekookie (community-rustbridge)
- wezm (community-content)

