### PR TITLE
Add hashbrown repo under automation

### DIFF
--- a/repos/rust-lang/hashbrown.toml
+++ b/repos/rust-lang/hashbrown.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "hashbrown"
+description = "Rust port of Google's SwissTable hash map"
+bots = ["bors"]
+
+[access.teams]
+libs = "write"
+libs-contributors = "write"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/hashbrown

CC @Amanieu

Extracted from GH:
```
org = "rust-lang"
name = "hashbrown"
description = "Rust port of Google's SwissTable hash map"
bots = []

[access.teams]
libs-api = "write"
libs-contributors = "write"
bots = "write"
libs = "write"
security = "pull"

[access.individuals]
badboy = "admin"
kennytm = "write"
pietroalbini = "admin"
ChrisDenton = "write"
workingjubilee = "write"
thomcc = "write"
dtolnay = "write"
joshtriplett = "write"
rust-highfive = "write"
m-ou-se = "write"
the8472 = "write"
JohnTitor = "write"
SimonSapin = "write"
bors = "write"
sunfishcode = "write"
yaahc = "write"
jdno = "admin"
rylev = "admin"
cramertj = "write"
KodrAus = "write"
rust-timer = "write"
rust-lang-owner = "admin"
cuviper = "write"
rustbot = "write"
Amanieu = "admin"
BurntSushi = "write"
Mark-Simulacrum = "admin"
```