### PR TITLE
Don't use `usize`s for user ids

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -31,7 +31,7 @@ pub struct Team {
 pub struct TeamMember {
     pub name: String,
     pub github: String,
-    pub github_id: usize,
+    pub github_id: u64,
     pub is_lead: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub roles: Vec<String>,
@@ -46,7 +46,7 @@ pub struct TeamGitHub {
 pub struct GitHubTeam {
     pub org: String,
     pub name: String,
-    pub members: Vec<usize>,
+    pub members: Vec<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -70,7 +70,7 @@ pub struct MemberRole {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TeamDiscord {
     pub name: String,
-    pub members: Vec<usize>,
+    pub members: Vec<u64>,
     pub color: Option<String>,
 }
 
@@ -115,7 +115,7 @@ pub enum ZulipGroupMember {
     // TODO(rylev): this variant can be removed once
     // it is verified that noone is relying on it
     Email(String),
-    Id(usize),
+    Id(u64),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -127,13 +127,13 @@ pub struct ZulipGroups {
 pub struct Permission {
     pub people: Vec<PermissionPerson>,
     pub github_users: Vec<String>,
-    pub github_ids: Vec<usize>,
-    pub discord_ids: Vec<usize>,
+    pub github_ids: Vec<u64>,
+    pub discord_ids: Vec<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PermissionPerson {
-    pub github_id: usize,
+    pub github_id: u64,
     pub github: String,
     pub name: String,
 }
@@ -153,7 +153,7 @@ pub struct RfcbotTeam {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ZulipMapping {
     /// Zulip ID to GitHub ID
-    pub users: IndexMap<usize, usize>,
+    pub users: IndexMap<u64, u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -211,7 +211,7 @@ pub struct BranchProtection {
 pub struct Person {
     pub name: String,
     pub email: Option<String>,
-    pub github_id: usize,
+    pub github_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -10,7 +10,7 @@ static TOKEN_VAR: &str = "GITHUB_TOKEN";
 
 #[derive(serde::Deserialize)]
 pub(crate) struct User {
-    pub(crate) id: usize,
+    pub(crate) id: u64,
     pub(crate) login: String,
     pub(crate) name: Option<String>,
     pub(crate) email: Option<String>,
@@ -114,11 +114,11 @@ impl GitHubApi {
             .json()?)
     }
 
-    pub(crate) fn usernames(&self, ids: &[usize]) -> Result<HashMap<usize, String>, Error> {
+    pub(crate) fn usernames(&self, ids: &[u64]) -> Result<HashMap<u64, String>, Error> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct Usernames {
-            database_id: usize,
+            database_id: u64,
             login: String,
         }
         #[derive(serde::Serialize)]
@@ -248,8 +248,8 @@ impl GitHubApi {
     }
 }
 
-fn user_node_id(id: usize) -> String {
-    base64::encode(format!("04:User{}", id))
+fn user_node_id(id: u64) -> String {
+    base64::encode(format!("04:User{id}"))
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ fn run() -> Result<(), Error> {
             struct PersonToAdd<'a> {
                 name: &'a str,
                 github: &'a str,
-                github_id: usize,
+                github_id: u64,
                 #[serde(skip_serializing_if = "Option::is_none")]
                 email: Option<&'a str>,
             }
@@ -518,7 +518,7 @@ fn dump_team_members(
         }
         println!(
             "{}{}{}",
-            "\t".repeat(tab_offset as usize),
+            "\t".repeat(usize::from(tab_offset)),
             member,
             if leads.contains(member) {
                 " (lead)"

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -59,12 +59,12 @@ pub(crate) enum Email<'a> {
 pub(crate) struct Person {
     name: String,
     github: String,
-    github_id: usize,
-    zulip_id: Option<usize>,
+    github_id: u64,
+    zulip_id: Option<u64>,
     irc: Option<String>,
     #[serde(default)]
     email: EmailField,
-    discord_id: Option<usize>,
+    discord_id: Option<u64>,
     #[serde(default)]
     permissions: Permissions,
 }
@@ -78,11 +78,11 @@ impl Person {
         &self.github
     }
 
-    pub(crate) fn github_id(&self) -> usize {
+    pub(crate) fn github_id(&self) -> u64 {
         self.github_id
     }
 
-    pub(crate) fn zulip_id(&self) -> Option<usize> {
+    pub(crate) fn zulip_id(&self) -> Option<u64> {
         self.zulip_id
     }
 
@@ -104,7 +104,7 @@ impl Person {
         }
     }
 
-    pub(crate) fn discord_id(&self) -> Option<usize> {
+    pub(crate) fn discord_id(&self) -> Option<u64> {
         self.discord_id
     }
 
@@ -449,7 +449,7 @@ impl Team {
         Ok(result)
     }
 
-    pub(crate) fn discord_ids(&self, data: &Data) -> Result<Vec<usize>, Error> {
+    pub(crate) fn discord_ids(&self, data: &Data) -> Result<Vec<u64>, Error> {
         Ok(self
             .members(data)?
             .iter()
@@ -492,14 +492,14 @@ impl DiscordRole {
 
 #[derive(Eq, PartialEq, Debug)]
 pub(crate) struct DiscordTeam {
-    pub(crate) members: Vec<usize>,
+    pub(crate) members: Vec<u64>,
 }
 
 #[derive(Eq, PartialEq)]
 pub(crate) struct GitHubTeam<'a> {
     pub(crate) org: &'a str,
     pub(crate) name: &'a str,
-    pub(crate) members: Vec<(&'a str, usize)>,
+    pub(crate) members: Vec<(&'a str, u64)>,
 }
 
 impl std::cmp::PartialOrd for GitHubTeam<'_> {
@@ -673,7 +673,7 @@ pub(crate) struct RawZulipGroup {
     #[serde(default)]
     pub(crate) extra_people: Vec<String>,
     #[serde(default)]
-    pub(crate) extra_zulip_ids: Vec<usize>,
+    pub(crate) extra_zulip_ids: Vec<u64>,
     #[serde(default)]
     pub(crate) extra_teams: Vec<String>,
     #[serde(default)]
@@ -720,8 +720,8 @@ impl ZulipGroup {
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub(crate) enum ZulipGroupMember {
-    MemberWithId { github: String, zulip_id: usize },
-    JustId(usize),
+    MemberWithId { github: String, zulip_id: u64 },
+    JustId(u64),
     MemberWithoutId { github: String },
 }
 

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -87,7 +87,7 @@ struct ZulipUsers {
 /// A single Zulip user
 #[derive(Clone, Deserialize, PartialEq, Eq, Hash)]
 pub(crate) struct ZulipUser {
-    pub(crate) user_id: usize,
+    pub(crate) user_id: u64,
     #[serde(rename = "full_name")]
     pub(crate) name: String,
 }


### PR DESCRIPTION
I don't think github (zulip, discord) IDs are platform dependant.