### PR TITLE
Add ar_archive_writer repo under automation

### DIFF
--- a/repos/rust-lang/ar_archive_writer.toml
+++ b/repos/rust-lang/ar_archive_writer.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "ar_archive_writer"
+description = "A writer for object file ar archives"
+bots = []
+
+[access.teams]
+compiler = "write"
+compiler-contributors = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/ar_archive_writer

CC @bjorn3

Extracted from GH:
```
org = "rust-lang"
name = "ar_archive_writer"
description = "A writer for object file ar archives"
bots = []

[access.teams]
compiler = "maintain"
compiler-contributors = "write"
security = "pull"

[access.individuals]
davidtwco = "maintain"
BoxyUwU = "write"
fee1-dead = "write"
tmiasko = "write"
rust-lang-owner = "admin"
TaKO8Ki = "write"
petrochenkov = "maintain"
eddyb = "maintain"
saethlin = "write"
Mark-Simulacrum = "admin"
b-naber = "write"
jdno = "admin"
rylev = "admin"
wesleywiser = "maintain"
nikomatsakis = "write"
compiler-errors = "maintain"
pietroalbini = "admin"
spastorino = "write"
nikic = "write"
badboy = "admin"
bjorn3 = "write"
tmandry = "write"
oli-obk = "maintain"
jackh726 = "maintain"
lcnr = "maintain"
eholk = "write"
durin42 = "write"
pnkfelix = "maintain"
chenyukang = "write"
antoyo = "write"
nagisa = "maintain"
estebank = "maintain"
WaffleLapkin = "write"
cjgillot = "maintain"
lqd = "write"
flodiebold = "write"
RalfJung = "write"
the8472 = "write"
Nadrieril = "write"
Nilstrieb = "write"
fmease = "write"
est31 = "write"
matthewjasper = "maintain"
SparrowLii = "write"
michaelwoerister = "maintain"
nnethercote = "write"
cuviper = "write"
Aaron1011 = "maintain"
apiraino = "write"
```