### PR TITLE
chore: Add T-cargo to calendar repo

### DIFF
--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -4,6 +4,7 @@ description = "Calendars for Rust project teams"
 bots = ["rustbot"]
 
 [access.teams]
+cargo = "maintain"
 compiler = "maintain"
 compiler-contributors = "maintain"
 crates-io = "maintain"


### PR DESCRIPTION
`T-cargo` uses the [calendar managed by the calendar repository](https://github.com/rust-lang/calendar/blob/62949e2748910a998d4bc15cd42fe3a3ad692bc0/cargo.toml), but does not have permission to edit the calendar. This adds `write` permissions for `T-cargo` as [suggested by this comment](https://github.com/rust-lang/team/pull/1180#discussion_r1446057760).