### PR TITLE
Add surveys repo under automation

### DIFF
--- a/repos/rust-lang/surveys.toml
+++ b/repos/rust-lang/surveys.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "surveys"
+description = "Repo for coordinating the creation, distribution, collection, and analysis of surveys for the Rust project. "
+bots = []
+
+[access.teams]
+community-survey = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/surveys

Extracted from GH:
```
org = "rust-lang"
name = "surveys"
description = "Repo for coordinating the creation, distribution, collection, and analysis of surveys for the Rust project. "
bots = []

[access.teams]
security = "pull"
community-survey = "maintain"

[access.individuals]
pietroalbini = "admin"
rylev = "admin"
apiraino = "maintain"
rust-lang-owner = "admin"
jdno = "admin"
Kobzol = "maintain"
badboy = "admin"
Mark-Simulacrum = "admin"
yaahc = "write"
```