### PR TITLE
Add rust-dbg-ext repository under automation

### DIFF
--- a/repos/rust-lang/rust-dbg-ext.toml
+++ b/repos/rust-lang/rust-dbg-ext.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust-dbg-ext"
+description = ""
+bots = []
+
+[access.teams]
+initiative-async-crashdump-debugging = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-dbg-ext

Extracted from GH:
```toml
org = "rust-lang"
name = "rust-dbg-ext"
description = ""
bots = []

[access.teams]
initiative-async-crashdump-debugging = "maintain"
security = "pull"

[access.individuals]
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
rylev = "admin"
badboy = "admin"
michaelwoerister = "maintain"
jdno = "admin"
```