### PR TITLE
Replace deprecated `failure` crate with `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -45,6 +45,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,9 +72,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -306,28 +315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "h2"
@@ -664,9 +651,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -713,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
@@ -964,13 +951,13 @@ name = "rust-team"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
+ "anyhow",
  "atty",
  "base64",
  "dialoguer",
  "difference",
  "duct",
  "env_logger",
- "failure",
  "indexmap",
  "log",
  "rayon",
@@ -998,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "ryu"
@@ -1176,18 +1163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,12 +1330,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Alex Crichton <alex@alexcrichton.com>", "Pietro Albini <pietro@pietr
 edition = '2018'
 
 [dependencies]
+anyhow = { version = "1", features = ["backtrace"] }
 base64 = "0.13.0"
 dialoguer = "0.10.1"
 env_logger = { version = "0.9.0", default-features = false }
-failure = "0.1"
 indexmap = "1.0.2"
 log = "0.4"
 rayon = "1.5"

--- a/src/check_synced.rs
+++ b/src/check_synced.rs
@@ -8,13 +8,13 @@ use log::{error, warn};
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 
-pub(crate) fn check(data: &Data) -> Result<(), failure::Error> {
+pub(crate) fn check(data: &Data) -> anyhow::Result<()> {
     check_github(data)?;
     check_zulip(data)?;
     Ok(())
 }
 
-fn check_zulip(data: &Data) -> Result<(), failure::Error> {
+fn check_zulip(data: &Data) -> anyhow::Result<()> {
     let zulip = ZulipApi::new();
     zulip.require_auth()?;
     let mut remote_groups = zulip
@@ -78,7 +78,7 @@ fn check_zulip(data: &Data) -> Result<(), failure::Error> {
     Ok(())
 }
 
-pub(crate) fn check_github(data: &Data) -> Result<(), failure::Error> {
+pub(crate) fn check_github(data: &Data) -> anyhow::Result<()> {
     const BOT_TEAMS: &[&str] = &["bors", "bots", "rfcbot", "highfive"];
     let github = GitHubApi::new();
     let pending_invites = github.pending_org_invites()?;
@@ -90,7 +90,7 @@ pub(crate) fn check_github(data: &Data) -> Result<(), failure::Error> {
             let members = github.team_members(team.id)?;
             Ok((team.name.clone(), (team, members)))
         })
-        .collect::<Result<HashMap<_, _>, failure::Error>>()?;
+        .collect::<anyhow::Result<HashMap<_, _>>>()?;
 
     for team in data.teams() {
         let local_teams = team.github_teams(data)?;

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,5 +1,5 @@
 use crate::schema::{Config, List, Person, Repo, Team, ZulipGroup};
-use failure::{bail, Error, ResultExt};
+use anyhow::{bail, Context as _, Error};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
@@ -65,9 +65,9 @@ impl Data {
         F: Fn(&mut Self, &str, T) -> Result<(), Error>,
         F: Clone,
     {
-        for entry in std::fs::read_dir(&dir).with_context(|e| {
+        for entry in std::fs::read_dir(&dir).with_context(|| {
             let dir = dir.as_ref().display();
-            format!("`load_dir` failed to read directory '{}': {}", dir, e)
+            format!("`load_dir` failed to read directory '{}'", dir)
         })? {
             let path = entry?.path();
             if nested && path.is_dir() {
@@ -168,8 +168,8 @@ impl Data {
 
 fn load_file<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, Error> {
     let content =
-        std::fs::read(path).with_context(|_| format!("failed to read {}", path.display()))?;
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
     let parsed = toml::from_slice(&content)
-        .with_context(|_| format!("failed to parse {}", path.display()))?;
+        .with_context(|| format!("failed to parse {}", path.display()))?;
     Ok(parsed)
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,4 +1,4 @@
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use reqwest::blocking::{Client, ClientBuilder, RequestBuilder};
 use reqwest::header::{self, HeaderValue};
 use reqwest::Method;

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,6 +1,6 @@
 use crate::data::Data;
 use crate::schema::{Config, Person};
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use std::collections::{HashMap, HashSet};
 
 #[derive(serde_derive::Deserialize, Debug, Clone, Default)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::data::Data;
 pub(crate) use crate::permissions::Permissions;
-use failure::{bail, err_msg, Error};
+use anyhow::{bail, format_err, Error};
 use std::collections::{HashMap, HashSet};
 
 #[derive(serde_derive::Deserialize, Debug)]
@@ -235,11 +235,11 @@ impl Team {
 
         for team in &self.people.included_teams {
             let team = data.team(team).ok_or_else(|| {
-                err_msg(format!(
+                format_err!(
                     "team '{}' includes members from non-existent team '{}'",
                     self.name(),
                     team
-                ))
+                )
             })?;
             members.extend(team.members(data)?);
         }
@@ -319,14 +319,14 @@ impl Team {
             for team in &raw_list.extra_teams {
                 let team = data
                     .team(team)
-                    .ok_or_else(|| err_msg(format!("team {} is missing", team)))?;
+                    .ok_or_else(|| format_err!("team {} is missing", team))?;
                 members.extend(team.members(data)?);
             }
 
             for member in members.iter() {
                 let member = data
                     .person(member)
-                    .ok_or_else(|| err_msg(format!("member {} is missing", member)))?;
+                    .ok_or_else(|| format_err!("member {} is missing", member))?;
                 if let Email::Present(email) = member.email() {
                     list.emails.push(email.to_string());
                 }
@@ -365,7 +365,7 @@ impl Team {
             for team in &raw_group.extra_teams {
                 let team = data
                     .team(team)
-                    .ok_or_else(|| err_msg(format!("team {} is missing", team)))?;
+                    .ok_or_else(|| format_err!("team {} is missing", team))?;
                 members.extend(team.members(data)?);
             }
             for excluded in &raw_group.excluded_people {
@@ -376,7 +376,7 @@ impl Team {
 
             for member in members.iter() {
                 let member = data.person(member).ok_or_else(|| {
-                    err_msg(format!("{} does not have a person configuration", member))
+                    format_err!("{} does not have a person configuration", member)
                 })?;
                 let member = match (member.github.clone(), member.zulip_id) {
                     (github, Some(zulip_id)) => ZulipGroupMember::MemberWithId { github, zulip_id },
@@ -411,7 +411,7 @@ impl Team {
             for team in &github.extra_teams {
                 members.extend(
                     data.team(team)
-                        .ok_or_else(|| failure::err_msg(format!("missing team {}", team)))?
+                        .ok_or_else(|| format_err!("missing team {}", team))?
                         .members(data)?
                         .iter()
                         .filter_map(|name| data.person(name).map(|p| (p.github(), p.github_id()))),

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -1,6 +1,6 @@
 use crate::data::Data;
 use crate::schema::{Bot, Email, Permissions, RepoPermission, TeamKind, ZulipGroupMember};
-use failure::Error;
+use anyhow::Error;
 use indexmap::IndexMap;
 use log::info;
 use rust_team_data::v1;

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2,7 +2,7 @@ use crate::data::Data;
 use crate::github::GitHubApi;
 use crate::schema::{Email, Permissions, Team, TeamKind, ZulipGroupMember};
 use crate::zulip::ZulipApi;
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use log::{error, warn};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use reqwest::blocking::{Client, ClientBuilder, Response};
 use reqwest::Method;
 use serde::Deserialize;

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -1,5 +1,5 @@
+use anyhow::{bail, Error};
 use duct::{cmd, Expression};
-use failure::Error;
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -112,7 +112,7 @@ impl ExpressionExt for Expression {
         print!("{}", String::from_utf8_lossy(&res.stdout));
 
         if !res.status.success() {
-            failure::bail!("command returned a non-zero exit code!");
+            bail!("command returned a non-zero exit code!");
         }
         Ok(())
     }


### PR DESCRIPTION
`failure` is risky to use in modern code because its formatting macros are not compatible with https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html.

```rust
fn main() {
    if let Err(err) = do_main() {
        eprintln!("{}", err);
    }
}

fn do_main() -> Result<(), failure::Error> {
    let person = "dtolnay";
    failure::bail!("person {person}");
    Ok(())
}
```

Output:

```console
person {person}
```