### PR TITLE
Fix mdbook permissions

### DIFF
--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -6,6 +6,11 @@ bots = ["rustbot"]
 [access.teams]
 devtools = "write"
 
+[access.individuals]
+# Dylan-DPC is maintaining mdbook along with ehuss. Planning to add a team
+# soon, and then this can be removed.
+Dylan-DPC = "write"
+
 [[branch-protections]]
 pattern = "master"
 ci-checks = ["Success gate"]


### PR DESCRIPTION
https://github.com/rust-lang/team/pull/1246 added mdbook to the team repo, but I did not notice that it removed @Dylan-DPC's permissions. This restores those permissions.

I was intending to create a team for this, but I will need to write an RFC first.
