### PR TITLE
Add an e-mail account for community survey team

### DIFF
--- a/teams/community-survey.toml
+++ b/teams/community-survey.toml
@@ -19,3 +19,6 @@ repo = "https://github.com/rust-lang/surveys"
 
 [[github]]
 orgs = ["rust-lang"]
+
+[[lists]]
+address = "surveys@rust-lang.org"


### PR DESCRIPTION
The e-mail is primarily designed to access online services (e.g. SurveyHero) under a shared account for now.