### PR TITLE
Add wg-allocators repository under automation

### DIFF
--- a/repos/rust-lang/wg-allocators.toml
+++ b/repos/rust-lang/wg-allocators.toml
@@ -4,4 +4,4 @@ description = "Home of the Allocators working group: Paving a path for a standar
 bots = []
 
 [access.teams]
-wg-allocators = "write"
+wg-allocators = "maintain"

--- a/repos/rust-lang/wg-allocators.toml
+++ b/repos/rust-lang/wg-allocators.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "wg-allocators"
+description = "Home of the Allocators working group: Paving a path for a standard set of allocator traits to be used in collections!"
+bots = []
+
+[access.teams]
+wg-allocators = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/wg-allocators

Extracted from GH:
```
org = "rust-lang"
name = "wg-allocators"
description = "Home of the Allocators working group: Paving a path for a standard set of allocator traits to be used in collections!"
bots = []

[access.teams]
security = "pull"

[access.individuals]
rust-lang-owner = "admin"
TimDiekmann = "admin"
SimonSapin = "admin"
ErichDonGubler = "admin"
jdno = "admin"
badboy = "admin"
pietroalbini = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
```