### PR TITLE
Delete trailing whitespace from wg-embedded subteam descriptions

### DIFF
--- a/teams/wg-embedded-cortex-a.toml
+++ b/teams/wg-embedded-cortex-a.toml
@@ -12,7 +12,7 @@ alumni = []
 
 [website]
 name = "Embedded Cortex-A team"
-description = "Develops and maintains the core of the Cortex-A crate ecosystem "
+description = "Develops and maintains the core of the Cortex-A crate ecosystem"
 
 [[github]]
 orgs = ["rust-embedded"]

--- a/teams/wg-embedded-cortex-m.toml
+++ b/teams/wg-embedded-cortex-m.toml
@@ -15,7 +15,7 @@ alumni = []
 
 [website]
 name = "Embedded Cortex-M team"
-description = "Develops and maintains the core of the Cortex-M crate ecosystem "
+description = "Develops and maintains the core of the Cortex-M crate ecosystem"
 
 [[github]]
 orgs = ["rust-embedded"]

--- a/teams/wg-embedded-cortex-r.toml
+++ b/teams/wg-embedded-cortex-r.toml
@@ -9,7 +9,7 @@ alumni = []
 
 [website]
 name = "Embedded Cortex-R team"
-description = "Develops and maintains the core of the Cortex-R crate ecosystem "
+description = "Develops and maintains the core of the Cortex-R crate ecosystem"
 
 [[github]]
 orgs = ["rust-embedded"]


### PR DESCRIPTION
This whitespace is problematic because it ends up as line-ending whitespace in the <span>www</span>.rust-lang.org repo in locales/en-US/teams.ftl after running `dump-website`.

https://github.com/rust-lang/www.rust-lang.org/blob/c4222cef26489f0a3925349d20725dcb70a919f7/locales/en-US/teams.ftl#L188-L195

and various editors will object to that. One person will run `cargo run -- dump-website > ../www.rust-lang.org/locales/en-US/teams.ftl` and commit it, the next person will make some unrelated change and end up with spurious diffs on the lines with whitespace.