### PR TITLE
Add `auto_merge` option to repositories

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -168,6 +168,9 @@ pub struct Repo {
     pub members: Vec<RepoMember>,
     pub branch_protections: Vec<BranchProtection>,
     pub archived: bool,
+    // Is the GitHub "Auto-merge" option enabled?
+    // https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request
+    pub auto_merge_enabled: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -757,7 +757,7 @@ pub(crate) struct Repo {
     pub branch_protections: Vec<BranchProtection>,
 }
 
-#[derive(serde_derive::Deserialize, Debug, Clone)]
+#[derive(serde_derive::Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum Bot {
     Bors,

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -54,6 +54,7 @@ impl<'a> Generator<'a> {
                     allowed_merge_teams: b.allowed_merge_teams.clone(),
                 })
                 .collect();
+            let managed_by_bors = r.bots.contains(&Bot::Bors);
             let repo = v1::Repo {
                 org: r.org.clone(),
                 name: r.name.clone(),
@@ -106,6 +107,7 @@ impl<'a> Generator<'a> {
                     .collect(),
                 branch_protections,
                 archived,
+                auto_merge_enabled: !managed_by_bors,
             };
 
             self.add(&format!("v1/repos/{}.json", r.name), &repo)?;

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -24,7 +24,8 @@
           "allowed_merge_teams": []
         }
       ],
-      "archived": true
+      "archived": true,
+      "auto_merge_enabled": true
     },
     {
       "org": "test-org",
@@ -52,7 +53,8 @@
           ]
         }
       ],
-      "archived": false
+      "archived": false,
+      "auto_merge_enabled": true
     }
   ]
 }

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -22,5 +22,6 @@
       "allowed_merge_teams": []
     }
   ],
-  "archived": true
+  "archived": true,
+  "auto_merge_enabled": true
 }

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -24,5 +24,6 @@
       ]
     }
   ],
-  "archived": false
+  "archived": false,
+  "auto_merge_enabled": true
 }


### PR DESCRIPTION
This will enable `sync-team` to enable this option on GH. It is not exposed to users directly, it is auto-derived from the presence of `bors`.