### PR TITLE
Add release-team repository under automation

### DIFF
--- a/repos/rust-lang/release-team.toml
+++ b/repos/rust-lang/release-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "release-team"
+description = "This repository contains all the documents related to the Rust release team."
+bots = []
+
+[access.teams]
+release = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/release-team

Extracted from GH:
```
org = "rust-lang"
name = "release-team"
description = ""
bots = []

[access.teams]
release = "write"
security = "pull"

[access.individuals]
Dylan-DPC = "write"
jdno = "admin"
rust-lang-owner = "admin"
Mark-Simulacrum = "admin"
badboy = "admin"
tmandry = "write"
pietroalbini = "admin"
cuviper = "write"
rylev = "admin"
```