### PR TITLE
Rename keyword-generics-initiative repository

### DIFF
--- a/repos/rust-lang/effects-initiative.toml
+++ b/repos/rust-lang/effects-initiative.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "effects-initiative"
+description = "Public repository for the Rust effects initiative"
+bots = []
+
+[access.teams]
+initiative-keyword-generics = "write"

--- a/repos/rust-lang/keyword-generics-initiative.toml
+++ b/repos/rust-lang/keyword-generics-initiative.toml
@@ -1,7 +1,0 @@
-org = "rust-lang"
-name = "keyword-generics-initiative"
-description = "Public repository for the Rust keyword generics initiative"
-bots = []
-
-[access.teams]
-initiative-keyword-generics = "write"


### PR DESCRIPTION
The effects initiative [has requested](https://github.com/rust-lang/keyword-generics-initiative/issues/44) that we rename their repository.

🚨 This PR needs to be merged at the same time that we rename the repository on GitHub.