### PR TITLE
Add crates.io-index repository under automation

### DIFF
--- a/repos/rust-lang/crates.io-index.toml
+++ b/repos/rust-lang/crates.io-index.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "crates.io-index"
+description = "Registry index for crates.io"
+bots = []
+
+[access.teams]
+crates-io = "write"
+crates-io-on-call = "write"
+
+[[branch-protections]]
+pattern = "master"
+pr-required = false


### PR DESCRIPTION
Repo: https://github.com/rust-lang/crates.io-index

Extracted from GH:
```toml
org = "rust-lang"
name = "crates.io-index"
description = "Registry index for crates.io"
bots = []

[access.teams]
security = "pull"
crates-io = "write"
crates-io-on-call = "write"

[access.individuals]
jdno = "admin"
pietroalbini = "admin"
Xylakant = "write"
Mark-Simulacrum = "admin"
tshepang = "write"
MarcoIeni = "admin"
justahero = "write"
Turbo87 = "write"
rust-lang-owner = "admin"
Veykril = "write"
jtgeibel = "write"
mdtro = "write"
LawnGnome = "write"
skade = "write"
eth3lbert = "write"
listochkin = "write"
Rustin170506 = "write"
carols10cents = "write"

[[branch-protections]]
pattern = "master"
required-approvals = 0
pr-required = false
```