### PR TITLE
Add rust-playground repository under automation

### DIFF
--- a/repos/rust-lang/rust-playground.toml
+++ b/repos/rust-lang/rust-playground.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "rust-playground"
+description = "The Rust Playground"
+bots = []
+
+[access.teams]
+infra = "maintain"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = []
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-playground

The proposed configuration protects from direct pushes to `master` and requires PRs, but doesn't require PR approvals. Let me know if I should change it.

CC @shepmaster

Extracted from GH:
```
org = "rust-lang"
name = "rust-playground"
description = "The Rust Playground"
bots = []

[access.teams]
security = "pull"
infra = "admin"

[access.individuals]
shepmaster = "admin"
Mark-Simulacrum = "admin"
badboy = "admin"
pietroalbini = "admin"
jdno = "admin"
Kobzol = "admin"
rust-lang-owner = "admin"
kennytm = "admin"
rylev = "admin"
```