### PR TITLE
Create a GitHub team for project const traits

### DIFF
--- a/teams/project-const-traits.toml
+++ b/teams/project-const-traits.toml
@@ -14,3 +14,5 @@ members = [
 ]
 alumni = []
 
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
The project group *project const traits* would like to have a corresponding GitHub team to enable group pings (of the form [@]rust-lang/project-const-traits).

The initial PR for project-const-traits #1173 listed this as one motivation for the existence of this project group:

> Adding this PG […] allows us to have a single ping group for important PRs, etc.

As far as I understand, my patch would accomplish this goal.

cc @compiler-errors, @fee1-dead, @oli-obk