### PR TITLE
Switch book repo to team access

### DIFF
--- a/repos/rust-lang/book.toml
+++ b/repos/rust-lang/book.toml
@@ -5,10 +5,7 @@ homepage = "https://doc.rust-lang.org/book/"
 bots = []
 
 [access.teams]
-
-[access.individuals]
-carols10cents = "maintain"
-chriskrycho = "maintain"
+book = "maintain"
 
 [[branch-protections]]
 pattern = "main"


### PR DESCRIPTION
With https://github.com/rust-lang/team/pull/1213 merged, the repo permissions for the book repo should now be able to go under the team.

cc @rust-lang/book 