### PR TITLE
Add ferris-says repository under automation

### DIFF
--- a/repos/rust-lang/ferris-says.toml
+++ b/repos/rust-lang/ferris-says.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "ferris-says"
+description = "A Rust flavored implementation of `cowsay`"
+bots = []
+
+[access.teams]
+crate-maintainers = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/ferris-says

This is a very important repository that should also be properly managed by `team` :)

Extracted from GH:
```
org = "rust-lang"
name = "ferris-says"
description = "A Rust flavored implementation of `cowsay`"
bots = []

[access.teams]
security = "pull"
website = "write"

[access.individuals]
jdno = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
badboy = "admin"
Manishearth = "write"
pietroalbini = "admin"
```