### PR TITLE
Add project-error-handling repository under automation

### DIFF
--- a/repos/rust-lang/project-error-handling.toml
+++ b/repos/rust-lang/project-error-handling.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "project-error-handling"
+description = "Error handling project group"
+bots = []
+
+[access.teams]
+project-error-handling = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/project-error-handling

Extracted from GH:
```toml
org = "rust-lang"
name = "project-error-handling"
description = "Error handling project group"
bots = []

[access.teams]
security = "pull"
libs = "write"
project-error-handling = "write"
libs-api = "write"

[access.individuals]
jdno = "admin"
cuviper = "write"
nagashi = "write"
badboy = "admin"
thomcc = "write"
mystor = "write"
yaahc = "write"
rust-lang-owner = "admin"
joshtriplett = "write"
Amanieu = "write"
the8472 = "write"
seanchen1991 = "write"
rylev = "admin"
dtolnay = "write"
Mark-Simulacrum = "admin"
pietroalbini = "admin"
BurntSushi = "write"
JDuchniewicz = "write"
m-ou-se = "write"
```