### PR TITLE
Add crates.io repository under automation

### DIFF
--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -1,0 +1,21 @@
+org = "rust-lang"
+name = "crates.io"
+description = "The Rust package registry"
+bots = ["bors"]
+
+[access.teams]
+crates-io = "write"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = [
+    "Backend / Lint",
+    "Backend / Test",
+    "Frontend / Lint",
+    "Frontend / Test",
+    "Backend / cargo-deny",
+]
+required-approvals = 0
+allowed-merge-teams = [
+    "crates-io",
+]

--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -1,6 +1,7 @@
 org = "rust-lang"
 name = "crates.io"
 description = "The Rust package registry"
+homepage = "https://crates.io"
 bots = ["bors"]
 
 [access.teams]

--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -17,6 +17,3 @@ ci-checks = [
     "Backend / cargo-deny",
 ]
 required-approvals = 0
-allowed-merge-teams = [
-    "crates-io",
-]

--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "crates.io"
 description = "The Rust package registry"
 homepage = "https://crates.io"
-bots = []
+bots = ["renovate"]
 
 [access.teams]
 crates-io = "write"

--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "crates.io"
 description = "The Rust package registry"
 homepage = "https://crates.io"
-bots = ["bors"]
+bots = []
 
 [access.teams]
 crates-io = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/crates.io

Here we can see a case where both bors and the `crates-io` team had an explicit permission to push to `master`:
```toml
allowed-merge-teams = [
    "bors",
    "crates-io",
]
```
which we can now automate (`bors` is added to these teams automatically, that's why it's missing in the PR).

However, `master` didn't require a PR before. I thought that our automation always requires a PR for each protected branch, but now that I think of it, if we set `allowed-merge-teams`, which sets `pushActorIds`, and also `restrictsPushes`, then maybe this allows only pushes and not PRs? (which is how bors works?).

Extracted from GH:
```toml
org = "rust-lang"
name = "crates.io"
description = "The Rust package registry"
bots = []

[access.teams]
bots = "write"
core = "admin"
cargo = "write"
crates-io = "write"
security = "pull"
mods = "write"

[access.individuals]
ehuss = "write"
rust-highfive = "write"
rust-timer = "write"
oli-obk = "write"
epage = "write"
Turbo87 = "maintain"
rylev = "admin"
joshtriplett = "write"
Eh2406 = "write"
Mark-Simulacrum = "admin"
jdno = "admin"
mdtro = "write"
technetos = "write"
Muscraft = "write"
LawnGnome = "write"
badboy = "admin"
rustbot = "write"
rust-lang-owner = "admin"
jtgeibel = "maintain"
carols10cents = "write"
weihanglo = "write"
JohnTitor = "write"
pietroalbini = "admin"
hi-rustin = "write"
bors = "write"
arlosi = "write"

[[branch-protections]]
pattern = "main"
ci-checks = [
    "Backend / Lint",
    "Backend / Test",
    "Frontend / Lint",
    "Frontend / Test",
    "Backend / cargo-deny",
]
required-approvals = 0
pr-required = false
restrict-pushes = true
allowed-merge-teams = [
    "bors",
    "crates-io",
]
```