### PR TITLE
Add T-lang-ops and WG-async to calendar repo

### DIFF
--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -10,9 +10,11 @@ crates-io = "maintain"
 docs-rs = "maintain"
 infra = "maintain"
 lang = "maintain"
+lang-ops = "maintain"
 leadership-council = "maintain"
 libs = "maintain"
 release = "maintain"
+wg-async = "maintain"
 
 [[branch-protections]]
 pattern = "main"


### PR DESCRIPTION
T-lang uses the calendar managed by the `calendar` repository, and the lang team itself already has the correct permissions here.  However, the T-lang-ops team mostly handles the scheduling for the T-lang meetings, so T-lang-ops needs perms on this repos also.  Let's add those.

Separately, WG-async uses the calendar managed by the `calendar` repository and so should also have permissions.