### PR TITLE
Create a GitHub team for wg-bindgen

### DIFF
--- a/teams/wg-bindgen.toml
+++ b/teams/wg-bindgen.toml
@@ -16,3 +16,6 @@ description = "Developing tools for generating FFI bindings"
 repo = "https://github.com/rust-lang-nursery/rust-bindgen"
 discord-invite = "https://discord.gg/kgujzMR"
 discord-name = "#wg-bindgen"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Required for https://github.com/rust-lang/team/pull/1259.