### PR TITLE
Add web-presence-team repository under automation

### DIFF
--- a/repos/rust-lang/web-presence-team.toml
+++ b/repos/rust-lang/web-presence-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "web-presence-team"
+description = "Home of the Web Presence Team"
+bots = []
+
+[access.teams]
+web-presence = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/web-presence-team

Extracted from GH:
```toml
org = "rust-lang"
name = "web-presence-team"
description = "Home of the Web Presence Team"
bots = []

[access.teams]
security = "pull"

[access.individuals]
badboy = "admin"
rylev = "admin"
jdno = "admin"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
```