### PR TITLE
Only allow infra-admins to merge into `sync-team`

### DIFF
--- a/repos/rust-lang/sync-team.toml
+++ b/repos/rust-lang/sync-team.toml
@@ -9,3 +9,4 @@ infra = "write"
 [[branch-protections]]
 pattern = "master"
 ci-checks = ["CI"]
+allowed-merge-teams = ["infra-admins"]

--- a/teams/infra-admins.toml
+++ b/teams/infra-admins.toml
@@ -14,7 +14,7 @@ alumni = [
 ]
 
 [[github]]
-orgs = ["rust-lang-deprecated"]
+orgs = ["rust-lang-deprecated", "rust-lang"]
 
 [permissions]
 sync-team-confirmation = true


### PR DESCRIPTION
Let's take https://github.com/rust-lang/team/pull/1282 for a test drive.