### PR TITLE
Remove remaining reference to core team.

### DIFF
--- a/repos/rust-lang/project-exploit-mitigations.toml
+++ b/repos/rust-lang/project-exploit-mitigations.toml
@@ -4,7 +4,6 @@ description = "Exploit Mitigations Project Group"
 bots = []
 
 [access.teams]
-core = "admin"
 mods = "maintain"
 project-exploit-mitigations = "maintain"
 


### PR DESCRIPTION
This removes what appears to be something that was left behind when previous core entries were removed.