### PR TITLE
remove branch protections from regex repo

### DIFF
--- a/repos/rust-lang/regex.toml
+++ b/repos/rust-lang/regex.toml
@@ -5,8 +5,3 @@ bots = []
 
 [access.teams]
 regex = "maintain"
-
-[[branch-protections]]
-pattern = "master"
-ci-checks = []
-required-approvals = 0


### PR DESCRIPTION
Commit 55158aeb89463e1fc2d8e5b5321810cb70757fc3 introduced automation
for the regex repo but also enabled branch protection for `master`. The
regex repo has never used branch protection and it is low traffic enough
to be annoying.

While most changes go in through a PR, I do for example push directly to
master when cutting a release (which is done through my own automation
locally).
