### PR TITLE
Add sync-team repo under automation

### DIFF
--- a/repos/rust-lang/sync-team.toml
+++ b/repos/rust-lang/sync-team.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "sync-team"
+description = "Synchronize the team repository with the services we use"
+bots = []
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["CI"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/sync-team

Extracted from GH:
```
org = "rust-lang"
name = "sync-team"
description = "Synchronize the team repository with the services we use"
bots = []

[access.teams]
security = "pull"
infra = "write"

[access.individuals]
kennytm = "write"
shepmaster = "write"
pietroalbini = "admin"
rylev = "admin"
rust-lang-owner = "admin"
Kobzol = "write"
jdno = "admin"
badboy = "admin"
Mark-Simulacrum = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = ["CI"]
dismiss-stale-review = false
pr-required = true
review-required = true
```