### PR TITLE
Add rustup-components-history repository under automation

### DIFF
--- a/repos/rust-lang/rustup-components-history.toml
+++ b/repos/rust-lang/rustup-components-history.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rustup-components-history"
+description = "Rustup package status history"
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustup-components-history

Extracted from GH:
```toml
org = "rust-lang"
name = "rustup-components-history"
description = "Rustup package status history"
bots = []

[access.teams]
security = "pull"
infra = "write"

[access.individuals]
Kobzol = "write"
jdno = "admin"
badboy = "admin"
shepmaster = "write"
mexus = "write"
kennytm = "write"
rylev = "admin"
Mark-Simulacrum = "admin"
pietroalbini = "admin"
rust-lang-owner = "admin"
```