### PR TITLE
crates.io: Add `eth3lbert` to the team

### DIFF
--- a/people/eth3lbert.toml
+++ b/people/eth3lbert.toml
@@ -1,0 +1,5 @@
+name = "eth3lbert"
+email = "eth3lbert+dev@gmail.com"
+github = "eth3lbert"
+github-id = 2889664
+zulip-id = 673720

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -10,6 +10,7 @@ members = [
     "LawnGnome",
     "mdtro",
     "hi-rustin",
+    "eth3lbert",
 ]
 alumni = [
     "steveklabnik",


### PR DESCRIPTION
We just discussed in the crates.io meeting to invite @eth3lbert to the team and they accepted. This PR officially adds them to the team and should hopefully sync the GitHub/Zulip/etc. permissions accordingly.

r? @rust-lang/team-repo-admins 

/cc @rust-lang/crates-io 