### PR TITLE
Add `all-hands-2020` under automation (archived)

### DIFF
--- a/repos/archive/rust-lang/all-hands-2020.toml
+++ b/repos/archive/rust-lang/all-hands-2020.toml
@@ -1,0 +1,6 @@
+org = "rust-lang"
+name = "all-hands-2020"
+description = "Website for the Rust All Hands 2020"
+bots = []
+
+[access.teams]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/all-hands-2020

This repo is not actually archived yet, but I think that it should be uncontroversial to archive it, which should test the new archiving sync functionality.

Extracted from GH:
```toml
org = "rust-lang"
name = "all-hands-2020"
description = "Website for the Rust All Hands 2020"
bots = []

[access.teams]
security = "pull"

[access.individuals]
pietroalbini = "admin"
rylev = "admin"
Mark-Simulacrum = "admin"
jdno = "admin"
XAMPPRocky = "admin"
nikomatsakis = "write"
rust-lang-owner = "admin"
badboy = "admin"
```