### PR TITLE
Add generate-manifest-list repository under automation

### DIFF
--- a/repos/rust-lang/generate-manifest-list.toml
+++ b/repos/rust-lang/generate-manifest-list.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "generate-manifest-list"
+description = "Creates a list of manifests on static.rust-lang.org"
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/generate-manifest-list

Extracted from GH:
```toml
org = "rust-lang"
name = "generate-manifest-list"
description = "Creates a list of manifests on static.rust-lang.org"
bots = []

[access.teams]
security = "pull"

[access.individuals]
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
rylev = "admin"
badboy = "admin"
jdno = "admin"
```