### PR TITLE
Make the infra-admins team a marker team

### DIFF
--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -1,4 +1,5 @@
 name = "infra-admins"
+kind = "marker-team"
 
 [people]
 leads = []


### PR DESCRIPTION
This team is only used for permissions purposes and thus is more appropriate as a marker team.