### PR TITLE
Add wg-async repository under automation

### DIFF
--- a/repos/rust-lang/wg-async.toml
+++ b/repos/rust-lang/wg-async.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "wg-async"
+description = "Working group dedicated to improving the foundations of Async I/O in Rust"
+bots = ["rustbot"]
+
+[access.teams]
+wg-async = "write"
+
+[[branch-protections]]
+pattern = "master"
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/wg-async

The branch protection requires a PR, but not approvals.

CC @traviscross

Extracted from GH:
```
org = "rust-lang"
name = "wg-async"
description = "Working group dedicated to improving the foundations of Async I/O in Rust"
bots = []

[access.teams]
compiler = "write"
libs = "write"
lang = "write"
security = "pull"
libs-api = "write"
wg-async = "write"

[access.individuals]
davidtwco = "write"
Mark-Simulacrum = "admin"
Amanieu = "write"
matthewjasper = "write"
badboy = "admin"
nagisa = "write"
joshtriplett = "write"
tmandry = "admin"
pnkfelix = "write"
thomcc = "write"
guswynn = "write"
Aaron1011 = "write"
BurntSushi = "write"
jdno = "admin"
the8472 = "write"
rust-lang-owner = "admin"
wesleywiser = "write"
yoshuawuyts = "write"
nrc = "write"
scottmcm = "write"
vincenzopalazzo = "write"
lcnr = "write"
nikomatsakis = "write"
rylev = "admin"
michaelwoerister = "write"
cuviper = "write"
m-ou-se = "write"
estebank = "write"
eholk = "write"
oli-obk = "write"
traviscross = "write"
eddyb = "write"
jackh726 = "write"
pietroalbini = "admin"
compiler-errors = "write"
taiki-e = "write"
petrochenkov = "write"
cjgillot = "write"
dtolnay = "write"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = false
review-required = false
```