### PR TITLE
Add jobserver-rs repository under automation

### DIFF
--- a/repos/rust-lang/jobserver-rs.toml
+++ b/repos/rust-lang/jobserver-rs.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "jobserver-rs"
+description = ""
+bots = []
+
+[access.teams]
+cargo = "write"
+compiler = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/jobserver-rs

Extracted from GH:
```toml
org = "rust-lang"
name = "jobserver-rs"
description = ""
bots = []

[access.teams]
cargo = "write"
security = "pull"
compiler = "write"

[access.individuals]
pnkfelix = "write"
rylev = "admin"
michaelwoerister = "write"
eddyb = "write"
weihanglo = "write"
jackh726 = "write"
nagisa = "write"
estebank = "write"
Muscraft = "write"
cjgillot = "write"
ehuss = "write"
Aaron1011 = "write"
arlosi = "write"
Mark-Simulacrum = "admin"
epage = "write"
badboy = "admin"
davidtwco = "write"
jdno = "admin"
rust-lang-owner = "admin"
joshtriplett = "write"
petrochenkov = "write"
pietroalbini = "admin"
compiler-errors = "write"
lcnr = "write"
Eh2406 = "write"
oli-obk = "write"
matthewjasper = "write"
alexcrichton = "write"
wesleywiser = "write"
```