### PR TITLE
Add `never-type-initiative` under automation (archived)

### DIFF
--- a/repos/archive/rust-lang/never-type-initiative.toml
+++ b/repos/archive/rust-lang/never-type-initiative.toml
@@ -1,0 +1,6 @@
+org = "rust-lang"
+name = "never-type-initiative"
+description = "In pursuit of the stabilization of never type"
+bots = []
+
+[access.teams]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/never-type-initiative

I assume that this repository isn't active (even though never type is not stabilized yet, and there is some development going on at the moment, AFAIK). CC @Mark-Simulacrum

Extracted from GH:
```toml
org = "rust-lang"
name = "never-type-initiative"
description = "In pursuit of the stabilization of never type"
bots = []

[access.teams]
lang = "write"
security = "pull"

[access.individuals]
nikomatsakis = "write"
rylev = "admin"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
pnkfelix = "write"
badboy = "admin"
jdno = "admin"
joshtriplett = "write"
scottmcm = "write"
tmandry = "write"
```