### PR TITLE
Add rustfmt repo under automation

### DIFF
--- a/repos/rust-lang/rustfmt.toml
+++ b/repos/rust-lang/rustfmt.toml
@@ -1,0 +1,33 @@
+org = "rust-lang"
+name = "rustfmt"
+description = "Format Rust code"
+bots = ["rustbot"]
+
+[access.teams]
+rustfmt = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = [
+    "(x86_64-unknown-linux-gnu, nightly)",
+    "(x86_64-unknown-linux-gnu, stable)",
+    "(x86_64-apple-darwin, nightly)",
+    "(x86_64-apple-darwin, stable)",
+    "(x86_64-pc-windows-msvc, nightly)",
+    "(i686-pc-windows-msvc, nightly)",
+    "(i686-pc-windows-msvc, stable)",
+    "(i686-pc-windows-gnu, stable)",
+    "(i686-pc-windows-gnu, nightly)",
+    "(x86_64-pc-windows-gnu, nightly)",
+    "(x86_64-pc-windows-msvc, stable)",
+    "(x86_64-pc-windows-gnu, stable)",
+    "rustdoc check",
+]
+
+[[branch-protections]]
+pattern = "libsyntax"
+required-approvals = 0
+
+[[branch-protections]]
+pattern = "rust-1.*"
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustfmt

Extracted from GH:
```
org = "rust-lang"
name = "rustfmt"
description = "Format Rust code"
bots = []

[access.teams]
security = "pull"
bots = "write"
rustfmt = "write"

[access.individuals]
badboy = "admin"
ytmimi = "write"
calebcartwright = "admin"
rustbot = "write"
nrc = "write"
rust-lang-owner = "admin"
rylev = "admin"
pietroalbini = "admin"
rust-timer = "write"
Mark-Simulacrum = "admin"
jdno = "admin"
rust-highfive = "write"
bors = "write"

[[branch-protections]]
pattern = "master"
ci-checks = [
    "(x86_64-unknown-linux-gnu, nightly)",
    "(x86_64-unknown-linux-gnu, stable)",
    "(x86_64-apple-darwin, nightly)",
    "(x86_64-apple-darwin, stable)",
    "(x86_64-pc-windows-msvc, nightly)",
    "(i686-pc-windows-msvc, nightly)",
    "(i686-pc-windows-msvc, stable)",
    "(i686-pc-windows-gnu, stable)",
    "(i686-pc-windows-gnu, nightly)",
    "(x86_64-pc-windows-gnu, nightly)",
    "(x86_64-pc-windows-msvc, stable)",
    "(x86_64-pc-windows-gnu, stable)",
    "rustdoc check",
]
dismiss-stale-review = false
pr-required = true
review-required = true

[[branch-protections]]
pattern = "libsyntax"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false

[[branch-protections]]
pattern = "rust-1.*"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```