### PR TITLE
Do not require approvals on libc 0.2 branch

### DIFF
--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -16,3 +16,4 @@ required-approvals = 0
 [[branch-protections]]
 pattern = 'libc-0.2'
 ci-checks = ['success']
+required-approvals = 0


### PR DESCRIPTION
Same as https://github.com/rust-lang/team/pull/1289 but for the libc-0.2 branch.