### PR TITLE
Include en-US description of custom roles in static API

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -23,6 +23,7 @@ pub struct Team {
     pub alumni: Vec<TeamMember>,
     pub github: Option<TeamGitHub>,
     pub website_data: Option<TeamWebsite>,
+    pub roles: Vec<MemberRole>,
     pub discord: Vec<TeamDiscord>,
 }
 
@@ -58,6 +59,12 @@ pub struct TeamWebsite {
     pub discord: Option<DiscordInvite>,
     pub zulip_stream: Option<String>,
     pub weight: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemberRole {
+    pub id: String,
+    pub description: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -189,6 +189,14 @@ impl<'a> Generator<'a> {
                     zulip_stream: ws.zulip_stream().map(|s| s.into()),
                     weight: ws.weight(),
                 }),
+                roles: team
+                    .roles()
+                    .iter()
+                    .map(|role| v1::MemberRole {
+                        id: role.id.clone(),
+                        description: role.description.clone(),
+                    })
+                    .collect(),
                 discord: team
                     .discord_roles()
                     .map(|roles| {

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -14,6 +14,7 @@
     "alumni": [],
     "github": null,
     "website_data": null,
+    "roles": [],
     "discord": []
   },
   "foo": {
@@ -69,6 +70,7 @@
       "zulip_stream": "t-foo",
       "weight": 1000
     },
+    "roles": [],
     "discord": []
   },
   "leaderless": {
@@ -86,6 +88,7 @@
     "alumni": [],
     "github": null,
     "website_data": null,
+    "roles": [],
     "discord": []
   },
   "leads-permissions": {
@@ -115,6 +118,7 @@
     "alumni": [],
     "github": null,
     "website_data": null,
+    "roles": [],
     "discord": []
   },
   "wg-test": {
@@ -145,6 +149,7 @@
     ],
     "github": null,
     "website_data": null,
+    "roles": [],
     "discord": []
   }
 }

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -130,7 +130,10 @@
         "name": "Second user",
         "github": "user-2",
         "github_id": 2,
-        "is_lead": true
+        "is_lead": true,
+        "roles": [
+          "convener"
+        ]
       }
     ],
     "alumni": [
@@ -149,7 +152,12 @@
     ],
     "github": null,
     "website_data": null,
-    "roles": [],
+    "roles": [
+      {
+        "id": "convener",
+        "description": "Convener"
+      }
+    ],
     "discord": []
   }
 }

--- a/tests/static-api/_expected/v1/teams/alumni.json
+++ b/tests/static-api/_expected/v1/teams/alumni.json
@@ -13,5 +13,6 @@
   "alumni": [],
   "github": null,
   "website_data": null,
+  "roles": [],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/foo.json
+++ b/tests/static-api/_expected/v1/teams/foo.json
@@ -51,5 +51,6 @@
     "zulip_stream": "t-foo",
     "weight": 1000
   },
+  "roles": [],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/leaderless.json
+++ b/tests/static-api/_expected/v1/teams/leaderless.json
@@ -13,5 +13,6 @@
   "alumni": [],
   "github": null,
   "website_data": null,
+  "roles": [],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/leads-permissions.json
+++ b/tests/static-api/_expected/v1/teams/leads-permissions.json
@@ -25,5 +25,6 @@
   "alumni": [],
   "github": null,
   "website_data": null,
+  "roles": [],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -7,7 +7,10 @@
       "name": "Second user",
       "github": "user-2",
       "github_id": 2,
-      "is_lead": true
+      "is_lead": true,
+      "roles": [
+        "convener"
+      ]
     }
   ],
   "alumni": [
@@ -26,6 +29,11 @@
   ],
   "github": null,
   "website_data": null,
-  "roles": [],
+  "roles": [
+    {
+      "id": "convener",
+      "description": "Convener"
+    }
+  ],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -26,5 +26,6 @@
   ],
   "github": null,
   "website_data": null,
+  "roles": [],
   "discord": []
 }

--- a/tests/static-api/teams/wg-test.toml
+++ b/tests/static-api/teams/wg-test.toml
@@ -3,5 +3,11 @@ kind = "working-group"
 
 [people]
 leads = ["user-2"]
-members = ["user-2"]
+members = [
+    { github = "user-2", roles = ["convener"] },
+]
 alumni = ["user-0", "user-5"]
+
+[[roles]]
+id = "convener"
+description = "Convener"


### PR DESCRIPTION
In #1154, the static-api data (v1/teams.json) included only ids of roles, such as `"roles": ["spec-editor"]`. Separately the public-facing descriptions for the roles would be included in a ftl translation file produced by `dump-website`.

```
governance-role-spec-editor = Editor
```

This worked!

![Screenshot from 2024-01-08 12-25-08](https://github.com/rust-lang/team/assets/1940490/f41d3b46-c6c0-4d94-a551-20780b817427)

but has the downside that if some new role is introduced into the team repo **before** the translation for it lands in rust-lang/www.rust-lang.org in locales/en-US/teams.ftl, then the website would temporarily display the following ugly placeholder, until a commit such as https://github.com/rust-lang/www.rust-lang.org/pull/1821 syncs the ftl file.

![Screenshot from 2024-01-08 13-17-28](https://github.com/rust-lang/team/assets/1940490/c267b4f1-7c5a-4cfc-8171-1133ad4d2a87)

There are 2 potential fixes:

1. Hide role from the website if localization is not available. This means roles would be added in rust-lang/team without immediately showing up on the website. They would show up only after the next ftl sync, which happens only about once a year.

2. Include an en-US description in static-api. As soon as a role appears in rust-lang/team, it will appear on the website with a fallback to the English description from teams.json.

Approach 2 is what the website already does for team names and descriptions. See the logic here: https://github.com/rust-lang/www.rust-lang.org/blob/b35215187ed75d4d2a9a056f1847309aa2d404d2/src/i18n.rs#L151-L169

Pseudocode:

```rust
if lang == "en-US" {
    write(team.website_data.description)
} else if let Some(localized) = fluent::get("governance-team-" + team.name + "-description") {
    write(localized)
} else {
    write(team.website_data.description)
}
```

This PR makes it possible to do approach 2 for roles too.

```js
{
  "name": "spec",
  "members": [
    ...
    {
      "name": "Joel Marcey",
      "github": "JoelMarcey",
      "roles": [
        "spec-editor"
      ]
    }
  ],
  "website_data": {
    "name": "Specification team",
    "description": "Creating and maintaining the specification for the Rust language",
    "page": "spec",
    ...
  },
  "roles": [
    {
      "id": "spec-editor",
      "description": "Editor"
    }
  ]
}
```