### PR TITLE
Add generic-associated-types-initiative repository under automation

### DIFF
--- a/repos/rust-lang/generic-associated-types-initiative.toml
+++ b/repos/rust-lang/generic-associated-types-initiative.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "generic-associated-types-initiative"
+description = "Generic Associated Types lang team initiative"
+bots = []
+
+[access.teams]
+initiative-generic-associated-types = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/generic-associated-types-initiative

Extracted from GH:
```toml
org = "rust-lang"
name = "generic-associated-types-initiative"
description = "Generic Associated Types lang team initiative"
bots = []

[access.teams]
lang = "maintain"
security = "pull"
initiative-generic-associated-types = "write"

[access.individuals]
Mark-Simulacrum = "admin"
pnkfelix = "maintain"
rylev = "admin"
nikomatsakis = "maintain"
tmandry = "maintain"
rust-lang-owner = "admin"
badboy = "admin"
jackh726 = "write"
joshtriplett = "maintain"
scottmcm = "maintain"
jdno = "admin"
pietroalbini = "admin"
```