### PR TITLE
Add calebzulawski to libs-contributors

### DIFF
--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -18,6 +18,7 @@ members = [
     "Nilstrieb",
     "jhpratt",
     "joboet",
+    "calebzulawski",
 ]
 alumni = [
     "shepmaster",

--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -18,7 +18,7 @@ members = [
     "Nilstrieb",
     "jhpratt",
     "joboet",
-    "calebzulawski",
+    "calebzulawski", # std::simd
 ]
 alumni = [
     "shepmaster",


### PR DESCRIPTION
From this comment, I'm wondering if I should have bors privileges: https://github.com/rust-lang/rust/pull/121269#issuecomment-1951374615

I don't think it makes sense to add bors permissions to the project-portable-simd team so adding myself to @rust-lang/libs-contributors might be correct?  Feel free to suggest any alternatives, and I'm not offended if this doesn't go anywhere.  Thanks!