### PR TITLE
Add rust-bindgen repository under automation

### DIFF
--- a/repos/rust-lang/rust-bindgen.toml
+++ b/repos/rust-lang/rust-bindgen.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "rust-bindgen"
+description = "Automatically generates Rust FFI bindings to C (and some C++) libraries."
+bots = ["rustbot"]
+
+[access.teams]
+wg-bindgen = "write"
+
+[[branch-protections]]
+pattern = "main"
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-bindgen

Extracted from GH:
```
org = "rust-lang"
name = "rust-bindgen"
description = "Automatically generates Rust FFI bindings to C (and some C++) libraries."
bots = []

[access.teams]
security = "pull"

[access.individuals]
amanjeev = "write"
jdno = "admin"
Manishearth = "admin"
kulp = "write"
pvdrz = "write"
rylev = "admin"
scoopr = "write"
fitzgen = "admin"
badboy = "admin"
pietroalbini = "admin"
emilio = "admin"
Mark-Simulacrum = "admin"
highfive = "write"
rust-lang-owner = "admin"

[[branch-protections]]
pattern = "main"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```