### PR TITLE
Archive the Cross team collaboration fun time repository and team

### DIFF
--- a/repos/archive/rust-lang/ctcft.toml
+++ b/repos/archive/rust-lang/ctcft.toml
@@ -1,0 +1,6 @@
+org = "rust-lang"
+name = "ctcft"
+description = "Cross Team Collaboration Fun Times"
+bots = []
+
+[access.teams]

--- a/teams/archive/community-ctcft.toml
+++ b/teams/archive/community-ctcft.toml
@@ -2,17 +2,14 @@ name = "community-ctcft"
 subteam-of = "community"
 
 [people]
-leads = [
-    "AngelOnFira",
-    "nikomatsakis",
-]
-members = [
+leads = []
+members = []
+alumni = [
     "AngelOnFira",
     "nikomatsakis",
     "technetos",
-    "yaahc",
+    "yaahc"
 ]
-alumni = []
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
Archives the https://github.com/rust-lang/ctcft repository and the corresponding team, with the assumption that it is no longer active.

CC @nikomatsakis @AngelOnFira

Extracted from GH:
```toml
org = "rust-lang"
name = "ctcft"
description = "Cross Team Collaboration Fun Times"
bots = []

[access.teams]
community-ctcft = "write"
security = "pull"
community = "write"

[access.individuals]
badboy = "admin"
nikomatsakis = "write"
jdno = "admin"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
nellshamrell = "write"
Manishearth = "write"
rylev = "admin"
technetos = "write"
AngelOnFira = "write"
sebasmagri = "write"
JohnTitor = "write"
yaahc = "write"
```