### PR TITLE
Add council-librarians team for working on the leadership council repo

### DIFF
--- a/repos/rust-lang/leadership-council.toml
+++ b/repos/rust-lang/leadership-council.toml
@@ -5,6 +5,7 @@ bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 leadership-council = "maintain"
+council-librarians = "write"
 
 [[branch-protections]]
 pattern = "main"

--- a/teams/council-librarians.toml
+++ b/teams/council-librarians.toml
@@ -1,0 +1,9 @@
+name = "council-librarians"
+kind = "marker-team"
+
+[people]
+leads = []
+members = ["rylev", "ehuss"]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
This is to help @ehuss with the maintenance of https://github.com/rust-lang/leadership-council