### PR TITLE
Add git2-rs repo under automation

### DIFF
--- a/repos/rust-lang/git2-rs.toml
+++ b/repos/rust-lang/git2-rs.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "git2-rs"
+description = "libgit2 bindings for Rust"
+bots = []
+
+[access.teams]
+cargo = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["Success gate"]
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/git2-rs

Assigned to `cargo` according to https://hackmd.io/@rust-leadership-council/Bk6ge9Xu6, but not sure about it.

CC @rust-lang/cargo

Extracted from GH:
```
org = "rust-lang"
name = "git2-rs"
description = "libgit2 bindings for Rust"
bots = []

[access.teams]
security = "pull"

[access.individuals]
joshtriplett = "admin"
Mark-Simulacrum = "admin"
rylev = "admin"
pietroalbini = "admin"
badboy = "admin"
rust-lang-owner = "admin"
jdno = "admin"
alexcrichton = "write"
ehuss = "write"

[[branch-protections]]
pattern = "master"
ci-checks = ["Success gate"]
dismiss-stale-review = false
pr-required = true
review-required = false
```