### PR TITLE
Re-introduce rust-analyzer-contributors

### DIFF
--- a/people/alibektas.toml
+++ b/people/alibektas.toml
@@ -1,0 +1,5 @@
+name = "Ali Bektas"
+github = "alibektas"
+github-id = 20956650
+email = "bektasali@protonmail.com"
+zulip-id = 605758

--- a/people/davidbarsky.toml
+++ b/people/davidbarsky.toml
@@ -1,0 +1,5 @@
+name = "David Barsky"
+github = "davidbarsky"
+github-id = 2067774
+email = "me@davidbarsky.com"
+zulip-id = 198819

--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -5,6 +5,7 @@ bots = ["bors", "rustbot"]
 
 [access.teams]
 rust-analyzer = "write"
+rust-analyzer-contributors = "triage"
 
 [[branch-protections]]
 pattern = "master"

--- a/teams/rust-analyzer-contributors.toml
+++ b/teams/rust-analyzer-contributors.toml
@@ -1,0 +1,20 @@
+name = "rust-analyzer-contributors"
+subteam-of = "rust-analyzer"
+
+[people]
+leads = []
+members = [
+    "alibektas",
+    "bjorn3",
+    "davidbarsky",
+    "Nadrieril",
+]
+alumni = []
+
+[website]
+name = "rust-analyzer team contributors"
+description = "Contributing to the rust-analyzer compiler front-end on a regular basis"
+repo = "https://github.com/rust-lang/rust-analyzer"
+
+[[github]]
+orgs = ["rust-lang", "rust-analyzer"]

--- a/teams/rust-analyzer.toml
+++ b/teams/rust-analyzer.toml
@@ -7,7 +7,6 @@ members = [
     "lnicola",
     "Veykril",
     "flodiebold",
-    "bjorn3",
     "lowr",
     "HKalbasi",
 ]


### PR DESCRIPTION
We kind of have a use for this again now

@rust-lang/rust-analyzer 