### PR TITLE
Add types-team repo under automation

### DIFF
--- a/repos/rust-lang/types-team.toml
+++ b/repos/rust-lang/types-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "types-team"
+description = "Home of the \"types team\", affiliated with the compiler and lang teams."
+bots = ["rustbot"]
+
+[access.teams]
+types = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/types-team

CC @jackh726

Extracted from GH:
```
org = "rust-lang"
name = "types-team"
description = "Home of the \"types team\", affiliated with the compiler and lang teams."
bots = []

[access.teams]
security = "pull"
types = "write"
lang = "admin"
compiler = "admin"
infra = "admin"
core = "admin"

[access.individuals]
lcnr = "admin"
Aaron1011 = "admin"
spastorino = "write"
cjgillot = "admin"
petrochenkov = "admin"
kennytm = "admin"
michaelwoerister = "admin"
joshtriplett = "admin"
nikomatsakis = "admin"
wesleywiser = "admin"
jdno = "admin"
pnkfelix = "admin"
jackh726 = "admin"
rustbot = "write"
Kobzol = "admin"
scottmcm = "admin"
pietroalbini = "admin"
badboy = "admin"
rylev = "admin"
davidtwco = "admin"
matthewjasper = "admin"
eddyb = "admin"
aliemjay = "write"
rust-lang-owner = "admin"
Mark-Simulacrum = "admin"
BoxyUwU = "write"
estebank = "admin"
nagisa = "admin"
compiler-errors = "admin"
shepmaster = "admin"
oli-obk = "admin"
tmandry = "admin"
```