### PR TITLE
Add project-thir-unsafeck repository under automation

### DIFF
--- a/repos/rust-lang/project-thir-unsafeck.toml
+++ b/repos/rust-lang/project-thir-unsafeck.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "project-thir-unsafeck"
+description = "Tracking the project to refactor the unsafe check to operate on THIR"
+bots = []
+
+[access.teams]
+project-thir-unsafeck = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/project-thir-unsafeck

Extracted from GH:
```toml
org = "rust-lang"
name = "project-thir-unsafeck"
description = "Tracking the project to refactor the unsafe check to operate on THIR"
bots = []

[access.teams]
security = "pull"
compiler = "admin"
compiler-contributors = "admin"
project-thir-unsafeck = "write"

[access.individuals]
RalfJung = "admin"
tmiasko = "admin"
pietroalbini = "admin"
b-naber = "admin"
cjgillot = "admin"
eddyb = "admin"
rylev = "admin"
the8472 = "admin"
durin42 = "admin"
fee1-dead = "admin"
nikomatsakis = "admin"
chenyukang = "admin"
estebank = "admin"
est31 = "admin"
tmandry = "admin"
compiler-errors = "admin"
matthewjasper = "admin"
Nilstrieb = "admin"
rust-lang-owner = "admin"
wesleywiser = "admin"
jackh726 = "admin"
spastorino = "admin"
jdno = "admin"
eholk = "admin"
TaKO8Ki = "admin"
oli-obk = "admin"
nnethercote = "admin"
nagisa = "admin"
apiraino = "admin"
Nadrieril = "admin"
Aaron1011 = "admin"
bjorn3 = "admin"
lcnr = "admin"
michaelwoerister = "admin"
SparrowLii = "admin"
WaffleLapkin = "admin"
Mark-Simulacrum = "admin"
nikic = "admin"
fmease = "admin"
badboy = "admin"
petrochenkov = "admin"
davidtwco = "admin"
saethlin = "admin"
cuviper = "admin"
BoxyUwU = "admin"
pnkfelix = "admin"
flodiebold = "admin"
lqd = "admin"
```