### PR TITLE
Add crater repository under automation

### DIFF
--- a/repos/rust-lang/crater.toml
+++ b/repos/rust-lang/crater.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "crater"
+description = "Run experiments across parts of the Rust ecosystem!"
+bots = ["bors", "highfive"]
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["homu"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/crater

Not sure if `highfive` is needed. Also, the CI check is weird, I haven't found any job named `homu` in the CI workflows. But it's not used anyway when `bors` is enabled on the repo (AFAIK).

Extracted from GH:
```toml
org = "rust-lang"
name = "crater"
description = "Run experiments across parts of the Rust ecosystem!"
bots = []

[access.teams]
security = "pull"
bots = "write"
infra = "write"

[access.individuals]
shepmaster = "write"
Kobzol = "write"
pietroalbini = "admin"
rust-timer = "write"
bors = "write"
badboy = "admin"
kennytm = "write"
Mark-Simulacrum = "admin"
rust-highfive = "write"
rustbot = "write"
rust-lang-owner = "admin"
jdno = "admin"
rylev = "admin"

[[branch-protections]]
pattern = "master"
ci-checks = ["homu"]
required-approvals = 0
restrict-pushes = true
allowed-merge-teams = ["bors"]
```