### PR TITLE
bors: Remove `crates.io` repo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,6 @@ permissions-bors-repos = [
     "clippy",
     "compiler-builtins",
     "crater",
-    "crates-io",
     "hashbrown",
     "measureme",
     "miri",

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -26,9 +26,6 @@ alumni = [
     "wycats",
 ]
 
-[permissions]
-bors.crates-io.review = true
-
 [[github]]
 orgs = ["rust-lang", "conduit-rust"]
 


### PR DESCRIPTION
The crates.io team hasn't been using bors for a while now, so there is no need for this unused permission.