### PR TITLE
Remove remaining references to core

### DIFF
--- a/teams/leads.toml
+++ b/teams/leads.toml
@@ -10,4 +10,4 @@ orgs = ["rust-lang"]
 
 [[lists]]
 address = "leads@rust-lang.org"
-extra-teams = ["wg-leads", "core"]
+extra-teams = ["wg-leads", "leadership-council"]

--- a/teams/wg-leads.toml
+++ b/teams/wg-leads.toml
@@ -9,4 +9,4 @@ include-wg-leads = true
 
 [[lists]]
 address = "wg-leads@rust-lang.org"
-extra-teams = ["core"]
+extra-teams = ["leadership-council"]


### PR DESCRIPTION
This removes the last remaining references to the Core team in active teams and replaced with references to the Leadership Council where appropriate. The Core team itself still remains and will be archived in a future PR and the core team is still referenced from archived teams. 
