### PR TITLE
Add a branch protection option to choose required approval count

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -292,4 +292,8 @@ ci-checks = ["CI"]
 # merging into this branch require another review. 
 # (optional - default `false`)
 dismiss-stale-review = false
+# How many approvals are required for a PR to be merged.
+# This option is only relevant if bors is not used.
+# (optional - default `1`)
+required-approvals = 1
 ```

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -186,6 +186,7 @@ pub struct BranchProtection {
     pub pattern: String,
     pub ci_checks: Vec<String>,
     pub dismiss_stale_review: bool,
+    pub required_approvals: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -733,4 +733,6 @@ pub(crate) struct BranchProtection {
     pub ci_checks: Vec<String>,
     #[serde(default)]
     pub dismiss_stale_review: bool,
+    #[serde(default)]
+    pub required_approvals: Option<u32>,
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -43,6 +43,7 @@ impl<'a> Generator<'a> {
                     pattern: b.pattern.clone(),
                     ci_checks: b.ci_checks.clone(),
                     dismiss_stale_review: b.dismiss_stale_review,
+                    required_approvals: b.required_approvals.unwrap_or(1),
                 })
                 .collect();
             let repo = v1::Repo {

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -18,7 +18,8 @@
           "ci_checks": [
             "CI"
           ],
-          "dismiss_stale_review": false
+          "dismiss_stale_review": false,
+          "required_approvals": 1
         }
       ]
     }

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -16,7 +16,8 @@
       "ci_checks": [
         "CI"
       ],
-      "dismiss_stale_review": false
+      "dismiss_stale_review": false,
+      "required_approvals": 1
     }
   ]
 }


### PR DESCRIPTION
Before this PR, the default value was implicitly 0 if bors is used or 1 if bors isn't used. However, for some repositories it's enough to require PRs, but approvals are not needed. Setting `required-approvals = 0` will allow that (once it's implemented in `sync-team`).

r? @Mark-Simulacrum :)