### PR TITLE
Rename measureme CI check name

### DIFF
--- a/repos/rust-lang/measureme.toml
+++ b/repos/rust-lang/measureme.toml
@@ -8,8 +8,8 @@ compiler = "write"
 
 [[branch-protections]]
 pattern = "master"
-ci-checks = ["build"]
+ci-checks = ["success"]
 
 [[branch-protections]]
 pattern = "stable"
-ci-checks = ["build"]
+ci-checks = ["success"]


### PR DESCRIPTION
Use a conclusion success job to avoid enumerating all the CI jobs from `measureme`.