### PR TITLE
Add project-inline-asm repository under automation

### DIFF
--- a/repos/rust-lang/project-inline-asm.toml
+++ b/repos/rust-lang/project-inline-asm.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "project-inline-asm"
+description = "Home for the Inline Assembly project group"
+bots = []
+
+[access.teams]
+wg-inline-asm = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/project-inline-asm

Extracted from GH:
```toml
org = "rust-lang"
name = "project-inline-asm"
description = "Home for the Inline Assembly project group"
bots = []

[access.teams]
compiler = "write"
security = "pull"
lang = "write"

[access.individuals]
nikomatsakis = "write"
rylev = "admin"
badboy = "admin"
nagisa = "write"
tmandry = "write"
cjgillot = "write"
petrochenkov = "write"
scottmcm = "write"
jackh726 = "write"
eddyb = "write"
Amanieu = "write"
michaelwoerister = "write"
Mark-Simulacrum = "admin"
lcnr = "write"
rust-lang-owner = "admin"
pnkfelix = "write"
pietroalbini = "admin"
compiler-errors = "write"
joshtriplett = "write"
wesleywiser = "write"
jdno = "admin"
estebank = "write"
Aaron1011 = "write"
oli-obk = "write"
davidtwco = "write"
matthewjasper = "write"
```