### PR TITLE
Add project group for const traits initiative

### DIFF
--- a/teams/project-const-traits.toml
+++ b/teams/project-const-traits.toml
@@ -1,0 +1,16 @@
+name = "project-const-traits"
+kind = "project-group"
+subteam-of = "compiler"
+
+[people]
+leads = [
+    "fee1-dead",
+]
+members = [
+    "compiler-errors",
+    "fee1-dead",
+    "fmease",
+    "oli-obk",
+]
+alumni = []
+


### PR DESCRIPTION
This PR adds a project group for the "const traits" initiative.

@fee1-dead and a few others have gathered around an effort to enable const traits in the language (rust-lang/rfcs#2632). The RFC never landed, but work has been under experimentation (https://github.com/rust-lang/rfcs/pull/2632#issuecomment-874924659), and has gained speed especially recently since all of the work was ripped out and reimplemented under the new `#![feature(effects)]`.

Adding this PG helps to acknowledge some of the people who work on this feature, and allows us to have a single ping group for important PRs, etc.

This PG is related to the keyword generics initiative (cc @rust-lang/initiative-keyword-generics) in that it's implementing a "const" effect, but I'd like for this to be under the stewardship of the compiler team (or ideally, types team, but that's not possible), since it's primarily focused around practical implementation work and implementation concerns (allowing users to implement and call `const` traits), rather than theoretical work of designing an over-arching feature of the language like the kw-generics initiative aims to do.