### PR TITLE
tests: Fix broken expectations

### DIFF
--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -4,6 +4,7 @@
       "org": "test-org",
       "name": "archived_repo",
       "description": "An archived repo!",
+      "homepage": null,
       "bots": [],
       "teams": [
         {

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -2,6 +2,7 @@
   "org": "test-org",
   "name": "archived_repo",
   "description": "An archived repo!",
+  "homepage": null,
   "bots": [],
   "teams": [
     {


### PR DESCRIPTION
idk exactly how it happened, but it looks like https://github.com/rust-lang/team/pull/1353 may have broken CI on the `master` branch. this PR fixes the issue by running the `bless.sh` script.

r? @rust-lang/infra 

/cc @ehuss 