### PR TITLE
Enable required status checks for rustup

### DIFF
--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -8,3 +8,4 @@ rustup = "maintain"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["conclusion"]


### PR DESCRIPTION
The rustup repository has enabled GitHub's merge queue feature, which requires a status check to determine the health of each build. The respective job has already been configured, but not enabled as a required status check.

cc @rami3l 