### PR TITLE
Add rustc_codegen_gcc repo under automation

### DIFF
--- a/repos/rust-lang/rustc_codegen_gcc.toml
+++ b/repos/rust-lang/rustc_codegen_gcc.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "rustc_codegen_gcc"
+description = "libgccjit AOT codegen for rustc"
+bots = []
+
+[access.teams]
+compiler = "write"
+
+[access.individuals]
+antoyo = "maintain"
+GuillaumeGomez = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustc_codegen_gcc

CC @antoyo

Extracted from GH:
```
org = "rust-lang"
name = "rustc_codegen_gcc"
description = "libgccjit AOT codegen for rustc"
bots = []

[access.teams]
security = "pull"
compiler = "maintain"

[access.individuals]
estebank = "maintain"
Aaron1011 = "maintain"
pnkfelix = "maintain"
eddyb = "maintain"
petrochenkov = "maintain"
matthewjasper = "maintain"
cjgillot = "maintain"
pietroalbini = "admin"
jackh726 = "maintain"
rust-lang-owner = "admin"
wesleywiser = "maintain"
rylev = "admin"
davidtwco = "maintain"
michaelwoerister = "maintain"
oli-obk = "maintain"
lcnr = "maintain"
compiler-errors = "maintain"
nagisa = "maintain"
jdno = "admin"
antoyo = "write"
Mark-Simulacrum = "admin"
badboy = "admin"
```