### PR TITLE
Add rustc-pr-tracking repository under automation

### DIFF
--- a/repos/rust-lang/rustc-pr-tracking.toml
+++ b/repos/rust-lang/rustc-pr-tracking.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rustc-pr-tracking"
+description = "Statistics about PRs on the rustc repository."
+bots = ["highfive"]
+
+[access.teams]
+release = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustc-pr-tracking

Configuration extracted from GitHub:
```
org = "rust-lang"
name = "rustc-pr-tracking"
description = "Statistics about PRs on the rustc repository."
bots = []

[access.teams]
security = "pull"
release = "write"

[access.individuals]
cuviper = "write"
badboy = "admin"
pietroalbini = "admin"
rust-highfive = "write"
jdno = "admin"
tmandry = "write"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
Dylan-DPC = "write"
rylev = "admin"
```