### PR TITLE
Add rfcbot-rs repository under automation

### DIFF
--- a/repos/rust-lang/rfcbot-rs.toml
+++ b/repos/rust-lang/rfcbot-rs.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rfcbot-rs"
+description = "Coordinates asynchronous decision making on Rust repositories. Status of tracked issues and PRs can be viewed at https://rfcbot.rs."
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rfcbot-rs

Extracted from GH:
```toml
org = "rust-lang"
name = "rfcbot-rs"
description = "Coordinates asynchronous decision making on Rust repositories. Status of tracked issues and PRs can be viewed at https://rfcbot.rs."
bots = []

[access.teams]
infra = "write"
security = "pull"

[access.individuals]
pietroalbini = "admin"
shepmaster = "write"
Mark-Simulacrum = "admin"
Kobzol = "write"
badboy = "admin"
rylev = "admin"
rust-lang-owner = "admin"
aturon = "write"
jdno = "admin"
anp = "write"
kennytm = "write"
```