### PR TITLE
Add impl-trait-initiative repository under automation

### DIFF
--- a/repos/rust-lang/impl-trait-initiative.toml
+++ b/repos/rust-lang/impl-trait-initiative.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "impl-trait-initiative"
+description = "Impl trait lang team initiative"
+bots = []
+
+[access.teams]
+initiative-impl-trait = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/impl-trait-initiative

Extracted from GH:
```toml
org = "rust-lang"
name = "impl-trait-initiative"
description = "Impl trait lang team initiative"
bots = []

[access.teams]
initiative-impl-trait = "write"
lang = "maintain"
security = "pull"

[access.individuals]
joshtriplett = "maintain"
rylev = "admin"
pnkfelix = "maintain"
tmandry = "maintain"
rust-lang-owner = "admin"
pietroalbini = "admin"
oli-obk = "write"
jdno = "admin"
Mark-Simulacrum = "admin"
badboy = "admin"
nikomatsakis = "maintain"
scottmcm = "maintain"
```