### PR TITLE
Add mdbook repo under automation

### DIFF
--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "mdBook"
+description = "Create book from markdown files. Like Gitbook but implemented in Rust"
+bots = ["rustbot"]
+
+[access.teams]
+devtools = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["Success gate"]
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/mdBook

The `rust-mdbook-deploy` user looked.. intriguing, so I kept it there.

CC @ehuss

Extracted from GH:
```
org = "rust-lang"
name = "mdBook"
description = "Create book from markdown files. Like Gitbook but implemented in Rust"
bots = []

[access.teams]
infra = "pull"
security = "pull"

[access.individuals]
rust-mdbook-deploy = "write"
Mark-Simulacrum = "admin"
badboy = "admin"
ehuss = "write"
jdno = "admin"
rust-lang-owner = "admin"
Dylan-DPC = "write"
rustbot = "write"
rylev = "admin"
pietroalbini = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = ["Success gate"]
dismiss-stale-review = false
pr-required = true
review-required = false
```