### PR TITLE
Add wg-debugging repository under automation

### DIFF
--- a/repos/rust-lang/wg-debugging.toml
+++ b/repos/rust-lang/wg-debugging.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "wg-debugging"
+description = "Work on debugging Rust code, under the compiler team."
+bots = []
+
+[access.teams]
+wg-debugging = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/wg-debugging

Extracted from GH:
```
org = "rust-lang"
name = "wg-debugging"
description = "Work on debugging Rust code, under the compiler team."
bots = []

[access.teams]
security = "pull"
wg-debugging = "write"
compiler = "maintain"

[access.individuals]
oli-obk = "maintain"
nagisa = "maintain"
wesleywiser = "maintain"
michaelwoerister = "maintain"
eddyb = "maintain"
compiler-errors = "maintain"
lcnr = "maintain"
Mark-Simulacrum = "admin"
jackh726 = "maintain"
pnkfelix = "maintain"
rust-lang-owner = "admin"
badboy = "admin"
rylev = "admin"
Aaron1011 = "maintain"
cjgillot = "maintain"
pietroalbini = "admin"
petrochenkov = "maintain"
davidtwco = "maintain"
estebank = "maintain"
matthewjasper = "maintain"
jdno = "admin"
```