### PR TITLE
Add  `infra = "triage"` permissions to `team`

### DIFF
--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -7,6 +7,7 @@ bots = []
 core = "admin"
 mods = "maintain"
 team-repo-admins = "write"
+infra = "triage"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
Members of the `infra` team (like me :) ) do work on this repository, so it would be nice to be able to ask for reviews.