### PR TITLE
Add relnotes repository under automation

### DIFF
--- a/repos/rust-lang/relnotes.toml
+++ b/repos/rust-lang/relnotes.toml
@@ -1,0 +1,21 @@
+org = "rust-lang"
+name = "relnotes"
+description = "Generate release notes for \"The Rust Programming Language\""
+bots = []
+
+[access.teams]
+release = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = [
+    "build (macos-latest, beta)",
+    "build (macos-latest, nightly)",
+    "build (macos-latest, stable)",
+    "build (ubuntu-latest, nightly)",
+    "build (ubuntu-latest, beta)",
+    "build (ubuntu-latest, stable)",
+    "build (windows-latest, beta)",
+    "build (windows-latest, nightly)",
+    "build (windows-latest, stable)",
+]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/relnotes

Extracted from GH:
```
org = "rust-lang"
name = "relnotes"
description = "Generate release notes for \"The Rust Programming Language\""
bots = []

[access.teams]
security = "pull"
release = "write"

[access.individuals]
Mark-Simulacrum = "admin"
jdno = "admin"
cuviper = "write"
rylev = "admin"
pietroalbini = "admin"
Dylan-DPC = "write"
tmandry = "write"
badboy = "admin"
rust-lang-owner = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = [
    "build (macos-latest, beta)",
    "build (macos-latest, nightly)",
    "build (macos-latest, stable)",
    "build (ubuntu-latest, nightly)",
    "build (ubuntu-latest, beta)",
    "build (ubuntu-latest, stable)",
    "build (windows-latest, beta)",
    "build (windows-latest, nightly)",
    "build (windows-latest, stable)",
]
dismiss-stale-review = false
pr-required = true
review-required = true
```