### PR TITLE
Add rust-installer repository under automation

### DIFF
--- a/repos/rust-lang/rust-installer.toml
+++ b/repos/rust-lang/rust-installer.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "rust-installer"
+description = "The Bourne shell installer used by Rust and Cargo"
+bots = []
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-installer

Assigned to `infra`, according to https://hackmd.io/@rust-leadership-council/Bk6ge9Xu6.

Extracted from GH:
```toml
org = "rust-lang"
name = "rust-installer"
description = "The Bourne shell installer used by Rust and Cargo"
bots = []

[access.teams]
core = "admin"
security = "pull"
highfive = "write"

[access.individuals]
badboy = "admin"
pietroalbini = "admin"
jdno = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
rustbot = "write"
rust-highfive = "write"
rust-lang-owner = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = []
dismiss-stale-review = false
pr-required = true
review-required = true
```