### PR TITLE
Add `stacker` under automation

### DIFF
--- a/repos/rust-lang/stacker.toml
+++ b/repos/rust-lang/stacker.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "stacker"
+description = "Manual segmented stacks for Rust"
+bots = []
+
+[access.teams]
+compiler = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/stacker

Added under `compiler`, based on https://github.com/rust-lang/stacker and a discussion with @nagisa.

Extracted from GH:
```toml
org = "rust-lang"
name = "stacker"
description = "Manual segmented stacks for Rust"
bots = []

[access.teams]
compiler = "admin"
security = "pull"

[access.individuals]
Mark-Simulacrum = "admin"
eddyb = "admin"
pnkfelix = "admin"
davidtwco = "admin"
petrochenkov = "admin"
rylev = "admin"
cjgillot = "admin"
matthewjasper = "admin"
pietroalbini = "admin"
Aaron1011 = "admin"
compiler-errors = "admin"
badboy = "admin"
oli-obk = "admin"
lcnr = "admin"
jdno = "admin"
michaelwoerister = "admin"
wesleywiser = "admin"
nagisa = "admin"
jackh726 = "admin"
estebank = "admin"
rust-lang-owner = "admin"
```