### PR TITLE
Archive project-edition-2021

### DIFF
--- a/teams/archive/project-edition-2021.toml
+++ b/teams/archive/project-edition-2021.toml
@@ -3,16 +3,13 @@ subteam-of = "core"
 kind = "project-group"
 
 [people]
-leads = [
-    "nikomatsakis",
-    "m-ou-se"
-]
-members = [
+leads = []
+members = []
+alumni = [
     "nikomatsakis",
     "m-ou-se",
-    "rylev"
+    "rylev",
 ]
-alumni = []
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
This group has been essentially replaced by project-edition-2024.
