### PR TITLE
Add portable-simd repo under automation

### DIFF
--- a/repos/rust-lang/portable-simd.toml
+++ b/repos/rust-lang/portable-simd.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "portable-simd"
+description = "The testing ground for the future of portable SIMD in Rust"
+bots = []
+
+[access.teams]
+project-portable-simd = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["x86-tests"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/portable-simd

CC @calebzulawski, mainly about the branch protection.

Extracted from GH:
```
org = "rust-lang"
name = "portable-simd"
description = "The testing ground for the future of portable SIMD in Rust"
bots = []

[access.teams]
libs = "write"
libs-contributors = "write"
project-portable-simd = "write"
security = "pull"
libs-api = "write"

[access.individuals]
badboy = "admin"
kennytm = "write"
programmerjake = "write"
workingjubilee = "write"
rust-lang-owner = "admin"
pietroalbini = "admin"
dtolnay = "write"
cramertj = "write"
thomcc = "write"
cuviper = "write"
the8472 = "write"
jdno = "admin"
rylev = "admin"
BurntSushi = "write"
yaahc = "write"
SimonSapin = "write"
ChrisDenton = "write"
sunfishcode = "write"
miguelraz = "write"
joshtriplett = "write"
Amanieu = "write"
m-ou-se = "write"
JohnTitor = "write"
Mark-Simulacrum = "admin"
KodrAus = "write"
calebzulawski = "write"
```