### PR TITLE
Add miri-test-libstd repository under automation

### DIFF
--- a/repos/rust-lang/miri-test-libstd.toml
+++ b/repos/rust-lang/miri-test-libstd.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "miri-test-libstd"
+description = "Testing the Rust standard library with Miri, continuously"
+bots = []
+
+[access.teams]
+miri = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["Success"]
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/miri-test-libstd

CC @RalfJung

Extracted from GH:
```
org = "rust-lang"
name = "miri-test-libstd"
description = "Testing the Rust standard library with Miri, continuously"
bots = []

[access.teams]
miri = "write"
security = "pull"

[access.individuals]
rylev = "admin"
oli-obk = "write"
RalfJung = "write"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
badboy = "admin"
pietroalbini = "admin"
saethlin = "write"
jdno = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = ["Success"]
dismiss-stale-review = false
pr-required = true
review-required = false
```