### PR TITLE
Weaken branch protection on portable-simd

### DIFF
--- a/repos/rust-lang/portable-simd.toml
+++ b/repos/rust-lang/portable-simd.toml
@@ -8,4 +8,4 @@ project-portable-simd = "write"
 
 [[branch-protections]]
 pattern = "master"
-ci-checks = ["x86-tests"]
+required-approvals = 0


### PR DESCRIPTION
Requested [here](https://github.com/rust-lang/team/pull/1252#issuecomment-1904719496).

Removes the need for CI to pass, and also removes the requirement to have an approval on PRs.