### PR TITLE
Add libs-team repository under automation

### DIFF
--- a/repos/rust-lang/libs-team.toml
+++ b/repos/rust-lang/libs-team.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "libs-team"
+description = "The home of the library team"
+bots = ["rustbot"]
+
+[access.teams]
+libs = "maintain"
+libs-api = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/libs-team

Extracted from GH:
```
org = "rust-lang"
name = "libs-team"
description = "The home of the library team"
bots = []

[access.teams]
bots = "write"
security = "pull"
libs = "maintain"
infra = "maintain"
libs-api = "write"

[access.individuals]
shepmaster = "maintain"
m-ou-se = "maintain"
rust-timer = "write"
dtolnay = "write"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
rustbot = "write"
kennytm = "maintain"
pietroalbini = "admin"
bors = "write"
badboy = "admin"
Amanieu = "maintain"
the8472 = "maintain"
rylev = "admin"
joshtriplett = "maintain"
jdno = "admin"
BurntSushi = "write"
thomcc = "maintain"
Kobzol = "maintain"
rust-highfive = "write"
cuviper = "maintain"
```