### PR TITLE
Drop branch protections on llvm-project

### DIFF
--- a/repos/rust-lang/llvm-project.toml
+++ b/repos/rust-lang/llvm-project.toml
@@ -5,9 +5,3 @@ bots = []
 
 [access.teams]
 wg-llvm = "maintain"
-
-[[branch-protections]]
-pattern = "rustc/*"
-
-[[branch-protections]]
-pattern = "master"


### PR DESCRIPTION
To restore to something that more closely resembles the state before https://github.com/rust-lang/team/pull/1208. Merging new changes from upstream release branches into our fork doesn't really benefit from going through a PR or review, especially for work-in-progress upgrade branches.

I would have preferred to keep the "no force push and branch deletion" part of the branch protection, but it looks like disabling the PR requirement is not supported.