### PR TITLE
Add std-dev-guide repository under automation

### DIFF
--- a/repos/rust-lang/std-dev-guide.toml
+++ b/repos/rust-lang/std-dev-guide.toml
@@ -1,0 +1,14 @@
+org = "rust-lang"
+name = "std-dev-guide"
+description = "Guide for standard library developers"
+bots = ["rustbot"]
+
+[access.teams]
+libs-contributors = "write"
+libs-api = "write"
+libs = "maintain"
+wg-rustc-dev-guide = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["book-test"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/std-dev-guide

I'm trying to add branch protections where they are missing, so I added one here. Let me know if I should remove it.

CC @m-ou-se

Extracted from GH:
```
org = "rust-lang"
name = "std-dev-guide"
description = "Guide for standard library developers"
bots = []

[access.teams]
libs-contributors = "write"
infra = "write"
libs-api = "write"
libs = "maintain"
security = "pull"
wg-rustc-dev-guide = "write"

[access.individuals]
the8472 = "maintain"
JohnTitor = "write"
cuviper = "maintain"
Kobzol = "write"
spastorino = "write"
camelid = "write"
shepmaster = "write"
cramertj = "write"
kennytm = "write"
tshepang = "write"
pietroalbini = "admin"
jdno = "admin"
Mark-Simulacrum = "admin"
thomcc = "maintain"
m-ou-se = "maintain"
dtolnay = "write"
rust-lang-owner = "admin"
sunfishcode = "write"
rylev = "admin"
ChrisDenton = "write"
KodrAus = "write"
badboy = "admin"
yaahc = "write"
SimonSapin = "write"
joshtriplett = "maintain"
BurntSushi = "write"
Amanieu = "maintain"
workingjubilee = "write"
igaray = "write"
```