### PR TITLE
Manage rust-lang/docker-rust

### DIFF
--- a/repos/rust-lang/docker-rust.toml
+++ b/repos/rust-lang/docker-rust.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "docker-rust"
+description = "The official Docker images for Rust"
+bots = []
+
+[access.teams]
+docker = "maintain"

--- a/teams/docker.toml
+++ b/teams/docker.toml
@@ -1,0 +1,12 @@
+name = "docker"
+
+[people]
+leads = []
+members = [
+    "sfackler",
+    "Muscraft",
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Managing the https://github.com/rust-lang/docker-rust repo, and adding @Muscraft and me as the initial maintainers.