### PR TITLE
Add new Google Summer of Code repository

### DIFF
--- a/repos/rust-lang/google-summer-of-code.toml
+++ b/repos/rust-lang/google-summer-of-code.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "google-summer-of-code"
+description = "Rust project ideas for Google Summer of Code"
+bots = []
+
+[access.teams]
+
+[access.individuals]
+Kobzol = "write"
+jackh726 = "write"


### PR DESCRIPTION
For storing the Rust GSoC (2024) project list.