### PR TITLE
Add nomicon repo under automation

### DIFF
--- a/repos/rust-lang/nomicon.toml
+++ b/repos/rust-lang/nomicon.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "nomicon"
+description = "The Dark Arts of Advanced and Unsafe Rust Programming"
+bots = []
+
+[access.teams]
+lang-docs = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["test"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/nomicon

The rustc-1-* branches looked obsolete, so I removed their branch protections.

Extracted from GH:
```
org = "rust-lang"
name = "nomicon"
description = "The Dark Arts of Advanced and Unsafe Rust Programming"
bots = []

[access.teams]
lang = "pull"
lang-docs = "write"
core = "pull"
security = "pull"

[access.individuals]
rylev = "admin"
RalfJung = "write"
JohnTitor = "write"
Mark-Simulacrum = "admin"
Gankra = "write"
rust-lang-owner = "admin"
ehuss = "write"
matthewjasper = "write"
frewsxcv = "write"
Havvy = "write"
pietroalbini = "admin"
jdno = "admin"
badboy = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = true
review-required = true

[[branch-protections]]
pattern = "rust-1.*"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```