### PR TITLE
Remove unused DiscordTeam

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -496,11 +496,6 @@ impl DiscordRole {
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
-pub(crate) struct DiscordTeam {
-    pub(crate) members: Vec<u64>,
-}
-
 #[derive(Eq, PartialEq)]
 pub(crate) struct GitHubTeam<'a> {
     pub(crate) org: &'a str,


### PR DESCRIPTION
This removes an unused struct `DiscordTeam`. It was added in https://github.com/rust-lang/team/pull/538, but it is not clear why as it is never used.  There is a similar `TeamDiscord`, so perhaps it was just a mistake.
