### PR TITLE
Add rust-mode repository under automation

### DIFF
--- a/repos/rust-lang/rust-mode.toml
+++ b/repos/rust-lang/rust-mode.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust-mode"
+description = "Emacs configuration for Rust"
+bots = []
+
+[access.teams]
+emacs = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-mode

Maybe the `emacs` team should be a subteam of `devtools`?

Extracted from GH:
```toml
org = "rust-lang"
name = "rust-mode"
description = "Emacs configuration for Rust"
bots = []

[access.teams]
emacs = "write"
highfive = "write"
security = "pull"
core = "admin"

[access.individuals]
rust-highfive = "write"
badboy = "admin"
jimblandy = "write"
MicahChalmer = "write"
psibi = "write"
pnkfelix = "write"
jdno = "admin"
tromey = "write"
Mark-Simulacrum = "admin"
brotzeit = "write"
rust-lang-owner = "admin"
rylev = "admin"
pietroalbini = "admin"
```