### PR TITLE
manage thorin using teams repo

### DIFF
--- a/repos/rust-lang/thorin.toml
+++ b/repos/rust-lang/thorin.toml
@@ -1,0 +1,11 @@
+org = 'rust-lang'
+name = 'thorin'
+description = 'DWARF packaging utility, written in Rust, supporting GNU extension and DWARF 5 package formats.'
+bots = ["rustbot"]
+
+[access.teams]
+compiler = 'maintain'
+compiler-contributors = 'maintain'
+
+[[branch-protections]]
+pattern = "main"


### PR DESCRIPTION
There's no reason [thorin](https://github.com/rust-lang/thorin) shouldn't be managed by the teams repository.