### PR TITLE
Add `project-deref-patterns` under automation

### DIFF
--- a/repos/rust-lang/project-deref-patterns.toml
+++ b/repos/rust-lang/project-deref-patterns.toml
@@ -1,0 +1,6 @@
+org = "rust-lang"
+name = "project-deref-patterns"
+description = ""
+bots = []
+
+[access.teams]

--- a/repos/rust-lang/project-deref-patterns.toml
+++ b/repos/rust-lang/project-deref-patterns.toml
@@ -4,3 +4,8 @@ description = ""
 bots = []
 
 [access.teams]
+
+[access.individuals]
+# Liaison for the deref-patterns initiative, which
+# doesn't have a working group yet.
+traviscross = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/project-deref-patterns

Based on a discussion [here](https://github.com/rust-lang/team/pull/1388#issuecomment-2002085244).

Extracted from GH:
```toml
org = "rust-lang"
name = "project-deref-patterns"
description = ""
bots = []

[access.teams]
security = "pull"

[access.individuals]
chorman0773 = "admin"
jdno = "admin"
rust-lang-owner = "admin"
pietroalbini = "admin"
Mark-Simulacrum = "admin"
rylev = "admin"
badboy = "admin"
nrc = "admin"
```