### PR TITLE
Add lang alumni

### DIFF
--- a/teams/archive/lang-shepherds.toml
+++ b/teams/archive/lang-shepherds.toml
@@ -6,5 +6,6 @@ leads = []
 members = []
 alumni = [
     "rpjohnst",
+    "solson",
     "whitequark",
 ]

--- a/teams/archive/reference.toml
+++ b/teams/archive/reference.toml
@@ -6,6 +6,10 @@ leads = []
 members = []
 alumni = [
     "alercah",
+    "Centril",
+    "ehuss",
+    "Havvy",
+    "matthewjasper",
 ]
 
 [website]

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -19,6 +19,7 @@ alumni = [
     "cramertj",
     "nrc",
     "withoutboats",
+    "eddyb",
 ]
 
 [permissions]

--- a/teams/style.toml
+++ b/teams/style.toml
@@ -11,6 +11,10 @@ members = [
 ]
 alumni = [
     "brson",
+    "japaric",
+    "nrc",
+    "solson",
+    "steveklabnik",
 ]
 
 [[github]]


### PR DESCRIPTION
Citations:

**`lang-shepherds`**
https://github.com/rust-lang/prev.rust-lang.org/pull/823. There are 4 other former members of lang-shepherds: Centril, cramertj, joshtriplett, scottmcm. I have not included them in "lang-shepherds alumni" because they are current lang team members or alumni. The precedent in https://github.com/rust-lang/prev.rust-lang.org/pull/914, https://github.com/rust-lang/prev.rust-lang.org/pull/1072, https://github.com/rust-lang/prev.rust-lang.org/pull/1176 is that when a member of lang-shepherds joins the lang team, it atomically subsumes their lang-shepherds role. Lang-shepherds is not listed on the website (because it is an archived team) but if it were, it would not make sense to list a current lang team member under lang-shepherds saying _"We also want to thank all past members for their invaluable contributions"_ when that person is effectively still performing a superset of that role.

**`reference`**
https://github.com/rust-lang/team/pull/307

**`lang`**
https://github.com/rust-lang/prev.rust-lang.org/pull/414

**`style`**
https://github.com/rust-lang/prev.rust-lang.org/pull/523

**`opsem`**
Not touched in this PR. But I wonder if it might make sense to list members of the erstwhile wg-unsafe-code-guidelines as "alumni" of opsem. In https://github.com/rust-lang/team/pull/926, opsem subsumed wg-unsafe-code-guidelines, including renaming the <kbd>t-lang/unsafe-code-guidelines</kbd> Zulip stream to <kbd>t-opsem</kbd>. It might be fair for wg-unsafe-code-guidelines members to be listed in an alumni section on https://www.rust-lang.org/governance/teams/lang#opsem (_"We also want to thank all past members for their invaluable contributions"_). @JakobDegen? This would apply to avadacatavra, comex, nikomatsakis. The counterargument is that sometimes wg membership has been laxer than team membership, where depending on the working group (I am not familiar with this one), anyone who shows up gets their name on the roster. It's not necessarily fair to get credited with team alumni status.

**`types`**
Similar situation to opsem. When types team was created in https://github.com/rust-lang/team/pull/760, wg-traits was archived saying _"this has effectively been replaced by the types team"_ and _"we want to archive this to recognize the various people that contributed while the group was under the 'wg-traits' label"_ implying some continuity of "the group" under a different name and possibly more formalized membership process. See also https://github.com/rust-lang/team/pull/858.