### PR TITLE
Add command for dumping users with individual access

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ cargo run dump-website
 
 The website will automatically load new teams added here, however they cannot be translated unless `tools.ftl` is also updated.
 
+You can also print a list of users with individual access to repositories
+
+```
+# Group the accesses by repository
+cargo run dump-individual-access --group-mode repo
+
+# Group the accesses by contributor
+cargo run dump-individual-access --group-mode person
+```
+
+
 ### Building the static API
 
 You can build locally the content of `https://team-api.infra.rust-lang.org/v1/`

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -763,7 +763,7 @@ pub(crate) struct RepoAccess {
     pub individuals: HashMap<String, RepoPermission>,
 }
 
-#[derive(serde_derive::Deserialize, Debug)]
+#[derive(serde_derive::Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) enum RepoPermission {
     Triage,


### PR DESCRIPTION
Proposed by @rylev [here](https://github.com/rust-lang/team/pull/1271#issuecomment-1905699241).

Allows us to see how many individual accesses there are (we want to eventually get rid of these).