### PR TITLE
Add rustc-rayon repository under automation

### DIFF
--- a/repos/rust-lang/rustc-rayon.toml
+++ b/repos/rust-lang/rustc-rayon.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "rustc-rayon"
+description = "Rayon: A data parallelism library for Rust"
+bots = []
+
+[access.teams]
+compiler = "write"
+compiler-contributors = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustc-rayon

Extracted from GH:
```toml
org = "rust-lang"
name = "rustc-rayon"
description = "Rayon: A data parallelism library for Rust"
bots = []

[access.teams]
compiler = "admin"
release = "admin"
security = "pull"
core = "admin"

[access.individuals]
jdno = "admin"
petrochenkov = "admin"
cuviper = "admin"
pietroalbini = "admin"
jackh726 = "admin"
Dylan-DPC = "admin"
matthewjasper = "admin"
tmandry = "admin"
oli-obk = "admin"
nagisa = "admin"
Mark-Simulacrum = "admin"
davidtwco = "admin"
eddyb = "admin"
wesleywiser = "admin"
compiler-errors = "admin"
lcnr = "admin"
badboy = "admin"
Aaron1011 = "admin"
rylev = "admin"
pnkfelix = "admin"
cjgillot = "admin"
estebank = "admin"
rust-lang-owner = "admin"
michaelwoerister = "admin"
```