### PR TITLE
Make alumni field non-optional

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -52,6 +52,10 @@ members = [
 ]
 # Past members of the team. They will not be considered as part of the team,
 # but they will be recognized on the website.
+#
+# Most teams are required to have this alumni key, even if its value is an empty
+# array. It is only optional in teams with kind="marker-team", and in teams
+# which comprise only members of other teams via include-team-leads or similar.
 alumni = [
     "buildbot",
 ]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -230,6 +230,11 @@ impl Team {
         self.discord_roles.as_ref()
     }
 
+    /// Exposed only for validation.
+    pub(crate) fn raw_people(&self) -> &TeamPeople {
+        &self.people
+    }
+
     pub(crate) fn members<'a>(&'a self, data: &'a Data) -> Result<HashSet<&'a str>, Error> {
         let mut members: HashSet<_> = self.people.members.iter().map(|s| s.as_str()).collect();
 
@@ -288,7 +293,7 @@ impl Team {
     }
 
     pub(crate) fn alumni(&self) -> &[String] {
-        &self.people.alumni
+        self.people.alumni.as_ref().map_or(&[], Vec::as_slice)
     }
 
     pub(crate) fn raw_lists(&self) -> &[TeamList] {
@@ -498,23 +503,22 @@ impl std::cmp::Ord for GitHubTeam<'_> {
 
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-struct TeamPeople {
-    leads: Vec<String>,
-    members: Vec<String>,
+pub(crate) struct TeamPeople {
+    pub leads: Vec<String>,
+    pub members: Vec<String>,
+    pub alumni: Option<Vec<String>>,
     #[serde(default)]
-    alumni: Vec<String>,
-    #[serde(default)]
-    included_teams: Vec<String>,
+    pub included_teams: Vec<String>,
     #[serde(default = "default_false")]
-    include_team_leads: bool,
+    pub include_team_leads: bool,
     #[serde(default = "default_false")]
-    include_wg_leads: bool,
+    pub include_wg_leads: bool,
     #[serde(default = "default_false")]
-    include_project_group_leads: bool,
+    pub include_project_group_leads: bool,
     #[serde(default = "default_false")]
-    include_all_team_members: bool,
+    pub include_all_team_members: bool,
     #[serde(default = "default_false")]
-    include_all_alumni: bool,
+    pub include_all_alumni: bool,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/teams/community-ctcft.toml
+++ b/teams/community-ctcft.toml
@@ -12,6 +12,7 @@ members = [
     "technetos",
     "yaahc",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/crate-maintainers.toml
+++ b/teams/crate-maintainers.toml
@@ -14,6 +14,7 @@ members = [
   "ChrisDenton",
   "Byron",
 ]
+alumni = []
 
 [permissions]
 bors.libc.review = true

--- a/teams/docs-rs-reviewers.toml
+++ b/teams/docs-rs-reviewers.toml
@@ -8,6 +8,7 @@ members = [
     "Nemo157",
     "syphar",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/infra-bors.toml
+++ b/teams/infra-bors.toml
@@ -8,6 +8,7 @@ members = [
     "pietroalbini",
     "Kobzol",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -13,6 +13,7 @@ members = [
     "Mark-Simulacrum",
     "wesleywiser",
 ]
+alumni = []
 
 # Granting these permissions because an advisor can use these to help when
 # reviewing a proposed change.

--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -16,6 +16,7 @@ members = [
   "sunfishcode",
   "yaahc",
 ]
+alumni = []
 
 [permissions]
 bors.rust.review = true

--- a/teams/project-async-crashdump-debugging.toml
+++ b/teams/project-async-crashdump-debugging.toml
@@ -9,6 +9,7 @@ leads = [
 members = [
     "michaelwoerister",
 ]
+alumni = []
 
 [website]
 name = "Async Crashdump Debugging Initiative"

--- a/teams/project-dyn-upcasting.toml
+++ b/teams/project-dyn-upcasting.toml
@@ -10,6 +10,7 @@ members = [
     "crlf0710",
     "nikomatsakis",
 ]
+alumni = []
 
 [website]
 name = "Dyn Upcasting Initiative"

--- a/teams/project-edition-2021.toml
+++ b/teams/project-edition-2021.toml
@@ -12,6 +12,7 @@ members = [
     "m-ou-se",
     "rylev"
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/project-edition-2024.toml
+++ b/teams/project-edition-2024.toml
@@ -12,6 +12,7 @@ members = [
     "ehuss",
     "m-ou-se",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/project-error-handling.toml
+++ b/teams/project-error-handling.toml
@@ -13,6 +13,7 @@ members = [
     "mystor",
     "senyosimpson",
 ]
+alumni = []
 
 [website]
 name = "Error Handling Project Group"

--- a/teams/project-exploit-mitigations.toml
+++ b/teams/project-exploit-mitigations.toml
@@ -10,6 +10,7 @@ members = [
     "cuviper",
     "rcvalle",
 ]
+alumni = []
 
 [website]
 name = "Exploit Mitigations Project Group"

--- a/teams/project-generic-associated-types.toml
+++ b/teams/project-generic-associated-types.toml
@@ -10,6 +10,7 @@ members = [
     "jackh726",
     "nikomatsakis",
 ]
+alumni = []
 
 [website]
 name = "Generic Associated Types Initiative"

--- a/teams/project-impl-trait.toml
+++ b/teams/project-impl-trait.toml
@@ -10,6 +10,7 @@ members = [
     "nikomatsakis",
     "oli-obk",
 ]
+alumni = []
 
 [website]
 name = "Impl Trait Initiative"

--- a/teams/project-keyword-generics.toml
+++ b/teams/project-keyword-generics.toml
@@ -13,6 +13,7 @@ members = [
     "yoshuawuyts",
     "lcnr",
 ]
+alumni = []
 
 [website]
 name = "Keyword Generics Initiative"

--- a/teams/project-negative-impls.toml
+++ b/teams/project-negative-impls.toml
@@ -12,6 +12,7 @@ members = [
     "pnkfelix",
     "spastorino",
 ]
+alumni = []
 
 [website]
 name = "Negative Impls Initiative"

--- a/teams/project-stable-mir.toml
+++ b/teams/project-stable-mir.toml
@@ -14,6 +14,7 @@ members = [
     "ouz-a",
     "spastorino"
 ]
+alumni = []
 
 [website]
 name = "Stable MIR Project Group"

--- a/teams/project-thir-unsafeck.toml
+++ b/teams/project-thir-unsafeck.toml
@@ -5,6 +5,7 @@ subteam-of = "compiler"
 [people]
 leads = ["nikomatsakis"]
 members = ["nikomatsakis"]
+alumni = []
 
 [website]
 name = "THIR Unsafety Checker Project Group"

--- a/teams/project-trait-system-refactor.toml
+++ b/teams/project-trait-system-refactor.toml
@@ -15,6 +15,7 @@ members = [
     "spastorino",
     "lcnr",
 ]
+alumni = []
 
 [website]
 name = "Rustc Trait System Refactor Initiative"

--- a/teams/regex.toml
+++ b/teams/regex.toml
@@ -4,6 +4,7 @@ subteam-of = "libs"
 [people]
 leads = ["BurntSushi"]
 members = ["BurntSushi"]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/rustdoc-contributors.toml
+++ b/teams/rustdoc-contributors.toml
@@ -6,6 +6,7 @@ leads = []
 members = [
     "fmease"
 ]
+alumni = []
 
 [permissions]
 bors.rust.review = true

--- a/teams/social-media.toml
+++ b/teams/social-media.toml
@@ -4,6 +4,7 @@ subteam-of = "leadership-council"
 [people]
 leads = ["m-ou-se"]
 members = ["m-ou-se"]
+alumni = []
 
 [[lists]]
 address = "social@rust-lang.org"

--- a/teams/testing-devex.toml
+++ b/teams/testing-devex.toml
@@ -10,6 +10,7 @@ members = [
     "thomcc",
     "weihanglo",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/triagebot.toml
+++ b/teams/triagebot.toml
@@ -8,6 +8,7 @@ members = [
     "ehuss",
     "spastorino",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/twir-reviewers.toml
+++ b/teams/twir-reviewers.toml
@@ -13,6 +13,7 @@ members = [
     "mariannegoldin",
     "U007D"
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/web-presence.toml
+++ b/teams/web-presence.toml
@@ -3,6 +3,7 @@ name = "web-presence"
 [people]
 leads = []
 members = []
+alumni = []
 
 [[lists]]
 address = "web-presence@rust-lang.org"

--- a/teams/wg-allocators.toml
+++ b/teams/wg-allocators.toml
@@ -14,6 +14,7 @@ members = [
     "TimDiekmann",
     "Wodann"
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-bindgen.toml
+++ b/teams/wg-bindgen.toml
@@ -8,6 +8,7 @@ members = [
     "emilio",
     "fitzgen",
 ]
+alumni = []
 
 [website]
 name = "Bindgen working group"

--- a/teams/wg-compiler-performance.toml
+++ b/teams/wg-compiler-performance.toml
@@ -15,6 +15,7 @@ members = [
     "lqd",
     "nnethercote",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-diagnostics.toml
+++ b/teams/wg-diagnostics.toml
@@ -12,6 +12,7 @@ members = [
   "estebank",
   "oli-obk",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-embedded-core.toml
+++ b/teams/wg-embedded-core.toml
@@ -8,6 +8,7 @@ members = [
     "adamgreig",
     "therealprof",
 ]
+alumni = []
 
 [website]
 name = "Embedded core team"

--- a/teams/wg-embedded-cortex-a.toml
+++ b/teams/wg-embedded-cortex-a.toml
@@ -8,6 +8,7 @@ members = [
     "raw-bin",
     "andre-richter",
 ]
+alumni = []
 
 [website]
 name = "Embedded Cortex-A team"

--- a/teams/wg-embedded-cortex-m.toml
+++ b/teams/wg-embedded-cortex-m.toml
@@ -11,6 +11,7 @@ members = [
     "thalesfragoso",
     "newAM",
 ]
+alumni = []
 
 [website]
 name = "Embedded Cortex-M team"

--- a/teams/wg-embedded-cortex-r.toml
+++ b/teams/wg-embedded-cortex-r.toml
@@ -4,8 +4,8 @@ kind = "working-group"
 
 [people]
 leads = []
-members = [
-]
+members = []
+alumni = []
 
 [website]
 name = "Embedded Cortex-R team"

--- a/teams/wg-embedded-hal.toml
+++ b/teams/wg-embedded-hal.toml
@@ -11,6 +11,7 @@ members = [
     "therealprof",
     "MabezDev"
 ]
+alumni = []
 
 [website]
 name = "Embedded HAL team"

--- a/teams/wg-embedded-infra.toml
+++ b/teams/wg-embedded-infra.toml
@@ -8,6 +8,7 @@ members = [
     "ryankurte",
     "nastevens",
 ]
+alumni = []
 
 [website]
 name = "Embedded infrastructure team"

--- a/teams/wg-embedded-linux.toml
+++ b/teams/wg-embedded-linux.toml
@@ -10,6 +10,7 @@ members = [
     "posborne",
     "ryankurte",
 ]
+alumni = []
 
 [website]
 name = "Embedded Linux team"

--- a/teams/wg-embedded-msp430.toml
+++ b/teams/wg-embedded-msp430.toml
@@ -8,6 +8,7 @@ members = [
     "cr1901",
     "YuhanLiin",
 ]
+alumni = []
 
 [website]
 name = "Embedded MSP430 team"

--- a/teams/wg-embedded-resources.toml
+++ b/teams/wg-embedded-resources.toml
@@ -12,6 +12,7 @@ members = [
     "jamesmunns",
     "therealprof",
 ]
+alumni = []
 
 [website]
 name = "Embedded resources working group"

--- a/teams/wg-embedded-riscv.toml
+++ b/teams/wg-embedded-riscv.toml
@@ -11,6 +11,7 @@ members = [
     "MabezDev",
     "jessebraham",
 ]
+alumni = []
 
 [website]
 name = "Embedded RISC-V team"

--- a/teams/wg-embedded-tools.toml
+++ b/teams/wg-embedded-tools.toml
@@ -14,6 +14,7 @@ members = [
     "therealprof",
     "jonathanpallant",
 ]
+alumni = []
 
 [website]
 name = "Embedded Tools Team"

--- a/teams/wg-embedded-triage.toml
+++ b/teams/wg-embedded-triage.toml
@@ -8,6 +8,7 @@ members = [
     "mathk",
     "jessebraham",
 ]
+alumni = []
 
 [website]
 name = "Embedded Triage Team"

--- a/teams/wg-gamedev.toml
+++ b/teams/wg-gamedev.toml
@@ -18,6 +18,7 @@ members = [
     "repi",
     "Wodann"
 ]
+alumni = []
 
 [website]
 page = "gamedev"

--- a/teams/wg-llvm.toml
+++ b/teams/wg-llvm.toml
@@ -9,6 +9,7 @@ members = [
     "nikic",
     "cuviper",
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-pgo.toml
+++ b/teams/wg-pgo.toml
@@ -5,6 +5,7 @@ kind = "working-group"
 [people]
 leads = ["michaelwoerister"]
 members = ["michaelwoerister"]
+alumni = []
 
 [website]
 name = "Profile-guided optimization working group"

--- a/teams/wg-polonius.toml
+++ b/teams/wg-polonius.toml
@@ -6,6 +6,7 @@ kind = "working-group"
 [people]
 leads = ["lqd", "nikomatsakis"]
 members = ["lqd", "nikomatsakis", "amandasystems", "matthewjasper", "ecstatic-morse"]
+alumni = []
 
 [website]
 name = "Polonius working group"

--- a/teams/wg-polymorphization.toml
+++ b/teams/wg-polymorphization.toml
@@ -5,6 +5,7 @@ kind = "working-group"
 [people]
 leads = ["davidtwco"]
 members = ["davidtwco", "eddyb", "lcnr"]
+alumni = []
 
 [website]
 name = "Polymorphization working group"

--- a/teams/wg-rfc-2229.toml
+++ b/teams/wg-rfc-2229.toml
@@ -15,6 +15,7 @@ members = [
         "null-sleep",
         "roxelo"
 ]
+alumni = []
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/wg-rustc-reading-club.toml
+++ b/teams/wg-rustc-reading-club.toml
@@ -5,6 +5,7 @@ kind = "working-group"
 [people]
 leads = ["nikomatsakis", "doc-jones"]
 members = ["doc-jones", "nikomatsakis"]
+alumni = []
 
 [website]
 name = "Rust Code Reading Club working group"

--- a/teams/wg-self-profile.toml
+++ b/teams/wg-self-profile.toml
@@ -5,6 +5,7 @@ kind = "working-group"
 [people]
 leads = ["michaelwoerister", "wesleywiser"]
 members = ["michaelwoerister", "wesleywiser"]
+alumni = []
 
 [permissions]
 perf = true

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -21,6 +21,7 @@ members = [
     "KittyBorgX",
     "Enselic",
 ]
+alumni = []
 
 [website]
 name = "Triage working group"

--- a/tests/static-api/teams/foo.toml
+++ b/tests/static-api/teams/foo.toml
@@ -3,6 +3,7 @@ name = "foo"
 [people]
 leads = ["user-0"]
 members = ["user-0", "user-1"]
+alumni = []
 
 [permissions]
 crater = true

--- a/tests/static-api/teams/leaderless.toml
+++ b/tests/static-api/teams/leaderless.toml
@@ -3,3 +3,4 @@ name = "leaderless"
 [people]
 leads = []
 members = ["user-0"]
+alumni = []

--- a/tests/static-api/teams/leads-permissions.toml
+++ b/tests/static-api/teams/leads-permissions.toml
@@ -3,6 +3,7 @@ name = "leads-permissions"
 [people]
 leads = ["user-6"]
 members = ["user-3", "user-4", "user-6"]
+alumni = []
 
 [leads-permissions]
 bors.crates-io.review = true


### PR DESCRIPTION
```rust
// Teams must contain an `alumni = […]` field (even if empty) so that there
// is an obvious place to move contributors within the same file when
// removing from `members`.
//
// Marker teams are exempt from this, as well as teams which comprise only
// members of other teams via `include-team-leads` or similar; they do not
// need `alumni = […]`. For these teams, the correct place to put alumni is
// in the same team they're being included from.
```