### PR TITLE
Add homu repository under automation

### DIFF
--- a/repos/rust-lang/homu.toml
+++ b/repos/rust-lang/homu.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "homu"
+description = "A bot that integrates with GitHub and your favorite continuous integration service"
+bots = []
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = []
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/homu

I guess that not requiring reviews is to make it easier to do emergency fixes when bors breaks?

Original configuration from GH:
```toml
org = "rust-lang"
name = "homu"
description = "A bot that integrates with GitHub and your favorite continuous integration service"
bots = []

[access.teams]
infra = "write"
security = "pull"

[access.individuals]
shepmaster = "write"
rylev = "admin"
pietroalbini = "admin"
kennytm = "write"
badboy = "admin"
jdno = "admin"
Kobzol = "write"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = true
review-required = false
```