### PR TITLE
Add `monitorbot` under automation

### DIFF
--- a/repos/rust-lang/monitorbot.toml
+++ b/repos/rust-lang/monitorbot.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "monitorbot"
+description = "Monitoring of external API services Rust infrastructure relies upon"
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/monitorbot

Extracted from GH:
```toml
org = "rust-lang"
name = "monitorbot"
description = "Monitoring of external API services Rust infrastructure relies upon"
bots = []

[access.teams]
security = "pull"
infra = "write"

[access.individuals]
Kobzol = "write"
rylev = "admin"
Mark-Simulacrum = "admin"
kennytm = "write"
badboy = "admin"
shepmaster = "write"
jdno = "admin"
pietroalbini = "admin"
rust-lang-owner = "admin"
```