### PR TITLE
Add gha-runner repository under automation

### DIFF
--- a/repos/rust-lang/gha-runner.toml
+++ b/repos/rust-lang/gha-runner.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "gha-runner"
+description = "Custom fork of the GitHub Actions runner"
+bots = []
+
+[access.teams]
+infra-admins = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/gha-runner

Extracted from GH:
```toml
org = "rust-lang"
name = "gha-runner"
description = "Custom fork of the GitHub Actions runner"
bots = []

[access.teams]
infra = "write"
security = "pull"

[access.individuals]
pietroalbini = "admin"
shepmaster = "write"
Kobzol = "write"
jdno = "admin"
rylev = "admin"
badboy = "admin"
Mark-Simulacrum = "admin"
kennytm = "write"
rust-lang-owner = "admin"
```