### PR TITLE
Add rustc-demangle repository under automation

### DIFF
--- a/repos/rust-lang/rustc-demangle.toml
+++ b/repos/rust-lang/rustc-demangle.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "rustc-demangle"
+description = "Rust symbol demangling"
+bots = []
+
+[access.teams]
+compiler = "write"
+compiler-contributors = "write"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = ["test"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustc-demangle

https://hackmd.io/@rust-leadership-council/Bk6ge9Xu6 suggests to put this under `compiler`. Maybe we should also give access to @alexcrichton?

I also added a branch protection.

Extracted from GH:
```
org = "rust-lang"
name = "rustc-demangle"
description = "Rust symbol demangling"
bots = []

[access.teams]
security = "pull"
compiler = "maintain"
compiler-contributors = "write"

[access.individuals]
badboy = "admin"
apiraino = "write"
lcnr = "maintain"
nnethercote = "write"
pnkfelix = "maintain"
jdno = "admin"
WaffleLapkin = "write"
nikic = "write"
chenyukang = "write"
Mark-Simulacrum = "admin"
Aaron1011 = "maintain"
spastorino = "write"
BoxyUwU = "write"
davidtwco = "maintain"
fmease = "write"
Nilstrieb = "write"
cjgillot = "maintain"
nikomatsakis = "write"
fee1-dead = "write"
SparrowLii = "write"
b-naber = "write"
rylev = "admin"
estebank = "maintain"
jackh726 = "maintain"
durin42 = "write"
compiler-errors = "maintain"
bjorn3 = "write"
tmandry = "write"
tmiasko = "write"
RalfJung = "write"
oli-obk = "maintain"
michaelwoerister = "maintain"
est31 = "write"
cuviper = "write"
the8472 = "write"
lqd = "write"
nagisa = "maintain"
rust-lang-owner = "admin"
petrochenkov = "maintain"
flodiebold = "write"
eholk = "write"
pietroalbini = "admin"
matthewjasper = "maintain"
saethlin = "write"
TaKO8Ki = "write"
Nadrieril = "write"
alexcrichton = "write"
eddyb = "maintain"
wesleywiser = "maintain"
```