### PR TITLE
Add gha-self-hosted repository under automation

### DIFF
--- a/repos/rust-lang/gha-self-hosted.toml
+++ b/repos/rust-lang/gha-self-hosted.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "gha-self-hosted"
+description = "GitHub Actions self-hosted runners infrastructure"
+bots = []
+
+[access.teams]
+infra-admins = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/gha-self-hosted

Extracted from GH:
```toml
org = "rust-lang"
name = "gha-self-hosted"
description = "GitHub Actions self-hosted runners infrastructure"
bots = []

[access.teams]
infra = "write"
security = "pull"

[access.individuals]
jdno = "admin"
rylev = "admin"
badboy = "admin"
pietroalbini = "admin"
kennytm = "write"
shepmaster = "write"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
Kobzol = "write"
```