### PR TITLE
Add `people` field to the `permissions` API

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -125,9 +125,17 @@ pub struct ZulipGroups {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Permission {
+    pub people: Vec<PermissionPerson>,
     pub github_users: Vec<String>,
     pub github_ids: Vec<usize>,
     pub discord_ids: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PermissionPerson {
+    pub github_id: usize,
+    pub github: String,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -290,9 +290,23 @@ impl<'a> Generator<'a> {
             github_users.sort();
             github_ids.sort_unstable();
             discord_ids.sort_unstable();
+
+            let mut people = allowed
+                .iter()
+                .map(|p| v1::PermissionPerson {
+                    name: p.name().into(),
+                    github: p.github().into(),
+                    github_id: p.github_id(),
+                })
+                .collect::<Vec<_>>();
+
+            // The sort operation here is necessary to ensure a stable output for the snapshot tests.
+            people.sort();
+
             self.add(
                 &format!("v1/permissions/{}.json", perm.replace('-', "_")),
                 &v1::Permission {
+                    people,
                     github_users,
                     github_ids,
                     discord_ids,

--- a/tests/static-api/_expected/v1/permissions/bors.crater.review.json
+++ b/tests/static-api/_expected/v1/permissions/bors.crater.review.json
@@ -1,4 +1,5 @@
 {
+  "people": [],
   "github_users": [],
   "github_ids": [],
   "discord_ids": []

--- a/tests/static-api/_expected/v1/permissions/bors.crater.try.json
+++ b/tests/static-api/_expected/v1/permissions/bors.crater.try.json
@@ -1,4 +1,21 @@
 {
+  "people": [
+    {
+      "github_id": 0,
+      "github": "user-0",
+      "name": "Zeroth user"
+    },
+    {
+      "github_id": 0,
+      "github": "user-1",
+      "name": "First user"
+    },
+    {
+      "github_id": 2,
+      "github": "user-2",
+      "name": "Second user"
+    }
+  ],
   "github_users": [
     "user-0",
     "user-1",

--- a/tests/static-api/_expected/v1/permissions/bors.crates_io.review.json
+++ b/tests/static-api/_expected/v1/permissions/bors.crates_io.review.json
@@ -1,4 +1,26 @@
 {
+  "people": [
+    {
+      "github_id": 0,
+      "github": "user-0",
+      "name": "Zeroth user"
+    },
+    {
+      "github_id": 0,
+      "github": "user-1",
+      "name": "First user"
+    },
+    {
+      "github_id": 2,
+      "github": "user-2",
+      "name": "Second user"
+    },
+    {
+      "github_id": 6,
+      "github": "user-6",
+      "name": "Sixth user"
+    }
+  ],
   "github_users": [
     "user-0",
     "user-1",

--- a/tests/static-api/_expected/v1/permissions/bors.crates_io.try.json
+++ b/tests/static-api/_expected/v1/permissions/bors.crates_io.try.json
@@ -1,4 +1,26 @@
 {
+  "people": [
+    {
+      "github_id": 0,
+      "github": "user-0",
+      "name": "Zeroth user"
+    },
+    {
+      "github_id": 0,
+      "github": "user-1",
+      "name": "First user"
+    },
+    {
+      "github_id": 2,
+      "github": "user-2",
+      "name": "Second user"
+    },
+    {
+      "github_id": 6,
+      "github": "user-6",
+      "name": "Sixth user"
+    }
+  ],
   "github_users": [
     "user-0",
     "user-1",

--- a/tests/static-api/_expected/v1/permissions/crater.json
+++ b/tests/static-api/_expected/v1/permissions/crater.json
@@ -1,4 +1,21 @@
 {
+  "people": [
+    {
+      "github_id": 0,
+      "github": "user-0",
+      "name": "Zeroth user"
+    },
+    {
+      "github_id": 0,
+      "github": "user-1",
+      "name": "First user"
+    },
+    {
+      "github_id": 2,
+      "github": "user-2",
+      "name": "Second user"
+    }
+  ],
   "github_users": [
     "user-0",
     "user-1",


### PR DESCRIPTION
This PR is similar to https://github.com/rust-lang/team/pull/1196, but adds the new fields to the v1 API instead of introducing a new API version.

---

The v1 permissions API can be misleading in that the order of the `github_users` does not match the order of the `github_ids` (see https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/team.20repo.20integration/near/412320079).

This change introduces a new `people` field on the `permissions` API which uses a list of objects instead of an object with multiple single-field lists. This allows us to easily show both GitHub login and ID of a person in the logs.

## Example

```json
{
  "people": [
    {
      "name": "Aaron Hill",
      "github": "Aaron1011",
      "github_id": 1408859,
      "discord_id": null
    },
    {
      "name": "Ed Page",
      "github": "epage",
      "github_id": 60961,
      "discord_id": null
    },
    {
      "name": "Jamie Hill-Daniel",
      "github": "clubby789",
      "github_id": 13556931,
      "discord_id": 85400548534145024
    }
  ]
}
```

Closes https://github.com/rust-lang/team/pull/1196

r? @rust-lang/infra 