### PR TITLE
Add project-group-template repository under automation

### DIFF
--- a/repos/rust-lang/project-group-template.toml
+++ b/repos/rust-lang/project-group-template.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "project-group-template"
+description = "Template for creating Project Groups"
+bots = []
+
+[access.teams]
+leadership-council = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/project-group-template

Assigned to `leadership-council` according to https://hackmd.io/@rust-leadership-council/Bk6ge9Xu6 (essentially replaces `core`).

Extracted from GH:
```toml
org = "rust-lang"
name = "project-group-template"
description = "Template for creating Project Groups"
bots = []

[access.teams]
core = "write"
lang = "write"
security = "pull"

[access.individuals]
joshtriplett = "write"
badboy = "admin"
tmandry = "write"
nikomatsakis = "write"
jdno = "admin"
pnkfelix = "write"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rylev = "admin"
rust-lang-owner = "admin"
scottmcm = "write"
XAMPPRocky = "admin"
```