### PR TITLE
Add wg-grammar repository under automation

### DIFF
--- a/repos/rust-lang/wg-grammar.toml
+++ b/repos/rust-lang/wg-grammar.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "wg-grammar"
+description = "Where the work of WG-grammar, aiming to provide a canonical grammar for Rust, resides"
+bots = []
+
+[access.teams]
+wg-grammar = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/wg-grammar

Extracted from GH:
```
org = "rust-lang"
name = "wg-grammar"
description = "Where the work of WG-grammar, aiming to provide a canonical grammar for Rust, resides"
bots = []

[access.teams]
security = "pull"
wg-grammar = "admin"

[access.individuals]
eddyb = "admin"
CAD97 = "admin"
rust-lang-owner = "admin"
pietroalbini = "admin"
badboy = "admin"
rylev = "admin"
jdno = "admin"
Mark-Simulacrum = "admin"
```