### PR TITLE
Add `zsh-config` under automation (archived)

### DIFF
--- a/repos/archive/rust-lang/zsh-config.toml
+++ b/repos/archive/rust-lang/zsh-config.toml
@@ -1,0 +1,6 @@
+org = "rust-lang"
+name = "zsh-config"
+description = "zsh configuration for Rust"
+bots = []
+
+[access.teams]


### PR DESCRIPTION
This PR adds the first archived managed repo, so that we have something to test for https://github.com/rust-lang/sync-team/pull/71.

This repo is actually already archived, so the sync should be a no-op.

Repo: https://github.com/rust-lang/zsh-config

Extracted from GH:
```
org = "rust-lang"
name = "zsh-config"
description = "zsh configuration for Rust"
bots = []

[access.teams]
core = "admin"
highfive = "write"
security = "pull"

[access.individuals]
Mark-Simulacrum = "admin"
pietroalbini = "admin"
rylev = "admin"
jdno = "admin"
rust-lang-owner = "admin"
badboy = "admin"
rust-highfive = "write"
```