### PR TITLE
Add the possibility to mark a repository as private

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -259,6 +259,10 @@ description = "A repo for awesome things!"
 homepage = "https://www.rust-lang.org/"
 # The bots that this repo requires (required)
 bots = ["bors", "rustbot", "rust-timer"]
+# Should the repository be private? (optional - default `false`)
+# Note that this only serves for documentation purposes, it is
+# not synchronized by automation.
+private-non-synced = false
 
 # The teams that have access to this repo along
 # with the access level. (required)

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -168,6 +168,8 @@ pub struct Repo {
     pub members: Vec<RepoMember>,
     pub branch_protections: Vec<BranchProtection>,
     pub archived: bool,
+    // This attribute is not synced by sync-team.
+    pub private: bool,
     // Is the GitHub "Auto-merge" option enabled?
     // https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request
     pub auto_merge_enabled: bool,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -746,6 +746,8 @@ pub(crate) struct Repo {
     pub name: String,
     pub description: String,
     pub homepage: Option<String>,
+    #[serde(default)]
+    pub private_non_synced: Option<bool>,
     pub bots: Vec<Bot>,
     pub access: RepoAccess,
     #[serde(default)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -60,6 +60,7 @@ impl<'a> Generator<'a> {
                 name: r.name.clone(),
                 description: r.description.clone(),
                 homepage: r.homepage.clone(),
+                private: r.private_non_synced.unwrap_or(false),
                 bots: r
                     .bots
                     .iter()

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -25,6 +25,7 @@
         }
       ],
       "archived": true,
+      "private": false,
       "auto_merge_enabled": true
     },
     {
@@ -54,6 +55,7 @@
         }
       ],
       "archived": false,
+      "private": false,
       "auto_merge_enabled": true
     }
   ]

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -23,5 +23,6 @@
     }
   ],
   "archived": true,
+  "private": false,
   "auto_merge_enabled": true
 }

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -25,5 +25,6 @@
     }
   ],
   "archived": false,
+  "private": false,
   "auto_merge_enabled": true
 }


### PR DESCRIPTION
This PR adds a `private-non-synced` field to the TOML schema. It should serve for documentation purposes to mark private repositories, but it actually won't be managed by automation (`sync-team`), because the action of making a repository private is destructive.