### PR TITLE
Add zulip_archive repository under automation

### DIFF
--- a/repos/rust-lang/zulip_archive.toml
+++ b/repos/rust-lang/zulip_archive.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "zulip_archive"
+description = "A tool for archiving and displaying Zulip chat channels."
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/zulip_archive

Extracted from GH:
```toml
org = "rust-lang"
name = "zulip_archive"
description = "A tool for archiving and displaying Zulip chat channels."
bots = []

[access.teams]
bors = "pull"
bots = "pull"
infra = "pull"
security = "pull"

[access.individuals]
rust-lang-owner = "admin"
jdno = "admin"
badboy = "admin"
pietroalbini = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
```