### PR TITLE
Switch more teams to marker teams.

### DIFF
--- a/teams/all.toml
+++ b/teams/all.toml
@@ -1,4 +1,5 @@
 name = "all"
+kind = "marker-team"
 
 [people]
 leads = []

--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -4,6 +4,7 @@
 # Do not add new members to this team. Instead add to `people.alumni` in the
 # appropriate team's file.
 name = "alumni"
+kind = "marker-team"
 
 [people]
 leads = []

--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -1,4 +1,5 @@
 name = "infra-admins"
+kind = "marker-team"
 
 [people]
 leads = []

--- a/teams/leads.toml
+++ b/teams/leads.toml
@@ -1,4 +1,5 @@
 name = "leads"
+kind = "marker-team"
 
 [people]
 leads = []


### PR DESCRIPTION
This switches more "teams" to be "marker-teams", as these aren't really teams that exist by themselves.

From what I can tell, this should not affect the website, and I checked the static JSON and the changes look like what I expect. From what I can tell, sync-team does not look at the team kind, either, so I don't think it should be affected.
