### PR TITLE
Remove requirement to create PRs from calendar repo

### DIFF
--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -19,3 +19,4 @@ wg-async = "maintain"
 
 [[branch-protections]]
 pattern = "main"
+pr-required = false


### PR DESCRIPTION
The calendar repository is used to maintain the calendar events for various teams.

For some teams, it's important that the friction for adding or updating calendar events be low, as otherwise team members start looking for or using alternate calendaring solutions.  Keeping this friction as low as possible is probably more important, in this case, than the benefits that we're getting from requiring PRs as part of the branch protection.  So let's remove that requirement.

The other option here would be to instead add `required-approvals = 0` to the branch protection.  This would require creating PRs but would avoid the need for a separate reviewer.

This is an option, but it would still increase the friction a bit, and it therefore seems net-better to just remove the need to create PRs.  Many other repositories here operate without branch protection at all without that creating any substantial problems.  In cases where someone thinks that something deserves a PR, e.g. so it can be discussed, that person can still of course create one.  But we don't need to require it.

For a calendar, the speed at which it can be updated is often the most important property.