### PR TITLE
Add rust-clippy repository under automation

### DIFF
--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "rust-clippy"
+description = "A bunch of lints to catch common mistakes and improve your Rust code. Book: https://doc.rust-lang.org/clippy/"
+bots = ["bors", "rustbot"]
+
+[access.teams]
+clippy = "write"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-clippy

Extracted from GH:
```
org = "rust-lang"
name = "rust-clippy"
description = "A bunch of lints to catch common mistakes and improve your Rust code. Book: https://doc.rust-lang.org/clippy/"
bots = []

[access.teams]
bors = "write"
security = "pull"
clippy = "maintain"

[access.individuals]
jdno = "admin"
rust-highfive = "write"
flip1995 = "maintain"
Manishearth = "maintain"
Alexendoo = "maintain"
xFrednet = "maintain"
dswij = "maintain"
blyxyas = "maintain"
rylev = "admin"
giraffate = "maintain"
Mark-Simulacrum = "admin"
llogiq = "maintain"
Centri3 = "maintain"
matthiaskrgr = "maintain"
badboy = "admin"
rustbot = "write"
rust-lang-owner = "admin"
pietroalbini = "admin"
Jarcho = "maintain"
bors = "write"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```