### PR TITLE
Add this-week-in-rust repo under automation

### DIFF
--- a/repos/rust-lang/this-week-in-rust.toml
+++ b/repos/rust-lang/this-week-in-rust.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "this-week-in-rust"
+description = "Data for this-week-in-rust.org"
+bots = []
+
+[access.teams]
+twir-reviewers = "write"
+twir = "write"
+
+[[branch-protections]]
+pattern = "master"
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/this-week-in-rust

CC @nellshamrell

Extracted from GH:
```
org = "rust-lang"
name = "this-week-in-rust"
description = "Data for this-week-in-rust.org"
bots = []

[access.teams]
twir-reviewers = "maintain"
security = "pull"

[access.individuals]
mariannegoldin = "maintain"
ericseppanen = "maintain"
rust-lang-owner = "admin"
rylev = "admin"
U007D = "maintain"
pietroalbini = "admin"
nellshamrell = "maintain"
extrawurst = "maintain"
Mark-Simulacrum = "admin"
bennyvasquez = "maintain"
cdmistman = "maintain"
badboy = "admin"
jdno = "admin"
andrewpollack = "maintain"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```