### PR TITLE
Add const-eval repo under automation

### DIFF
--- a/repos/rust-lang/const-eval.toml
+++ b/repos/rust-lang/const-eval.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "const-eval"
+description = "home for proposals in and around compile-time function evaluation"
+bots = []
+
+[access.teams]
+wg-const-eval = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/const-eval

Extracted from GH:
```
org = "rust-lang"
name = "const-eval"
description = "home for proposals in and around compile-time function evaluation"
bots = []

[access.teams]
compiler = "pull"
lang = "pull"
security = "pull"

[access.individuals]
badboy = "admin"
nikomatsakis = "admin"
oli-obk = "write"
rylev = "admin"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
RalfJung = "write"
jdno = "admin"
```