### PR TITLE
Update project-stable-mir.toml

### DIFF
--- a/teams/project-stable-mir.toml
+++ b/teams/project-stable-mir.toml
@@ -27,3 +27,4 @@ orgs = ["rust-lang"]
 
 [permissions]
 bors.rust.review = true
+bors.project-stable-mir.review = true


### PR DESCRIPTION
Bors still doesn't seem to work in our repository, and it seems that we can't merge things manually any more.

Is there any other step we need to take to enable bors?