### PR TITLE
Add static-api round trip test

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub static BASE_URL: &str = "https://team-api.infra.rust-lang.org/v1";
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TeamKind {
     Team,
@@ -14,7 +14,7 @@ pub enum TeamKind {
     Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Team {
     pub name: String,
     pub kind: TeamKind,
@@ -26,29 +26,29 @@ pub struct Team {
     pub discord: Vec<TeamDiscord>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TeamMember {
     pub name: String,
     pub github: String,
     pub github_id: usize,
     pub is_lead: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub roles: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TeamGitHub {
     pub teams: Vec<GitHubTeam>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GitHubTeam {
     pub org: String,
     pub name: String,
     pub members: Vec<usize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TeamWebsite {
     pub name: String,
     pub description: String,
@@ -60,49 +60,49 @@ pub struct TeamWebsite {
     pub weight: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TeamDiscord {
     pub name: String,
     pub members: Vec<usize>,
     pub color: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DiscordInvite {
     pub channel: String,
     pub url: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Teams {
     #[serde(flatten)]
     pub teams: IndexMap<String, Team>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Repos {
     #[serde(flatten)]
     pub repos: IndexMap<String, Vec<Repo>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct List {
     pub address: String,
     pub members: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Lists {
     pub lists: IndexMap<String, List>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZulipGroup {
     pub name: String,
     pub members: Vec<ZulipGroupMember>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ZulipGroupMember {
     // TODO(rylev): this variant can be removed once
@@ -111,37 +111,37 @@ pub enum ZulipGroupMember {
     Id(usize),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZulipGroups {
     pub groups: IndexMap<String, ZulipGroup>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Permission {
     pub github_users: Vec<String>,
     pub github_ids: Vec<usize>,
     pub discord_ids: Vec<usize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Rfcbot {
     pub teams: IndexMap<String, RfcbotTeam>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RfcbotTeam {
     pub name: String,
     pub ping: String,
     pub members: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZulipMapping {
     /// Zulip ID to GitHub ID
     pub users: IndexMap<usize, usize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Repo {
     pub org: String,
     pub name: String,
@@ -162,19 +162,19 @@ pub enum Bot {
     Rfcbot,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RepoTeam {
     pub name: String,
     pub permission: RepoPermission,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RepoMember {
     pub name: String,
     pub permission: RepoPermission,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RepoPermission {
     Write,
@@ -183,7 +183,7 @@ pub enum RepoPermission {
     Triage,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BranchProtection {
     pub pattern: String,
     pub ci_checks: Vec<String>,
@@ -191,14 +191,14 @@ pub struct BranchProtection {
     pub required_approvals: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Person {
     pub name: String,
     pub email: Option<String>,
     pub github_id: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct People {
     /// GitHub name as key.
     pub people: IndexMap<String, Person>,


### PR DESCRIPTION
This catches a bug in #1154's `rust_team_data` change.

```console
$ cargo run -- static-api build
[INFO  rust_team::static_api] writing API object v1/teams/arm-maintainers.json...
[ERROR rust_team] failed to deserialize v1/teams/arm-maintainers.json
    
    Caused by:
        missing field `roles` at line 11 column 5
```