### PR TITLE
Add llvm-project repository under automation

### DIFF
--- a/repos/rust-lang/llvm-project.toml
+++ b/repos/rust-lang/llvm-project.toml
@@ -1,0 +1,13 @@
+org = "rust-lang"
+name = "llvm-project"
+description = "Rust-specific fork of LLVM."
+bots = []
+
+[access.teams]
+wg-llvm = "maintain"
+
+[[branch-protections]]
+pattern = "rustc/*"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/llvm-project

I kept the branch protections, although I'm not sure if they are even needed on this repo.

CC @nikic

Extracted from GH:
```
org = "rust-lang"
name = "llvm-project"
description = "Rust-specific fork of LLVM."
bots = []

[access.teams]
wg-llvm = "maintain"
core = "admin"
security = "pull"

[access.individuals]
cuviper = "maintain"
badboy = "admin"
jdno = "admin"
pietroalbini = "admin"
nikic = "maintain"
nagisa = "maintain"
rust-lang-owner = "admin"
Mark-Simulacrum = "admin"
rylev = "admin"

[[branch-protections]]
pattern = "rustc/*"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```