### PR TITLE
Add Zulip stream representation

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -202,6 +202,20 @@ excluded-people = [
     "rylev",
 ]
 
+# Define Zulip streams owned
+# It's optional, and there can be more than one
+[[zulip-streams]]
+# The name of the Zulip stream (required)
+name = "t-overlords"
+# Zulip groups that will have access to the stream if it is private (optional)
+groups = ["T-overlords"]
+# Visibility of the stream (optional, default = "public")
+# Possible values:
+# "public": a web-public stream readable by anyone even without Zulip login
+# "private-shared": a private stream with a shared history (joining the stream reveals you the whole history)
+# "private-protected": a private stream with a protected history (joining the stream doesn't reveal its history)
+visibility = "public"
+
 # Roles to define in Discord.
 [[discord-roles]]
 # The name of the role.

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -126,7 +126,7 @@ pub struct ZulipGroups {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZulipStream {
     pub name: String,
-    pub groups: Vec<ZulipGroup>,
+    pub groups: Vec<String>,
     pub visibility: ZulipStreamVisibility,
 }
 

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -124,6 +124,26 @@ pub struct ZulipGroups {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ZulipStream {
+    pub name: String,
+    pub groups: Vec<ZulipGroup>,
+    pub visibility: ZulipStreamVisibility,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ZulipStreamVisibility {
+    WebPublic,
+    PrivateSharedHistory,
+    PrivateProtectedHistory,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ZulipStreams {
+    pub streams: IndexMap<String, ZulipStream>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Permission {
     pub github_users: Vec<String>,
     pub github_ids: Vec<usize>,

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,5 +1,6 @@
 use crate::schema::{Config, List, Person, Repo, Team, ZulipGroup};
 use anyhow::{bail, Context as _, Error};
+use rust_team_data::v1::ZulipStream;
 use serde::de::DeserializeOwned;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
@@ -110,6 +111,16 @@ impl Data {
             }
         }
         Ok(groups)
+    }
+
+    pub(crate) fn zulip_streams(&self) -> Result<HashMap<String, ZulipStream>, Error> {
+        let mut streams = HashMap::new();
+        for team in self.teams() {
+            for stream in team.zulip_streams()? {
+                streams.insert(stream.name.clone(), stream);
+            }
+        }
+        Ok(streams)
     }
 
     pub(crate) fn team(&self, name: &str) -> Option<&Team> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -172,6 +172,8 @@ pub(crate) struct Team {
     lists: Vec<TeamList>,
     #[serde(default)]
     zulip_groups: Vec<RawZulipGroup>,
+    #[serde(default)]
+    zulip_streams: Vec<RawZulipStream>,
     discord_roles: Option<Vec<DiscordRole>>,
 }
 
@@ -678,6 +680,28 @@ pub(crate) struct RawZulipGroup {
     pub(crate) extra_teams: Vec<String>,
     #[serde(default)]
     pub(crate) excluded_people: Vec<String>,
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) struct RawZulipStream {
+    pub(crate) name: String,
+    #[serde(default)]
+    pub(crate) groups: Vec<String>,
+    #[serde(default = "default_zulip_stream_visibility")]
+    pub(crate) visibility: RawZulipVisibility,
+}
+
+fn default_zulip_stream_visibility() -> RawZulipVisibility {
+    RawZulipVisibility::Public
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum RawZulipVisibility {
+    Public,
+    PrivateShared,
+    PrivateProtected,
 }
 
 #[derive(Debug)]

--- a/tests/static-api/_expected/v1/zulip-streams.json
+++ b/tests/static-api/_expected/v1/zulip-streams.json
@@ -1,0 +1,11 @@
+{
+  "streams": {
+    "t-foo": {
+      "name": "t-foo",
+      "groups": [
+        "T-foo"
+      ],
+      "visibility": "private-shared-history"
+    }
+  }
+}

--- a/tests/static-api/teams/foo.toml
+++ b/tests/static-api/teams/foo.toml
@@ -47,3 +47,8 @@ extra-teams = ["wg-test"]
 
 [[zulip-groups]]
 name = "T-foo"
+
+[[zulip-streams]]
+name = "t-foo"
+groups = ["T-foo"]
+visibility = "private-shared"


### PR DESCRIPTION
This PR adds a representation of Zulip streams to the team data. The idea is to represent streams in the TOML files, so that new streams can be declaratively created and their permissions (private/public) and membership (Zulip groups) can be modified.

This PR proposes attaching streams to teams, to avoid creating a separate `streams` directory. This means that each team is a an owner of a stream, but this doesn't need to be enforced anywhere, it can be only used for "bookkeeping" purposes. To add access to a stream, users can enumerate Zulip groups that have access to it.