### PR TITLE
Create a repos entry for bindgen

### DIFF
--- a/repos/rust-lang/rust-bindgen.toml
+++ b/repos/rust-lang/rust-bindgen.toml
@@ -1,0 +1,19 @@
+org = "rust-lang"
+name = "rust-bindgen"
+description = "Automatically generates Rust FFI bindings to C (and some C++) libraries."
+bots = ["rustbot"]
+
+[access.teams]
+wg-bindgen = "write"
+
+[access.individuals]
+emilio = "admin"
+fitzgen = "admin"
+pvdrz = "write"
+
+[[branch-protections]]
+pattern = "main"
+required-approvals = 0
+ci-checks = [
+    "test",
+]


### PR DESCRIPTION
This sets up https://github.com/rust-lang/rust-bindgen to be able to use rustbot. This was okayed at https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Bindgen.20triage.

cc @emilio