### PR TITLE
Require CI to pass in simpleinfra

### DIFF
--- a/repos/rust-lang/simpleinfra.toml
+++ b/repos/rust-lang/simpleinfra.toml
@@ -8,4 +8,5 @@ infra = "write"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["Rust projects", "Terraform configuration", "GitHub Actions (JS)"]
 required-approvals = 0


### PR DESCRIPTION
This will also allow using auto-merge rather than waiting for the checks to pass.