### PR TITLE
Remove spastorino from project-trait-system-refactor.toml

### DIFF
--- a/teams/project-trait-system-refactor.toml
+++ b/teams/project-trait-system-refactor.toml
@@ -12,7 +12,6 @@ members = [
     "BoxyUwU",
     "cjgillot",
     "compiler-errors",
-    "spastorino",
     "lcnr",
 ]
 alumni = []


### PR DESCRIPTION
I've originally added myself with the intention of helping with the refactor and did a couple of small PRs but then ended involved in other things. Removing myself without even adding me to alumni properly reflect my relationship with the refactor :).