### PR TITLE
Add areweasyncyet.rs repository under automation

### DIFF
--- a/people/upsuper.toml
+++ b/people/upsuper.toml
@@ -1,0 +1,3 @@
+name = "Xidorn Quan"
+github = "upsuper"
+github-id = 333750

--- a/repos/rust-lang/areweasyncyet.rs.toml
+++ b/repos/rust-lang/areweasyncyet.rs.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "areweasyncyet.rs"
+description = "Are we async yet?"
+bots = []
+
+[access.teams]
+wg-async = "write"
+
+[access.individuals]
+upsuper = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/areweasyncyet.rs

It seems that `upsuper` is maintaining this repo.

Extracted from GH:
```toml
org = "rust-lang"
name = "areweasyncyet.rs"
description = "Are we async yet?"
bots = []

[access.teams]
security = "pull"

[access.individuals]
rust-lang-owner = "admin"
jdno = "admin"
upsuper = "write"
Mark-Simulacrum = "admin"
pietroalbini = "admin"
badboy = "admin"
rylev = "admin"
```