### PR TITLE
Add `rustc-reading-club` under automation

### DIFF
--- a/repos/rust-lang/rustc-reading-club.toml
+++ b/repos/rust-lang/rustc-reading-club.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rustc-reading-club"
+description = "Rust Code Reading Clubs"
+bots = []
+
+[access.teams]
+wg-rustc-reading-club = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/rustc-reading-club

Extracted from GH:
```toml
org = "rust-lang"
name = "rustc-reading-club"
description = "Rust Code Reading Clubs"
bots = []

[access.teams]
security = "pull"
wg-rustc-reading-club = "maintain"
compiler = "maintain"

[access.individuals]
matthewjasper = "maintain"
cjgillot = "maintain"
Aaron1011 = "maintain"
estebank = "maintain"
pnkfelix = "maintain"
lcnr = "maintain"
jackh726 = "maintain"
oli-obk = "maintain"
rust-lang-owner = "admin"
davidtwco = "maintain"
petrochenkov = "maintain"
doc-jones = "maintain"
rylev = "admin"
nagisa = "maintain"
jdno = "admin"
wesleywiser = "maintain"
eddyb = "maintain"
badboy = "admin"
michaelwoerister = "maintain"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
compiler-errors = "maintain"
nikomatsakis = "maintain"
```