### PR TITLE
Add miri repository under automation

### DIFF
--- a/repos/rust-lang/miri.toml
+++ b/repos/rust-lang/miri.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "miri"
+description = "An interpreter for Rust's mid-level intermediate representation"
+bots = ["rustbot", "bors"]
+
+[access.teams]
+compiler = "write"
+miri = "write"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/miri

CC @RalfJung

Extracted from GH:
```
org = "rust-lang"
name = "miri"
description = "An interpreter for Rust's mid-level intermediate representation"
bots = []

[access.teams]
compiler = "write"
miri = "write"
security = "pull"
bots = "write"

[access.individuals]
estebank = "write"
davidtwco = "write"
rylev = "admin"
oli-obk = "write"
rust-timer = "write"
wesleywiser = "write"
matthewjasper = "write"
cjgillot = "write"
Mark-Simulacrum = "admin"
RalfJung = "write"
badboy = "admin"
rustbot = "write"
solson = "write"
compiler-errors = "write"
lcnr = "write"
eddyb = "write"
saethlin = "write"
nagisa = "write"
rust-highfive = "write"
jdno = "admin"
Aaron1011 = "write"
pnkfelix = "write"
michaelwoerister = "write"
petrochenkov = "write"
rust-lang-owner = "admin"
jackh726 = "write"
pietroalbini = "admin"
bors = "write"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```