### PR TITLE
Add reference repository under automation

### DIFF
--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "reference"
+description = "The Rust Reference"
+bots = ["rustbot"]
+
+[access.teams]
+lang-docs = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["Test"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/reference

Assigned to `lang-docs` according to https://hackmd.io/@rust-leadership-council/Bk6ge9Xu6.

Extracted from GH:
```
org = "rust-lang"
name = "reference"
description = "The Rust Reference"
bots = []

[access.teams]
security = "pull"
lang-docs = "write"
lang = "admin"
core = "admin"

[access.individuals]
Mark-Simulacrum = "admin"
QuietMisdreavus = "admin"
JohnTitor = "write"
tmandry = "admin"
pnkfelix = "admin"
Havvy = "admin"
RalfJung = "write"
Gankra = "write"
rylev = "admin"
GuillaumeGomez = "admin"
matthewjasper = "write"
badboy = "admin"
jdno = "admin"
joshtriplett = "admin"
scottmcm = "admin"
rustbot = "write"
frewsxcv = "admin"
rust-lang-owner = "admin"
pietroalbini = "admin"
steveklabnik = "write"
nikomatsakis = "admin"
ehuss = "write"

[[branch-protections]]
pattern = "master"
ci-checks = ["Test"]
dismiss-stale-review = false
pr-required = true
review-required = true
```