### PR TITLE
Add `rust.vim` under automation

### DIFF
--- a/repos/rust-lang/rust.vim.toml
+++ b/repos/rust-lang/rust.vim.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust.vim"
+description = "Vim configuration for Rust."
+bots = []
+
+[access.teams]
+vim = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust.vim

This doesn't seem to be [actively maintained](https://github.com/rust-lang/rust.vim/issues/502) at the moment, although people seem to be still using it. Maybe we should archive it to make it clear that it's unmaintained?

Extracted from GH:
```toml
org = "rust-lang"
name = "rust.vim"
description = "Vim configuration for Rust."
bots = []

[access.teams]
security = "pull"
highfive = "write"
core = "admin"
vim = "write"

[access.individuals]
rust-lang-owner = "admin"
badboy = "admin"
jdno = "admin"
Mark-Simulacrum = "admin"
chris-morgan = "write"
pietroalbini = "admin"
da-x = "write"
rust-highfive = "write"
rylev = "admin"
```