### PR TITLE
Add rust-by-example repo under automation

### DIFF
--- a/repos/rust-lang/rust-by-example.toml
+++ b/repos/rust-lang/rust-by-example.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust-by-example"
+description = "Learn Rust with examples (Live code editor included)"
+bots = ["rustbot"]
+
+[access.teams]
+wg-rust-by-example = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-by-example

It seems that `highfive` is no longer used by the repo, so I didn't keep it.

CC @marioidival

Extracted from GH:
```
org = "rust-lang"
name = "rust-by-example"
description = "Learn Rust with examples (Live code editor included)"
bots = []

[access.teams]
core = "admin"
highfive = "write"
security = "pull"
wg-rust-by-example = "write"

[access.individuals]
pietroalbini = "admin"
rylev = "admin"
rustbot = "write"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
marioidival = "write"
jdno = "admin"
rust-highfive = "write"
badboy = "admin"
```