### PR TITLE
Remove required approvals for cc-rs

### DIFF
--- a/repos/rust-lang/cc-rs.toml
+++ b/repos/rust-lang/cc-rs.toml
@@ -11,3 +11,4 @@ NobodyXu = 'write'
 
 [[branch-protections]]
 pattern = 'main'
+required-approvals = 0


### PR DESCRIPTION
Since the crate only has a single active maintainer, it doesn't make sense to require separate approval for PRs.

cc @NobodyXu