### PR TITLE
Remove core access to the team repo

### DIFF
--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -4,7 +4,6 @@ description = "Rust teams structure"
 bots = []
 
 [access.teams]
-core = "admin"
 mods = "maintain"
 team-repo-admins = "write"
 infra = "triage"


### PR DESCRIPTION
It shouldn't be needed anymore I think, and anyway `core` is now a subset of `team-repo-admins`.