### PR TITLE
Add `pontoon` under automation

### DIFF
--- a/repos/rust-lang/pontoon.toml
+++ b/repos/rust-lang/pontoon.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "pontoon"
+description = "Localization platform used by Rust"
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/pontoon

Maybe we will want to archive this soon (https://github.com/rust-lang/infra-team/issues/91), but in any case it should be managed by `team` (unless we want to delete it completely).

Extracted from GH:
```toml
org = "rust-lang"
name = "pontoon"
description = "Localization platform used by Rust"
bots = []

[access.teams]
community = "triage"
security = "pull"
bors = "write"
bots = "write"

[access.individuals]
Manishearth = "triage"
technetos = "triage"
rylev = "admin"
rust-lang-owner = "admin"
jdno = "admin"
XAMPPRocky = "write"
badboy = "admin"
rust-highfive = "write"
Mark-Simulacrum = "admin"
JohnTitor = "triage"
sebasmagri = "triage"
skade = "write"
nellshamrell = "triage"
pietroalbini = "admin"
bors = "write"
rustbot = "write"
rust-timer = "write"
```