### PR TITLE
Add www.rust-lang.org repository under automation

### DIFF
--- a/repos/rust-lang/www.rust-lang.org.toml
+++ b/repos/rust-lang/www.rust-lang.org.toml
@@ -1,0 +1,18 @@
+org = "rust-lang"
+name = "www.rust-lang.org"
+description = "The home of the Rust website"
+homepage = "https://www.rust-lang.org"
+bots = ["rustbot"]
+
+[access.teams]
+# Admin is needed for integrating with external services, e.g. Pontoon
+website = "admin"
+
+[[branch-protections]]
+pattern = "master"
+pr-required = false
+
+[[branch-protections]]
+pattern = "deploy"
+pr-required = false
+allowed-merge-teams = ["website"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/www.rust-lang.org

CC @dtolnay @Manishearth

Extracted from GH:
```
org = "rust-lang"
name = "www.rust-lang.org"
description = "The home of the Rust website"
bots = []

[access.teams]
website = "write"
security = "pull"

[access.individuals]
pietroalbini = "admin"
MarcoIeni = "admin"
senekor = "write"
Mark-Simulacrum = "admin"
rustbot = "write"
rust-pontoon-trial = "write"
Manishearth = "write"
rust-lang-owner = "admin"
jdno = "admin"

[[branch-protections]]
pattern = "master"
required-approvals = 0
pr-required = false

[[branch-protections]]
pattern = "deploy"
required-approvals = 0
pr-required = false
restrict-pushes = true
allowed-merge-teams = ["website"]

[[branch-protections]]
pattern = "try"
required-approvals = 0
pr-required = false
```