### PR TITLE
Add pin-utils repository under automation

### DIFF
--- a/repos/rust-lang/pin-utils.toml
+++ b/repos/rust-lang/pin-utils.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "pin-utils"
+description = "Utilities for pinning"
+bots = []
+
+[access.teams]
+wg-async = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/pin-utils

Extracted from GH:
```toml
org = "rust-lang"
name = "pin-utils"
description = "Utilities for pinning"
bots = []

[access.teams]
wg-async = "write"
security = "pull"

[access.individuals]
michaelwoerister = "write"
eholk = "write"
rylev = "admin"
nikomatsakis = "write"
taiki-e = "write"
tmandry = "write"
vincenzopalazzo = "write"
traviscross = "write"
aturon = "write"
pietroalbini = "admin"
nrc = "write"
Mark-Simulacrum = "admin"
estebank = "write"
badboy = "admin"
rust-lang-owner = "admin"
pnkfelix = "write"
compiler-errors = "write"
yoshuawuyts = "write"
jdno = "admin"
guswynn = "write"
```