### PR TITLE
Add glacier repo under automation

### DIFF
--- a/repos/rust-lang/glacier.toml
+++ b/repos/rust-lang/glacier.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "glacier"
+description = "A big 'ol pile of ICE."
+bots = []
+
+[access.teams]
+wg-triage = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/glacier

Assigned to `wg-triage` according to https://hackmd.io/@rust-leadership-council/Bk6ge9Xu6.

Extracted from GH:
```
org = "rust-lang"
name = "glacier"
description = "A big 'ol pile of ICE."
bots = []

[access.teams]
core = "admin"
release = "write"
wg-triage = "write"
security = "pull"

[access.individuals]
badboy = "admin"
Enselic = "write"
pitaj = "write"
Mark-Simulacrum = "admin"
joelpalmer = "write"
JohnTitor = "write"
camelid = "write"
Dylan-DPC = "write"
cuviper = "write"
KittyBorgX = "write"
anden3 = "write"
pietroalbini = "admin"
JohnCSimon = "write"
rust-lang-owner = "admin"
rylev = "admin"
crlf0710 = "write"
Muirrum = "write"
bstrie = "write"
jdno = "admin"
Alexendoo = "write"
alice-i-cecile = "write"
tmandry = "write"
```