### PR TITLE
Fix documentation of `[[github]]` in teams

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -99,7 +99,7 @@ include-all-alumni = false
 
 # Configure the GitHub integration
 # This is optional, and if missing the team won't be synchronized with GitHub
-[github]
+[[github]]
 team-name = "overlords-team"  # The name of the GitHub team (optional)
 orgs = ["rust-lang"]  # Organizations to create the team in (required)
 # Include members of these Rust teams in this GitHub team (optional)


### PR DESCRIPTION
It is supposed to be an array, not an object.

Looks like the TOML docs rots fast, I wonder if we could somehow autogenerate it from the team data structures directly (e.g. by attaching the comments and defaults values to them using a proc macro).