### PR TITLE
Add moderation-team repository under automation

### DIFF
--- a/repos/rust-lang/moderation-team.toml
+++ b/repos/rust-lang/moderation-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "moderation-team"
+description = "Home of the Rust Moderation team."
+bots = []
+
+[access.teams]
+mods = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/moderation-team

Extracted from GH:
```toml
org = "rust-lang"
name = "moderation-team"
description = "Home of the Rust Moderation team."
bots = []

[access.teams]
mods = "write"
security = "pull"

[access.individuals]
badboy = "admin"
jdno = "admin"
technetos = "write"
oli-obk = "write"
rylev = "admin"
pietroalbini = "admin"
rust-lang-owner = "admin"
Mark-Simulacrum = "admin"
```