### PR TITLE
Add regex repo under automation

### DIFF
--- a/repos/rust-lang/regex.toml
+++ b/repos/rust-lang/regex.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "regex"
+description = "An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs."
+bots = []
+
+[access.teams]
+regex = "maintain"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = []
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/regex

CC @BurntSushi

Extracted from GH:
```
org = "rust-lang"
name = "regex"
description = "An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs."
bots = []

[access.teams]
regex = "maintain"

[access.individuals]
badboy = "admin"
bors = "write"
jdno = "admin"
BurntSushi = "maintain"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
rylev = "admin"
```