### PR TITLE
Add promote-release repository under automation

### DIFF
--- a/repos/rust-lang/promote-release.toml
+++ b/repos/rust-lang/promote-release.toml
@@ -1,0 +1,18 @@
+org = "rust-lang"
+name = "promote-release"
+description = "Tooling to publish Rust releases."
+bots = []
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = [
+    "Local release (beta)",
+    "Local release (nightly)",
+    "Local release (stable)",
+    "Build Docker image",
+    "Test",
+]
+required-approvals = 0


### PR DESCRIPTION
Repo: https://github.com/rust-lang/promote-release

Extracted from GH:
```toml
org = "rust-lang"
name = "promote-release"
description = "Tooling to publish Rust releases."
bots = []

[access.teams]
infra = "write"
security = "pull"

[access.individuals]
shepmaster = "write"
Mark-Simulacrum = "admin"
Kobzol = "write"
rust-lang-owner = "admin"
badboy = "admin"
pietroalbini = "admin"
kennytm = "write"
jdno = "admin"
rylev = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = [
    "Local release (beta)",
    "Local release (nightly)",
    "Local release (stable)",
    "Build Docker image",
    "Test",
]
dismiss-stale-review = false
pr-required = true
review-required = false
```