### PR TITLE
Add rust-log-analyzer repository under automation

### DIFF
--- a/repos/rust-lang/rust-log-analyzer.toml
+++ b/repos/rust-lang/rust-log-analyzer.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust-log-analyzer"
+description = "Analyzing Travis and Azure Pipelines logs to find encountered errors"
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-log-analyzer

Extracted from GH:
```
org = "rust-lang"
name = "rust-log-analyzer"
description = "Analyzing Travis and Azure Pipelines logs to find encountered errors"
bots = []

[access.teams]
security = "pull"
infra = "write"

[access.individuals]
badboy = "admin"
shepmaster = "write"
TimNN = "admin"
rylev = "admin"
Kobzol = "write"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
kennytm = "write"
jdno = "admin"
```