### PR TITLE
Add rustlings repository under automation

### DIFF
--- a/repos/rust-lang/rustlings.toml
+++ b/repos/rust-lang/rustlings.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "rustlings"
+description = ":crab: Small exercises to get you used to reading and writing Rust code!"
+bots = []
+
+[access.teams]
+
+[access.individuals]
+# This repository probably needs a separate team?
+shadows-withal = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustlings

CC @shadows-withal

Not sure if there should be a separate team for this?

Extracted from GH:
```toml
org = "rust-lang"
name = "rustlings"
description = ":crab: Small exercises to get you used to reading and writing Rust code!"
bots = []

[access.teams]
security = "pull"

[access.individuals]
jdno = "admin"
shadows-withal = "admin"
rust-lang-owner = "admin"
pietroalbini = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
AbdouSeck = "write"
badboy = "admin"
jrvidal = "write"
carols10cents = "write"
```