### PR TITLE
Add rust-repos repository under automation

### DIFF
--- a/repos/rust-lang/rust-repos.toml
+++ b/repos/rust-lang/rust-repos.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust-repos"
+description = "Dataset of Rust source code repositories"
+bots = ["highfive"]
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-repos

Extracted from GH:
```toml
org = "rust-lang"
name = "rust-repos"
description = "Dataset of Rust source code repositories"
bots = []

[access.teams]
security = "pull"
infra = "write"

[access.individuals]
Mark-Simulacrum = "admin"
rust-highfive = "write"
badboy = "admin"
pietroalbini = "admin"
Kobzol = "write"
rust-lang-owner = "admin"
rylev = "admin"
jdno = "admin"
shepmaster = "write"
kennytm = "write"
```