### PR TITLE
Add cargo-bisect-rustc repository under automation

### DIFF
--- a/repos/rust-lang/cargo-bisect-rustc.toml
+++ b/repos/rust-lang/cargo-bisect-rustc.toml
@@ -1,0 +1,14 @@
+org = "rust-lang"
+name = "cargo-bisect-rustc"
+description = "Bisects rustc, either nightlies or CI artifacts"
+bots = []
+
+[access.teams]
+compiler = "write"
+
+[access.individuals]
+ehuss = "write"
+
+[[branch-protections]]
+pattern = "master"
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/cargo-bisect-rustc

Configuration extracted from GitHub:
```
org = "rust-lang"
name = "cargo-bisect-rustc"
description = "Bisects rustc, either nightlies or CI artifacts"
bots = []

[access.teams]
security = "pull"
compiler = "write"

[access.individuals]
ehuss = "write"
Aaron1011 = "write"
oli-obk = "write"
rust-lang-owner = "admin"
compiler-errors = "write"
badboy = "admin"
wesleywiser = "write"
eddyb = "write"
pietroalbini = "admin"
estebank = "write"
michaelwoerister = "write"
matthewjasper = "write"
spastorino = "admin"
chrissimpkins = "write"
Mark-Simulacrum = "admin"
pnkfelix = "write"
nagisa = "write"
lcnr = "write"
rylev = "admin"
jackh726 = "write"
jdno = "admin"
petrochenkov = "write"
cjgillot = "write"
davidtwco = "write"
```