### PR TITLE
Add async-book repo under automation

### DIFF
--- a/repos/rust-lang/async-book.toml
+++ b/repos/rust-lang/async-book.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "async-book"
+description = "Asynchronous Programming in Rust"
+bots = []
+
+[access.teams]
+wg-async = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/async-book

Extracted from GH:
```
org = "rust-lang"
name = "async-book"
description = "Asynchronous Programming in Rust"
bots = []

[access.teams]
security = "pull"
wg-async = "write"

[access.individuals]
nrc = "write"
pietroalbini = "admin"
pnkfelix = "write"
tmandry = "write"
jdno = "admin"
compiler-errors = "write"
eholk = "write"
traviscross = "write"
tinaun = "write"
guswynn = "write"
nikomatsakis = "write"
badboy = "admin"
yoshuawuyts = "write"
rust-lang-owner = "admin"
rylev = "admin"
Nemo157 = "write"
estebank = "write"
cramertj = "admin"
vincenzopalazzo = "write"
taiki-e = "write"
michaelwoerister = "write"
Mark-Simulacrum = "admin"
```