### PR TITLE
Add rustc-hash repository under automation

### DIFF
--- a/repos/rust-lang/rustc-hash.toml
+++ b/repos/rust-lang/rustc-hash.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "rustc-hash"
+description = "Custom hash algorithm used by rustc (plus hashmap/set aliases): fast, deterministic, not secure"
+bots = []
+
+[access.teams]
+compiler = "write"
+compiler-contributors = "write"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustc-hash

Extracted from GH:
```
org = "rust-lang"
name = "rustc-hash"
description = "Custom hash algorithm used by rustc (plus hashmap/set aliases): fast, deterministic, not secure"
bots = []

[access.teams]
security = "pull"
compiler = "write"

[access.individuals]
estebank = "write"
jdno = "admin"
cjgillot = "write"
compiler-errors = "write"
eddyb = "write"
davidtwco = "write"
rylev = "admin"
michaelwoerister = "write"
pietroalbini = "admin"
Aaron1011 = "write"
jackh726 = "write"
Mark-Simulacrum = "admin"
nagisa = "write"
petrochenkov = "write"
pnkfelix = "write"
badboy = "admin"
rust-lang-owner = "admin"
matthewjasper = "write"
wesleywiser = "write"
oli-obk = "write"
lcnr = "write"
```