### PR TITLE
Implement RFC#3533 Combining Infra and Release

### DIFF
--- a/teams/leadership-council.toml
+++ b/teams/leadership-council.toml
@@ -10,10 +10,9 @@ members = [
     "jonathanpallant",
     "Mark-Simulacrum",
     "m-ou-se",
-    "rylev",
     "technetos",
 ]
-alumni = ["khionu"]
+alumni = ["khionu", "rylev"]
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]

--- a/teams/release.toml
+++ b/teams/release.toml
@@ -1,4 +1,5 @@
 name = "release"
+subteam-of = "infra"
 
 [people]
 leads = ["Mark-Simulacrum"]

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -1,5 +1,4 @@
 name = "wg-triage"
-subteam-of = "release"
 kind = "working-group"
 
 [people]
@@ -20,7 +19,7 @@ members = [
     "anden3",
     "KittyBorgX",
     "Enselic",
-    "tranquillity-codes"
+    "tranquillity-codes",
 ]
 alumni = []
 


### PR DESCRIPTION
This implements [RFC#3533](https://github.com/rust-lang/rfcs/pull/3533).

Concretely this means:
* Make Release a subteam of Infra
* Remove @rylev from Leadership Council
  * While @Mark-Simulacrum was the Release representative on the Council, it was agreed that as part of this move @rylev would step down as Infra representative and @Mark-Simulacrum would take over as the Infra rep

There are a few follow ups that need to happen as a result of implementing RFC 3533 that cannot be addressed in this PR:
* The launching pad needs to be created so wg-triage can be placed underneath it. This is being worked on in https://github.com/rust-lang/team/pull/1206 cc @ehuss 
* https://github.com/rust-lang/team/pull/1182 needs to be updated to reflect the change in roles (i.e., the @rylev is no longer a Council member, that the Release team no longer has direct representation, and that @Mark-Simulacrum is the new representative for Infra) cc @dtolnay 