### PR TITLE
Add chalk repository under automation

### DIFF
--- a/repos/rust-lang/chalk.toml
+++ b/repos/rust-lang/chalk.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "chalk"
+description = "An implementation and definition of the Rust trait system using a PROLOG-like logic solver"
+bots = ["rustbot", "bors"]
+
+[access.teams]
+types = "write"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/chalk

Extracted from GH:
```
org = "rust-lang"
name = "chalk"
description = "An implementation and definition of the Rust trait system using a PROLOG-like logic solver"
bots = []

[access.teams]
security = "pull"
infra = "admin"
compiler = "write"
types = "write"
lang = "write"

[access.individuals]
rust-lang-owner = "admin"
oli-obk = "write"
pnkfelix = "write"
joshtriplett = "write"
aturon = "admin"
Aaron1011 = "write"
cjgillot = "write"
compiler-errors = "write"
wesleywiser = "write"
fabric-and-ink = "write"
rustbot = "maintain"
kennytm = "admin"
shepmaster = "admin"
tweerwag = "write"
scalexm = "admin"
tmandry = "write"
withoutboats = "admin"
rust-highfive = "write"
scottmcm = "write"
matthewjasper = "write"
estebank = "write"
davidtwco = "write"
badboy = "admin"
nikomatsakis = "write"
bors = "write"
BoxyUwU = "write"
jackh726 = "write"
michaelwoerister = "write"
Mark-Simulacrum = "admin"
rylev = "admin"
petrochenkov = "write"
aliemjay = "write"
jdno = "admin"
Kobzol = "admin"
nagisa = "write"
pietroalbini = "admin"
lcnr = "write"
spastorino = "write"
eddyb = "write"
```