### PR TITLE
Add Rust blog repository to automation

### DIFF
--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "blog.rust-lang.org"
+description = "Home of the Rust and Inside Rust blogs"
+bots = []
+
+[access.teams]
+inside-rust-reviewers = "write"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
I'm not sure who should have merge rights (CC @Mark-Simulacrum), so the team list is empty currently.