### PR TITLE
Add support for repo archiving

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -165,6 +165,7 @@ pub struct Repo {
     pub teams: Vec<RepoTeam>,
     pub members: Vec<RepoMember>,
     pub branch_protections: Vec<BranchProtection>,
+    pub archived: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,7 +10,7 @@ pub(crate) struct Data {
     people: HashMap<String, Person>,
     teams: HashMap<String, Team>,
     archived_teams: Vec<Team>,
-    repos: HashMap<(String, String), Repo>,
+    repos: Vec<Repo>,
     config: Config,
 }
 
@@ -20,7 +20,7 @@ impl Data {
             people: HashMap::new(),
             teams: HashMap::new(),
             archived_teams: Vec::new(),
-            repos: HashMap::new(),
+            repos: Vec::new(),
             config: load_file(Path::new("config.toml"))?,
         };
 
@@ -41,8 +41,7 @@ impl Data {
                 )
             }
 
-            this.repos
-                .insert((repo.org.clone(), repo.name.clone()), repo);
+            this.repos.push(repo);
             Ok(())
         })?;
 
@@ -154,7 +153,7 @@ impl Data {
     }
 
     pub(crate) fn repos(&self) -> impl Iterator<Item = &Repo> {
-        self.repos.values()
+        self.repos.iter()
     }
 
     pub(crate) fn archived_teams(&self) -> impl Iterator<Item = &Team> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -27,7 +27,7 @@ impl Data {
         };
 
         fn validate_repo(org: &str, repo: &Repo, path: &Path) -> anyhow::Result<()> {
-            if &repo.org != org {
+            if repo.org != org {
                 bail!(
                     "repo '{}' is located in the '{}' org directory but its org is '{}'",
                     repo.name,
@@ -180,6 +180,10 @@ impl Data {
 
     pub(crate) fn archived_repos(&self) -> impl Iterator<Item = &Repo> {
         self.archived_repos.iter()
+    }
+
+    pub(crate) fn all_repos(&self) -> impl Iterator<Item = &Repo> {
+        self.repos().chain(self.archived_repos())
     }
 
     pub(crate) fn archived_teams(&self) -> impl Iterator<Item = &Team> {

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -36,7 +36,13 @@ impl<'a> Generator<'a> {
 
     fn generate_repos(&self) -> Result<(), Error> {
         let mut repos: IndexMap<String, Vec<v1::Repo>> = IndexMap::new();
-        for r in self.data.repos() {
+        let repo_iter = self
+            .data
+            .repos()
+            .map(|repo| (repo, false))
+            .chain(self.data.archived_repos().map(|repo| (repo, true)));
+
+        for (r, archived) in repo_iter {
             let branch_protections: Vec<_> = r
                 .branch_protections
                 .iter()
@@ -98,6 +104,7 @@ impl<'a> Generator<'a> {
                     })
                     .collect(),
                 branch_protections,
+                archived,
             };
 
             self.add(&format!("v1/repos/{}.json", r.name), &repo)?;

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -316,7 +316,7 @@ fn validate_inactive_members(data: &Data, errors: &mut Vec<String>) {
     let all_members = data.people().map(|p| p.github()).collect::<HashSet<_>>();
     // All the individual contributors to any Rust controlled repos
     let all_ics = data
-        .repos()
+        .all_repos()
         .flat_map(|r| r.access.individuals.keys())
         .map(|n| n.as_str())
         .collect::<HashSet<_>>();

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -2,6 +2,29 @@
   "test-org": [
     {
       "org": "test-org",
+      "name": "archived_repo",
+      "description": "An archived repo!",
+      "bots": [],
+      "teams": [
+        {
+          "name": "foo",
+          "permission": "admin"
+        }
+      ],
+      "members": [],
+      "branch_protections": [
+        {
+          "pattern": "master",
+          "ci_checks": [
+            "CI"
+          ],
+          "dismiss_stale_review": false
+        }
+      ],
+      "archived": true
+    },
+    {
+      "org": "test-org",
       "name": "some_repo",
       "description": "A repo!",
       "bots": [],
@@ -24,7 +47,8 @@
             "foo"
           ]
         }
-      ]
+      ],
+      "archived": false
     }
   ]
 }

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -18,7 +18,9 @@
           "ci_checks": [
             "CI"
           ],
-          "dismiss_stale_review": false
+          "dismiss_stale_review": false,
+          "required_approvals": 1,
+          "allowed_merge_teams": []
         }
       ],
       "archived": true

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -1,7 +1,7 @@
 {
   "org": "test-org",
-  "name": "some_repo",
-  "description": "A repo!",
+  "name": "archived_repo",
+  "description": "An archived repo!",
   "bots": [],
   "teams": [
     {
@@ -16,12 +16,8 @@
       "ci_checks": [
         "CI"
       ],
-      "dismiss_stale_review": false,
-      "required_approvals": 1,
-      "allowed_merge_teams": [
-        "foo"
-      ]
+      "dismiss_stale_review": false
     }
   ],
-  "archived": false
+  "archived": true
 }

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -16,7 +16,9 @@
       "ci_checks": [
         "CI"
       ],
-      "dismiss_stale_review": false
+      "dismiss_stale_review": false,
+      "required_approvals": 1,
+      "allowed_merge_teams": []
     }
   ],
   "archived": true

--- a/tests/static-api/repos/archive/test-org/archived_repo.toml
+++ b/tests/static-api/repos/archive/test-org/archived_repo.toml
@@ -1,0 +1,11 @@
+org = "test-org"
+name = "archived_repo"
+description = "An archived repo!"
+bots = []
+
+[access.teams]
+foo = "admin"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["CI"]


### PR DESCRIPTION
Archived repos are in `repos/archive`. Currently there is no validation that the repo contains no team access, I can add it if you want.