### PR TITLE
Add docker-rust-nightly repository under automation (archived)

### DIFF
--- a/repos/archive/rust-lang/docker-rust-nightly.toml
+++ b/repos/archive/rust-lang/docker-rust-nightly.toml
@@ -1,0 +1,6 @@
+org = "rust-lang"
+name = "docker-rust-nightly"
+description = ""
+bots = []
+
+[access.teams]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/docker-rust-nightly

I copied the permissions from the `docker-rust` repo.

Extracted from GH:
```
org = "rust-lang"
name = "docker-rust-nightly"
description = ""
bots = []

[access.teams]
security = "pull"
infra = "pull"

[access.individuals]
pietroalbini = "admin"
rust-highfive = "admin"
rylev = "admin"
badboy = "admin"
Mark-Simulacrum = "admin"
jdno = "admin"
sfackler = "admin"
rust-lang-owner = "admin"
```