### PR TITLE
Add wg-cargo-std-aware repository under automation

### DIFF
--- a/repos/rust-lang/wg-cargo-std-aware.toml
+++ b/repos/rust-lang/wg-cargo-std-aware.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "wg-cargo-std-aware"
+description = "Repo for working on \"std aware cargo\""
+bots = []
+
+[access.teams]
+cargo = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/wg-cargo-std-aware

CC @ehuss

Extracted from GH:
```
org = "rust-lang"
name = "wg-cargo-std-aware"
description = "Repo for working on \"std aware cargo\""
bots = []

[access.teams]
security = "pull"
cargo = "maintain"

[access.individuals]
rylev = "admin"
Eh2406 = "maintain"
joshtriplett = "maintain"
weihanglo = "maintain"
Muscraft = "maintain"
arlosi = "maintain"
rust-lang-owner = "admin"
ehuss = "maintain"
badboy = "admin"
epage = "maintain"
jdno = "admin"
jamesmunns = "maintain"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
```