### PR TITLE
Add api-guidelines repository under automation

### DIFF
--- a/repos/rust-lang/api-guidelines.toml
+++ b/repos/rust-lang/api-guidelines.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "api-guidelines"
+description = "Rust API guidelines"
+bots = []
+
+[access.teams]
+libs-api = "write"
+libs = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/api-guidelines

CC @dtolnay

Extracted from GH:
```toml
org = "rust-lang"
name = "api-guidelines"
description = "Rust API guidelines"
bots = []

[access.teams]
libs-api = "write"
security = "pull"
libs = "maintain"

[access.individuals]
cuviper = "maintain"
dtolnay = "write"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
BurntSushi = "write"
rust-lang-owner = "admin"
m-ou-se = "maintain"
joshtriplett = "maintain"
Amanieu = "maintain"
thomcc = "maintain"
jdno = "admin"
the8472 = "maintain"
rylev = "admin"
badboy = "admin"
```