### PR TITLE
Add keyword-generics-initiative repo under automation

### DIFF
--- a/repos/rust-lang/keyword-generics-initiative.toml
+++ b/repos/rust-lang/keyword-generics-initiative.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "keyword-generics-initiative"
+description = "Public repository for the Rust keyword generics initiative"
+bots = []
+
+[access.teams]
+initiative-keyword-generics = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/keyword-generics-initiative

Extracted from GH:
```
org = "rust-lang"
name = "keyword-generics-initiative"
description = "Public repository for the Rust keyword generics initiative"
bots = []

[access.teams]
security = "pull"

[access.individuals]
rylev = "admin"
badboy = "admin"
jdno = "admin"
pietroalbini = "admin"
rust-lang-owner = "admin"
oli-obk = "write"
nikomatsakis = "write"
yoshuawuyts = "write"
Mark-Simulacrum = "admin"
```