### PR TITLE
Switch rustc_codegen_gcc to team access

### DIFF
--- a/repos/rust-lang/rustc_codegen_gcc.toml
+++ b/repos/rust-lang/rustc_codegen_gcc.toml
@@ -5,7 +5,4 @@ bots = []
 
 [access.teams]
 compiler = "write"
-
-[access.individuals]
-antoyo = "maintain"
-GuillaumeGomez = "write"
+wg-gcc-backend = "maintain"


### PR DESCRIPTION
With https://github.com/rust-lang/team/pull/1372 merged, the repo permissions for the rustc_codegen_gcc repo should now be able to go under the team.

cc @rust-lang/wg-gcc-backend 