### PR TITLE
Add team-admins github team

### DIFF
--- a/teams/team-repo-admins.toml
+++ b/teams/team-repo-admins.toml
@@ -1,0 +1,17 @@
+name = "team-repo-admins"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "Mark-Simulacrum",
+    "rylev",
+    "jackh726",
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "team-repo-admins"


### PR DESCRIPTION
See https://github.com/rust-lang/rust-forge/pull/707, https://github.com/rust-lang/leadership-council/issues/35 for context.

Needed to merge the forge PR (so we can link to the merged file).