### PR TITLE
Add ena repository under automation

### DIFF
--- a/repos/rust-lang/ena.toml
+++ b/repos/rust-lang/ena.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "ena"
+description = "An implementation of union-find / congruence-closure in Rust. Extracted from rustc for independent experimentation."
+bots = []
+
+[access.teams]
+compiler = "write"
+compiler-contributors = "write"
+
+[[branch-protections]]
+pattern = 'master'


### PR DESCRIPTION
Repo: https://github.com/rust-lang/ena

Extracted from GH:
```
org = "rust-lang"
name = "ena"
description = "An implementation of union-find / congruence-closure in Rust. Extracted from rustc for independent experimentation."
bots = []

[access.teams]
security = "pull"
compiler = "pull"
compiler-contributors = "pull"

[access.individuals]
pietroalbini = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
jdno = "admin"
badboy = "admin"
nikomatsakis = "write"
```