### PR TITLE
Add rust-lang.github.io repository under automation

### DIFF
--- a/repos/rust-lang/rust-lang.github.io.toml
+++ b/repos/rust-lang/rust-lang.github.io.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust-lang.github.io"
+description = "GitHub Pages redirects"
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-lang.github.io

Extracted from GH:
```toml
org = "rust-lang"
name = "rust-lang.github.io"
description = "GitHub Pages redirects"
bots = []

[access.teams]
security = "pull"

[access.individuals]
jdno = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
pietroalbini = "admin"
rust-lang-owner = "admin"
badboy = "admin"
```