### PR TITLE
Add project-edition-2024 to forge

### DIFF
--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -13,6 +13,7 @@ infra = "maintain"
 lang = "maintain"
 leadership-council = "maintain"
 libs = "maintain"
+project-edition-2024 = "maintain"
 release = "maintain"
 triagebot = "maintain"
 


### PR DESCRIPTION
As part of https://github.com/rust-lang/rust-forge/pull/715, we will be hosting project-team docs on the forge.
