### PR TITLE
Add a CI check for `stdarch`

### DIFF
--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -8,4 +8,5 @@ libs = "write"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["success"]
 required-approvals = 0


### PR DESCRIPTION
Related PR: https://github.com/rust-lang/stdarch/pull/1519 (this should only be merged after that PR).

We have discussed this with @Amanieu.