### PR TITLE
Add branch protection for compiler-builtins

### DIFF
--- a/repos/rust-lang/compiler-builtins.toml
+++ b/repos/rust-lang/compiler-builtins.toml
@@ -5,3 +5,8 @@ bots = []
 
 [access.teams]
 crate-maintainers = 'maintain'
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["success"]
+required-approvals = 0


### PR DESCRIPTION
Requested by Amanieu, to enable CI checks on the `master` branch.

Blocked on https://github.com/rust-lang/compiler-builtins/pull/569.