### PR TITLE
Add edition-guide repo

### DIFF
--- a/repos/rust-lang/edition-guide.toml
+++ b/repos/rust-lang/edition-guide.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "edition-guide"
+description = "A guide to changes between various editions of Rust"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+project-edition-2024 = "maintain"


### PR DESCRIPTION
This adds the https://github.com/rust-lang/edition-guide/ repository to the team repository so that we can manage the permissions here.

I am not adding a branch protection yet, since I sometimes need to be able to manage the docs (and GitHub doesn't allow to self-approve). Ideally it would be nice to have a branch protection without a required approved review.

cc @rust-lang/project-edition-2024 