### PR TITLE
Add launching-pad team.

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -185,15 +185,6 @@ fn validate_subteam_of(data: &Data, errors: &mut Vec<String>) {
                 );
             };
 
-            if !matches!(team.kind(), TeamKind::Team) && parent.subteam_of().is_some() {
-                bail!(
-                    "{} `{}` can't be a subteam of a subteam (`{}`)",
-                    team.kind(),
-                    team.name(),
-                    parent.name(),
-                );
-            }
-
             team = parent;
         }
         Ok(())

--- a/teams/community.toml
+++ b/teams/community.toml
@@ -1,4 +1,5 @@
 name = "community"
+subteam-of = "launching-pad"
 
 [people]
 leads = []

--- a/teams/docker.toml
+++ b/teams/docker.toml
@@ -1,4 +1,5 @@
 name = "docker"
+subteam-of = "launching-pad"
 
 [people]
 leads = []

--- a/teams/launching-pad.toml
+++ b/teams/launching-pad.toml
@@ -1,0 +1,7 @@
+name = "launching-pad"
+
+[people]
+# This is an "umbrella" team, and thus does not have any members.
+leads = []
+members = []
+alumni = []

--- a/teams/twir.toml
+++ b/teams/twir.toml
@@ -1,4 +1,5 @@
 name = "twir"
+subteam-of = "launching-pad"
 
 [people]
 leads = ["nellshamrell"]

--- a/teams/web-presence.toml
+++ b/teams/web-presence.toml
@@ -1,4 +1,5 @@
 name = "web-presence"
+subteam-of = "launching-pad"
 
 [people]
 leads = []

--- a/teams/wg-async.toml
+++ b/teams/wg-async.toml
@@ -1,4 +1,5 @@
 name = "wg-async"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]

--- a/teams/wg-cli.toml
+++ b/teams/wg-cli.toml
@@ -1,4 +1,5 @@
 name = "wg-cli"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]

--- a/teams/wg-embedded.toml
+++ b/teams/wg-embedded.toml
@@ -1,4 +1,5 @@
 name = "wg-embedded"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]

--- a/teams/wg-gamedev.toml
+++ b/teams/wg-gamedev.toml
@@ -1,4 +1,5 @@
 name = "wg-gamedev"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]

--- a/teams/wg-rust-by-example.toml
+++ b/teams/wg-rust-by-example.toml
@@ -1,4 +1,5 @@
 name = "wg-rust-by-example"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]

--- a/teams/wg-secure-code.toml
+++ b/teams/wg-secure-code.toml
@@ -1,4 +1,5 @@
 name = "wg-secure-code"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]

--- a/teams/wg-security-response.toml
+++ b/teams/wg-security-response.toml
@@ -1,4 +1,5 @@
 name = "wg-security-response"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -1,5 +1,6 @@
 name = "wg-triage"
 kind = "working-group"
+subteam-of = "launching-pad"
 
 [people]
 leads = ["Dylan-DPC"]

--- a/teams/wg-wasm.toml
+++ b/teams/wg-wasm.toml
@@ -1,4 +1,5 @@
 name = "wg-wasm"
+subteam-of = "launching-pad"
 kind = "working-group"
 
 [people]


### PR DESCRIPTION
This adds the launching-pad team, and connects all of its subteams into it. This should help with tracking the team membership and their status and connections.

cc @jonathanpallant
