### PR TITLE
Add gcc-backend team

### DIFF
--- a/people/antoyo.toml
+++ b/people/antoyo.toml
@@ -1,4 +1,5 @@
 name = 'Antoni Boucher'
 github = 'antoyo'
 github-id = 584972
+email = "bouanto@zoho.com"
 zulip-id = 404242

--- a/teams/wg-gcc-backend.toml
+++ b/teams/wg-gcc-backend.toml
@@ -1,0 +1,20 @@
+name = "wg-gcc-backend"
+subteam-of = "compiler"
+kind = "working-group"
+
+[people]
+leads = ["antoyo"]
+members = ["antoyo", "GuillaumeGomez"]
+alumni = []
+
+[permissions]
+perf = true
+
+[website]
+name = "rustc_codegen_gcc"
+description = "libgccjit AOT codegen for rustc"
+zulip-stream = "rustc-codegen-gcc"
+repo = "https://github.com/rust-lang/rustc_codegen_gcc"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
As suggested [here](https://github.com/rust-lang/team/pull/1371#discussion_r1519874386) and [there](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/meeting.202024-03-11/near/425934306), I'm creating a team for rustc_codegen_gcc.

This team will manage the existing rustc_codegen_gcc repo as well as the 2 new repos that were recently moved to the rust-lang organization [in this PR](https://github.com/rust-lang/team/pull/1371).