### PR TITLE
Add stdarch repository under automation

### DIFF
--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "stdarch"
+description = "Rust's standard library vendor-specific APIs and run-time feature detection"
+bots = ["rustbot"]
+
+[access.teams]
+libs = "write"
+
+[[branch-protections]]
+pattern = "master"
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/stdarch

The two old branch protections (see below) looked suspicious, so I removed them, and only kept `master`. The proposed branch protection requires PRs, but not PR approvals.

CC @Amanieu

Extracted from GH:
```
org = "rust-lang"
name = "stdarch"
description = "Rust's standard library vendor-specific APIs and run-time feature detection"
bots = []

[access.teams]
libs-contributors = "write"
security = "pull"
release = "write"
libs = "write"
bots = "write"
libs-api = "write"

[access.individuals]
joshtriplett = "write"
gnzlbg = "admin"
rust-highfive = "write"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
rust-timer = "write"
workingjubilee = "write"
dtolnay = "write"
BurntSushi = "write"
Amanieu = "write"
m-ou-se = "write"
jdno = "admin"
rylev = "admin"
yaahc = "write"
bors = "write"
cuviper = "write"
ChrisDenton = "write"
JohnTitor = "write"
Dylan-DPC = "write"
SimonSapin = "write"
lu-zero = "write"
sunfishcode = "write"
kennytm = "write"
KodrAus = "write"
badboy = "admin"
rustbot = "write"
pietroalbini = "admin"
thomcc = "write"
cramertj = "write"
the8472 = "write"
tmandry = "write"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false

[[branch-protections]]
pattern = "rust-1.28.0"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false

[[branch-protections]]
pattern = "*do-not-delete*"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```