### PR TITLE
Remove myself from wg-compiler-performance

### DIFF
--- a/teams/wg-compiler-performance.toml
+++ b/teams/wg-compiler-performance.toml
@@ -5,7 +5,6 @@ kind = "working-group"
 [people]
 leads = ["Mark-Simulacrum"]
 members = [
-    "wesleywiser",
     "Mark-Simulacrum",
     "rylev",
     "tgnottingham",
@@ -15,7 +14,9 @@ members = [
     "lqd",
     "nnethercote",
 ]
-alumni = []
+alumni = [
+    "wesleywiser"
+]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
It's been a while since I've had time to work specifically on compiler performance, so I think it's more accurate for me to remove myself from the active working group members. 