### PR TITLE
Grant team-repo-admins merge permissions for team repo

### DIFF
--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -6,6 +6,7 @@ bots = []
 [access.teams]
 core = "admin"
 mods = "maintain"
+team-repo-admins = "write"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
The team-repo-admins team was created to formalize who should have merge permissions to the team repo. See [rust-lang/team#1145] for details.

[rust-lang/team#1145]: https://github.com/rust-lang/team/pull/1145