### PR TITLE
Add `crates-io-admins` team

### DIFF
--- a/teams/crates-io-admins.toml
+++ b/teams/crates-io-admins.toml
@@ -1,0 +1,10 @@
+# This team is regularly synced to the crates.io database and defines who has
+# access to admin functionality on crates.io.
+
+name = "crates-io-admins"
+kind = "marker-team"
+
+[people]
+leads = []
+members = []
+included-teams = ["crates-io"]


### PR DESCRIPTION
This is a marker team that defines the group of people that are granted admin access on crates.io. Once the PR is merged we can implement a regular background job on the crates.io side that syncs the team repo into the crates.io user database.

Related:

- https://github.com/rust-lang/crates.io/pull/7852
- https://github.com/rust-lang/crates.io/pull/7858