### PR TITLE
Retire wg-grammar

### DIFF
--- a/repos/archive/rust-lang/wg-grammar.toml
+++ b/repos/archive/rust-lang/wg-grammar.toml
@@ -4,4 +4,3 @@ description = "Where the work of WG-grammar, aiming to provide a canonical gramm
 bots = []
 
 [access.teams]
-wg-grammar = "write"

--- a/teams/archive/wg-grammar.toml
+++ b/teams/archive/wg-grammar.toml
@@ -3,12 +3,11 @@ subteam-of = "lang"
 kind = "working-group"
 
 [people]
-leads = ["eddyb"]
-members = [
+leads = []
+members = []
+alumni = [
     "eddyb",
     "CAD97",
-]
-alumni = [
     "Centril",
     "qmx",
 ]


### PR DESCRIPTION
wg-grammar has not met in several years, so I think it is time to go ahead and retire it. I don't foresee it starting up again. Also, I'm presuming that the spec team will be picking up this work in some form.

cc @rust-lang/wg-grammar 
cc @rust-lang/spec 

