### PR TITLE
Add `rust-artwork` under automation

### DIFF
--- a/repos/rust-lang/rust-artwork.toml
+++ b/repos/rust-lang/rust-artwork.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rust-artwork"
+description = "Official artwork for the Rust project."
+bots = []
+
+# There is no current clear owner of this repository, so the access is left empty for now.
+[access.teams]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rust-artwork

Since this hasn't been touched in years, I think it's fine to leave it without any access currently (?). I wouldn't archive it though, as it the content itself it probably still relevant.

CC @nikomatsakis

Extracted from GH:
```toml
org = "rust-lang"
name = "rust-artwork"
description = "Official artwork for the Rust project."
bots = []

[access.teams]
core = "pull"
security = "pull"

[access.individuals]
nikomatsakis = "write"
badboy = "admin"
rylev = "admin"
pietroalbini = "admin"
jdno = "admin"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
```