### PR TITLE
Enable required status check in libc repo

### DIFF
--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -11,3 +11,8 @@ crate-maintainers = 'maintain'
 
 [[branch-protections]]
 pattern = 'main'
+ci-checks = ['success']
+
+[[branch-protections]]
+pattern = 'libc-0.2'
+ci-checks = ['success']


### PR DESCRIPTION
Merge qeues have been enabled in the [libc] repository, which require a status check to determine the success of each build.

[libc]: https://github.com/rust-lang/libc