### PR TITLE
Add core-team repository under automation

### DIFF
--- a/repos/rust-lang/core-team.toml
+++ b/repos/rust-lang/core-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "core-team"
+description = "A place to house minutes and other documents related to the core team."
+bots = []
+
+[access.teams]
+core = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/core-team

(candidate for archival).

Extracted from GH:
```toml
org = "rust-lang"
name = "core-team"
description = "A place to house minutes and other documents related to the core team."
bots = []

[access.teams]
core = "admin"
security = "pull"

[access.individuals]
Mark-Simulacrum = "admin"
badboy = "admin"
jdno = "admin"
rust-lang-owner = "admin"
rust-lang-core-team-agenda-bot = "triage"
rylev = "admin"
pietroalbini = "admin"
```