### PR TITLE
Add myself to libs-contributors

### DIFF
--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -16,6 +16,7 @@ members = [
   "sunfishcode",
   "yaahc",
   "Nilstrieb",
+  "jhpratt",
 ]
 alumni = [
   "shepmaster",


### PR DESCRIPTION
I would like to review some PRs here and there. I don't see any way to "just" give review permissions, so I have added myself to libs-contributors. If granting me review permissions is acceptable, I don't particularly care how this works under the hood.

One question, though. Does this add me to a reviewer rotation? I would prefer to **not** have this be the case.