### PR TITLE
Add measureme repository under automation

### DIFF
--- a/repos/rust-lang/measureme.toml
+++ b/repos/rust-lang/measureme.toml
@@ -1,0 +1,14 @@
+org = "rust-lang"
+name = "measureme"
+description = "Support crate for rustc's self-profiling feature"
+bots = ["bors"]
+
+[access.teams]
+compiler = "write"
+
+[[branch-protections]]
+pattern = "master"
+
+[[branch-protections]]
+pattern = "stable"
+ci-checks = ["bors build finished"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/measureme

CC @michaelwoerister

Extracted from GH:
```
org = "rust-lang"
name = "measureme"
description = "Support crate for rustc's self-profiling feature"
bots = []

[access.teams]
security = "pull"
compiler = "admin"

[access.individuals]
compiler-errors = "admin"
Aaron1011 = "admin"
wesleywiser = "admin"
cjgillot = "admin"
nagisa = "admin"
pnkfelix = "admin"
rylev = "admin"
jdno = "admin"
pietroalbini = "admin"
jackh726 = "admin"
estebank = "admin"
michaelwoerister = "admin"
Mark-Simulacrum = "admin"
matthewjasper = "admin"
rust-lang-owner = "admin"
petrochenkov = "admin"
oli-obk = "admin"
eddyb = "admin"
davidtwco = "admin"
lcnr = "admin"
bors = "write"
badboy = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false

[[branch-protections]]
pattern = "stable"
ci-checks = ["bors build finished"]
dismiss-stale-review = false
pr-required = true
review-required = true
```