### PR TITLE
Add project-portable-simd repository under automation

### DIFF
--- a/repos/rust-lang/project-portable-simd.toml
+++ b/repos/rust-lang/project-portable-simd.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "project-portable-simd"
+description = "Portable SIMD project group"
+bots = []
+
+[access.teams]
+project-portable-simd = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/project-portable-simd

Extracted from GH:
```toml
org = "rust-lang"
name = "project-portable-simd"
description = "Portable SIMD project group"
bots = []

[access.teams]
security = "pull"
libs = "write"
libs-api = "write"

[access.individuals]
joshtriplett = "write"
rust-lang-owner = "admin"
the8472 = "write"
thomcc = "write"
dtolnay = "write"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
BurntSushi = "write"
badboy = "admin"
cuviper = "write"
Amanieu = "write"
m-ou-se = "write"
rylev = "admin"
jdno = "admin"
```