### PR TITLE
Add packed_simd repository under automation

### DIFF
--- a/repos/rust-lang/packed_simd.toml
+++ b/repos/rust-lang/packed_simd.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "packed_simd"
+description = "Portable Packed SIMD Vectors for Rust standard library"
+bots = []
+
+[access.teams]
+libs-contributors = "write"
+libs-api = "write"
+libs = "write"
+project-portable-simd = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/packed_simd

CC @workingjubilee regarding the permissions.

Extracted from GH:
```toml
org = "rust-lang"
name = "packed_simd"
description = "Portable Packed SIMD Vectors for Rust standard library"
bots = []

[access.teams]
libs-contributors = "write"
security = "pull"
libs-api = "write"
libs = "write"
project-portable-simd = "write"

[access.individuals]
thomcc = "write"
jdno = "admin"
miguelraz = "write"
Mark-Simulacrum = "admin"
the8472 = "write"
m-ou-se = "write"
yaahc = "write"
sunfishcode = "write"
calebzulawski = "write"
JohnTitor = "write"
badboy = "admin"
SimonSapin = "write"
rylev = "admin"
KodrAus = "write"
workingjubilee = "write"
GabrielMajeri = "write"
cuviper = "write"
joshtriplett = "write"
Amanieu = "write"
dtolnay = "write"
programmerjake = "write"
cramertj = "write"
pietroalbini = "admin"
Nilstrieb = "write"
ChrisDenton = "write"
BurntSushi = "write"
gnzlbg = "admin"
rust-lang-owner = "admin"
kennytm = "write"
```