### PR TITLE
Add project-const-generics repository under automation

### DIFF
--- a/repos/rust-lang/project-const-generics.toml
+++ b/repos/rust-lang/project-const-generics.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "project-const-generics"
+description = ""
+bots = []
+
+[access.teams]
+project-const-generics = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/project-const-generics

Extracted from GH:
```toml
org = "rust-lang"
name = "project-const-generics"
description = ""
bots = []

[access.teams]
project-const-generics = "maintain"
security = "pull"

[access.individuals]
badboy = "admin"
davidtwco = "maintain"
pietroalbini = "admin"
rust-lang-owner = "admin"
nikomatsakis = "maintain"
oli-obk = "maintain"
rylev = "admin"
jdno = "admin"
varkor = "maintain"
lcnr = "maintain"
Mark-Simulacrum = "admin"
BoxyUwU = "maintain"
```