### PR TITLE
Add support for custom roles in website, beyond "Team leader"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d05712b2d8d88102bc9868020c9e5c7a1f5527c452b9b97450a1d006140ba7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,18 +871,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -993,6 +1002,7 @@ dependencies = [
  "reqwest",
  "rust_team_data",
  "serde",
+ "serde-untagged",
  "serde_derive",
  "serde_json",
  "structopt",
@@ -1073,22 +1083,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.193"
+name = "serde-untagged"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "6a160535368dfc353348e7eaa299156bd508c60c45a9249725f5f6d370d82a66"
+dependencies = [
+ "erased-serde",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -1201,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "1726efe18f42ae774cc644f330953a5e7b3c3003d3edcecf18850fe9d4dd9afb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust_team_data = { path = "rust_team_data", features = ["email-encryption"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+serde-untagged = "0.1"
 structopt = "0.3.26"
 toml = "0.8"
 

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -49,6 +49,12 @@ members = [
     "rfcbot",
     "craterbot",
     "rust-timer",
+    # Any subset of members may hold custom roles, beyond "Team leader" which is
+    # controlled by the `leads` array above. See [[website.roles]]. Members with
+    # roles are written using an inline table as follows. A simple string member
+    # like "bors" is equivalent to {name = "bors", roles = []}.
+    { name = "Crab01", roles = ["cohost"] },
+    { name = "Crab02", roles = ["cohost"] },
 ]
 # Past members of the team. They will not be considered as part of the team,
 # but they will be recognized on the website.
@@ -140,10 +146,6 @@ weight = -100
 id = "cohost"
 # Text to appear on the website beneath the team member's name and GitHub handle.
 description = "Co-host"
-# Subset of the team's members holding this role. A member may hold arbitrarily
-# many roles. Each team member's roles will appear comma-separated in the same
-# order as roles are listed in the website.roles array.
-members = ["Crab01", "Crab03"]
 
 # Define the mailing lists used by the team
 # It's optional, and there can be more than one

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -133,6 +133,18 @@ zulip-stream = "t-lang"
 # Default is 0.
 weight = -100
 
+# Customized roles held by a subset of the team's members, beyond "Team leader"
+# which is rendered automatically for members of the `leads` array.
+[[website.roles]]
+# Kebab-case id for the role. This serves as a key for translations.
+id = "cohost"
+# Text to appear on the website beneath the team member's name and GitHub handle.
+description = "Co-host"
+# Subset of the team's members holding this role. A member may hold arbitrarily
+# many roles. Each team member's roles will appear comma-separated in the same
+# order as roles are listed in the website.roles array.
+members = ["Crab01", "Crab03"]
+
 # Define the mailing lists used by the team
 # It's optional, and there can be more than one
 [[lists]]

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -50,11 +50,12 @@ members = [
     "craterbot",
     "rust-timer",
     # Any subset of members may hold custom roles, beyond "Team leader" which is
-    # controlled by the `leads` array above. See [[website.roles]]. Members with
-    # roles are written using an inline table as follows. A simple string member
-    # like "bors" is equivalent to {name = "bors", roles = []}.
-    { name = "Crab01", roles = ["cohost"] },
-    { name = "Crab02", roles = ["cohost"] },
+    # controlled by the `leads` array above. Members with roles are written
+    # using an inline table as follows. A simple string member like "bors" is
+    # equivalent to {github = "bors", roles = []}. The strings in `roles` must
+    # be present as the `id` of some role in [[roles]] section below.
+    { github = "Crab01", roles = ["cohost"] },
+    { github = "Crab02", roles = ["cohost"] },
 ]
 # Past members of the team. They will not be considered as part of the team,
 # but they will be recognized on the website.
@@ -141,7 +142,7 @@ weight = -100
 
 # Customized roles held by a subset of the team's members, beyond "Team leader"
 # which is rendered automatically for members of the `leads` array.
-[[website.roles]]
+[[roles]]
 # Kebab-case id for the role. This serves as a key for translations.
 id = "cohost"
 # Text to appear on the website beneath the team member's name and GitHub handle.

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -32,6 +32,8 @@ pub struct TeamMember {
     pub github: String,
     pub github_id: usize,
     pub is_lead: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,9 +393,9 @@ fn run() -> Result<(), Error> {
                         name,
                         website.description()
                     );
-                    for role in website.roles() {
-                        roles.insert(&role.id, &role.description);
-                    }
+                }
+                for role in team.roles() {
+                    roles.insert(&role.id, &role.description);
                 }
             }
             for (role_id, description) in roles {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ use schema::{Email, Team, TeamKind};
 
 use anyhow::{bail, format_err, Error};
 use log::{error, info, warn};
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(structopt::StructOpt)]
@@ -382,6 +383,7 @@ fn run() -> Result<(), Error> {
             );
             let mut teams: Vec<_> = data.teams().collect();
             teams.sort_by_key(|team| team.name());
+            let mut roles = BTreeMap::new();
             for team in teams {
                 if let Some(website) = team.website_data() {
                     let name = team.name();
@@ -391,7 +393,13 @@ fn run() -> Result<(), Error> {
                         name,
                         website.description()
                     );
+                    for role in website.roles() {
+                        roles.insert(&role.id, &role.description);
+                    }
                 }
+            }
+            for (role_id, description) in roles {
+                println!("governance-role-{role_id} = {description}");
             }
         }
         Cli::DumpPermission { ref name } => {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -551,6 +551,8 @@ pub(crate) struct WebsiteData {
     name: String,
     description: String,
     page: Option<String>,
+    #[serde(default)]
+    roles: Vec<WebsiteRole>,
     email: Option<String>,
     repo: Option<String>,
     discord_invite: Option<String>,
@@ -577,6 +579,10 @@ impl WebsiteData {
         self.page.as_deref()
     }
 
+    pub(crate) fn roles(&self) -> &[WebsiteRole] {
+        &self.roles
+    }
+
     pub(crate) fn email(&self) -> Option<&str> {
         self.email.as_deref()
     }
@@ -599,6 +605,14 @@ impl WebsiteData {
     pub(crate) fn zulip_stream(&self) -> Option<&str> {
         self.zulip_stream.as_deref()
     }
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WebsiteRole {
+    pub id: String,
+    pub description: String,
+    pub members: Vec<String>,
 }
 
 #[derive(serde_derive::Deserialize, Debug)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -236,7 +236,12 @@ impl Team {
     }
 
     pub(crate) fn members<'a>(&'a self, data: &'a Data) -> Result<HashSet<&'a str>, Error> {
-        let mut members: HashSet<_> = self.people.members.iter().map(|s| s.as_str()).collect();
+        let mut members: HashSet<_> = self
+            .people
+            .members
+            .iter()
+            .map(|s| s.github.as_str())
+            .collect();
 
         for team in &self.people.included_teams {
             let team = data.team(team).ok_or_else(|| {
@@ -450,7 +455,7 @@ impl Team {
     }
 
     // People explicitly set as members
-    pub(crate) fn explicit_members(&self) -> &Vec<String> {
+    pub(crate) fn explicit_members(&self) -> &[TeamMember] {
         &self.people.members
     }
 
@@ -505,7 +510,7 @@ impl std::cmp::Ord for GitHubTeam<'_> {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub(crate) struct TeamPeople {
     pub leads: Vec<String>,
-    pub members: Vec<String>,
+    pub members: Vec<TeamMember>,
     pub alumni: Option<Vec<String>>,
     #[serde(default)]
     pub included_teams: Vec<String>,
@@ -519,6 +524,12 @@ pub(crate) struct TeamPeople {
     pub include_all_team_members: bool,
     #[serde(default = "default_false")]
     pub include_all_alumni: bool,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(transparent)]
+pub(crate) struct TeamMember {
+    pub github: String,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -167,6 +167,8 @@ pub(crate) struct Team {
     rfcbot: Option<RfcbotData>,
     website: Option<WebsiteData>,
     #[serde(default)]
+    roles: Vec<MemberRole>,
+    #[serde(default)]
     lists: Vec<TeamList>,
     #[serde(default)]
     zulip_groups: Vec<RawZulipGroup>,
@@ -226,6 +228,10 @@ impl Team {
 
     pub(crate) fn website_data(&self) -> Option<&WebsiteData> {
         self.website.as_ref()
+    }
+
+    pub(crate) fn roles(&self) -> &[MemberRole] {
+        &self.roles
     }
 
     pub(crate) fn discord_roles(&self) -> Option<&Vec<DiscordRole>> {
@@ -529,9 +535,8 @@ pub(crate) struct TeamPeople {
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]
-#[serde(remote = "Self")]
+#[serde(remote = "Self", deny_unknown_fields)]
 pub(crate) struct TeamMember {
-    #[serde(rename = "name")]
     pub github: String,
     pub roles: Vec<String>,
 }
@@ -586,8 +591,6 @@ pub(crate) struct WebsiteData {
     name: String,
     description: String,
     page: Option<String>,
-    #[serde(default)]
-    roles: Vec<WebsiteRole>,
     email: Option<String>,
     repo: Option<String>,
     discord_invite: Option<String>,
@@ -612,10 +615,6 @@ impl WebsiteData {
 
     pub(crate) fn page(&self) -> Option<&str> {
         self.page.as_deref()
-    }
-
-    pub(crate) fn roles(&self) -> &[WebsiteRole] {
-        &self.roles
     }
 
     pub(crate) fn email(&self) -> Option<&str> {
@@ -644,7 +643,7 @@ impl WebsiteData {
 
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct WebsiteRole {
+pub(crate) struct MemberRole {
     pub id: String,
     pub description: String,
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -128,9 +128,7 @@ impl<'a> Generator<'a> {
                         github: (*github_name).into(),
                         github_id: person.github_id(),
                         is_lead: leads.contains(github_name),
-                        roles: website_roles
-                            .get(*github_name)
-                            .map_or_else(Vec::new, Vec::clone),
+                        roles: website_roles.get(*github_name).cloned().unwrap_or_default(),
                     });
                 }
             }

--- a/teams/spec.toml
+++ b/teams/spec.toml
@@ -6,7 +6,7 @@ leads = ["pnkfelix", "m-ou-se"]
 members = [
     "pnkfelix",
     "m-ou-se",
-    "JoelMarcey",
+    { name =  "JoelMarcey", roles = ["spec-editor"] },
     "ehuss",
 ]
 alumni = []
@@ -20,7 +20,6 @@ repo = "https://github.com/rust-lang/spec"
 [[website.roles]]
 id = "spec-editor"
 description = "Editor"
-members = ["JoelMarcey"]
 
 [rfcbot]
 label = "T-spec"

--- a/teams/spec.toml
+++ b/teams/spec.toml
@@ -6,7 +6,7 @@ leads = ["pnkfelix", "m-ou-se"]
 members = [
     "pnkfelix",
     "m-ou-se",
-    { name =  "JoelMarcey", roles = ["spec-editor"] },
+    { github =  "JoelMarcey", roles = ["spec-editor"] },
     "ehuss",
 ]
 alumni = []
@@ -17,7 +17,7 @@ description = "Creating and maintaining the specification for the Rust language"
 zulip-stream = "t-spec"
 repo = "https://github.com/rust-lang/spec"
 
-[[website.roles]]
+[[roles]]
 id = "spec-editor"
 description = "Editor"
 

--- a/teams/spec.toml
+++ b/teams/spec.toml
@@ -17,6 +17,11 @@ description = "Creating and maintaining the specification for the Rust language"
 zulip-stream = "t-spec"
 repo = "https://github.com/rust-lang/spec"
 
+[[website.roles]]
+id = "spec-editor"
+description = "Editor"
+members = ["JoelMarcey"]
+
 [rfcbot]
 label = "T-spec"
 name = "Spec"


### PR DESCRIPTION
I would like to render "Editor" below @JoelMarcey's entry in https://www.rust-lang.org/governance/teams/lang#spec, in the same location that others have "Team leader".

Source: https://blog.rust-lang.org/inside-rust/2023/11/15/spec-vision.html#specification-team

Output of `cargo run -- dump-website` for translations:

```console
...
governance-team-wg-triage-name = Triage working group
governance-team-wg-triage-description = Triaging repositories under the rust-lang organisation

governance-team-wg-wasm-name = WebAssembly (WASM) working group
governance-team-wg-wasm-description = Improving on the end-to-end experience of embedding Rust code in JS libraries and apps via WebAssembly

governance-role-spec-editor = Editor
```

Output of `cargo run -- static-api` under v1/teams/spec.json:

```json
{
  "name": "spec",
  "kind": "team",
  "subteam_of": "lang",
  "members": [
    {
      "name": "Mara Bos",
      "github": "m-ou-se",
      "github_id": 783247,
      "is_lead": true
    },
    {
      "name": "Felix Klock",
      "github": "pnkfelix",
      "github_id": 173127,
      "is_lead": true
    },
    {
      "name": "Eric Huss",
      "github": "ehuss",
      "github_id": 43198,
      "is_lead": false
    },
    {
      "name": "Joel Marcey",
      "github": "JoelMarcey",
      "github_id": 3757713,
      "is_lead": false,
      "roles": [
        "spec-editor"
      ]
    }
  ],
```