### PR TITLE
Add simpleinfra repo under automation

### DIFF
--- a/repos/rust-lang/simpleinfra.toml
+++ b/repos/rust-lang/simpleinfra.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "simpleinfra"
+description = "Rust Infrastructure automation"
+bots = []
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "master"
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/simpleinfra/

Extracted from GH:
```
org = "rust-lang"
name = "simpleinfra"
description = "Rust Infrastructure automation"
bots = []

[access.teams]
security = "pull"
infra = "write"

[access.individuals]
rylev = "admin"
badboy = "admin"
pietroalbini = "admin"
jdno = "admin"
shepmaster = "write"
Mark-Simulacrum = "admin"
kennytm = "write"
rust-lang-owner = "admin"
Kobzol = "write"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```