### PR TITLE
Add book repository under automation

### DIFF
--- a/repos/rust-lang/book.toml
+++ b/repos/rust-lang/book.toml
@@ -1,0 +1,13 @@
+org = "rust-lang"
+name = "book"
+description = "The Rust Programming Language"
+bots = []
+
+[access.teams]
+
+[access.individuals]
+carols10cents = "maintain"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = []


### PR DESCRIPTION
Repo: https://github.com/rust-lang/book

The current GitHub permissions (see below) don't really contain any reasonable team, so I'm not sure who to add here, since the docs team is archived. I saw @carols10cents being active, so I added access for her.

Extracted from GH:
```
org = "rust-lang"
name = "book"
description = "The Rust Programming Language"
bots = []

[access.teams]
security = "pull"
highfive = "write"

[access.individuals]
carols10cents = "admin"
rust-lang-owner = "admin"
rylev = "admin"
badboy = "admin"
jdno = "admin"
Mark-Simulacrum = "admin"
pietroalbini = "admin"
rust-highfive = "write"
frewsxcv = "write"

[[branch-protections]]
pattern = "main"
ci-checks = []
dismiss-stale-review = false
pr-required = true
review-required = true
```