### PR TITLE
Add `discord-mods-bot` under automation

### DIFF
--- a/repos/rust-lang/discord-mods-bot.toml
+++ b/repos/rust-lang/discord-mods-bot.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "discord-mods-bot"
+description = "discord moderation bot"
+bots = []
+
+[access.teams]
+mods-discord = "write"

--- a/teams/mods-discord.toml
+++ b/teams/mods-discord.toml
@@ -25,3 +25,6 @@ address = "discord-mods@rust-lang.org"
 [[discord-roles]]
 name = "mods"
 color = "#e74c3c"
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/discord-mods-bot

Extracted from GH:
```toml
org = "rust-lang"
name = "discord-mods-bot"
description = "discord moderation bot"
bots = []

[access.teams]
security = "pull"

[access.individuals]
badboy = "admin"
technetos = "admin"
pietroalbini = "admin"
khionu = "admin"
rust-lang-owner = "admin"
jdno = "admin"
Manishearth = "admin"
Mark-Simulacrum = "admin"
rylev = "admin"
```