### PR TITLE
Require subteam-of to be specified.

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -31,6 +31,8 @@ directory. The structure of the file is this:
 ```toml
 name = "overlords"  # Name of the team, used for GitHub (required)
 subteam-of = "gods"  # Name of the parent team of this team (optional)
+# Set this to `true` if it is a top-level team, with a representative on the leadership-council.
+top-level = true
 
 # The kind of the team (optional). Could be be:
 # - team (default)

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -19,6 +19,8 @@ pub struct Team {
     pub name: String,
     pub kind: TeamKind,
     pub subteam_of: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_level: Option<bool>,
     pub members: Vec<TeamMember>,
     pub alumni: Vec<TeamMember>,
     pub github: Option<TeamGitHub>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -163,6 +163,7 @@ pub(crate) struct Team {
     #[serde(default)]
     kind: TeamKind,
     subteam_of: Option<String>,
+    top_level: Option<bool>,
     people: TeamPeople,
     #[serde(default)]
     permissions: Permissions,
@@ -192,6 +193,10 @@ impl Team {
 
     pub(crate) fn subteam_of(&self) -> Option<&str> {
         self.subteam_of.as_deref()
+    }
+
+    pub(crate) fn top_level(&self) -> Option<bool> {
+        self.top_level
     }
 
     // Return's whether the provided team is a subteam of this team

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -174,6 +174,7 @@ impl<'a> Generator<'a> {
                     TeamKind::MarkerTeam => v1::TeamKind::MarkerTeam,
                 },
                 subteam_of: team.subteam_of().map(|st| st.into()),
+                top_level: team.top_level(),
                 members,
                 alumni,
                 github: Some(v1::TeamGitHub {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -618,6 +618,14 @@ fn validate_subteam_of_required(data: &Data, errors: &mut Vec<String>) {
                 team.name()
             );
         }
+        if top_level && team.kind() != TeamKind::Team {
+            bail!(
+                "team `{}` is top-level, but is a `{}` team kind, \
+                 it must be a normal team (don't specify \"kind\")",
+                team.name(),
+                team.kind()
+            );
+        }
         if team.kind() != TeamKind::MarkerTeam
             && team.subteam_of().is_none()
             && !matches!(team.name(), "leadership-council" | "core")

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -1,4 +1,5 @@
 name = "compiler"
+subteam-of = "leadership-council"
 
 [people]
 leads = ["davidtwco", "wesleywiser"]

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -1,5 +1,5 @@
 name = "compiler"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = ["davidtwco", "wesleywiser"]

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -1,4 +1,5 @@
 name = "crates-io"
+subteam-of = "leadership-council"
 
 [people]
 leads = ["jtgeibel", "Turbo87"]

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -1,5 +1,5 @@
 name = "crates-io"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = ["jtgeibel", "Turbo87"]

--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -1,5 +1,5 @@
 name = "devtools"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = ["Manishearth"]

--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -1,4 +1,5 @@
 name = "devtools"
+subteam-of = "leadership-council"
 
 [people]
 leads = ["Manishearth"]

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -1,4 +1,5 @@
 name = "infra"
+subteam-of = "leadership-council"
 
 [people]
 leads = ["shepmaster", "jdno"]

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -1,5 +1,5 @@
 name = "infra"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = ["shepmaster", "jdno"]

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -1,5 +1,5 @@
 name = "lang"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = [

--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -1,4 +1,5 @@
 name = "lang"
+subteam-of = "leadership-council"
 
 [people]
 leads = [

--- a/teams/launching-pad.toml
+++ b/teams/launching-pad.toml
@@ -1,4 +1,5 @@
 name = "launching-pad"
+subteam-of = "leadership-council"
 
 [people]
 # This is an "umbrella" team, and thus does not have any members.

--- a/teams/launching-pad.toml
+++ b/teams/launching-pad.toml
@@ -1,5 +1,5 @@
 name = "launching-pad"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 # This is an "umbrella" team, and thus does not have any members.

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -1,4 +1,5 @@
 name = "libs"
+subteam-of = "leadership-council"
 
 [people]
 leads = [

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -1,5 +1,5 @@
 name = "libs"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = [

--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -1,5 +1,5 @@
 name = "mods"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = []

--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -1,4 +1,5 @@
 name = "mods"
+subteam-of = "leadership-council"
 
 [people]
 leads = []

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -1,7 +1,7 @@
 {
   "alumni": {
     "name": "alumni",
-    "kind": "team",
+    "kind": "marker_team",
     "subteam_of": null,
     "members": [
       {
@@ -20,7 +20,7 @@
   "foo": {
     "name": "foo",
     "kind": "team",
-    "subteam_of": null,
+    "subteam_of": "leadership-council",
     "members": [
       {
         "name": "Zeroth user",
@@ -77,7 +77,7 @@
   "leaderless": {
     "name": "leaderless",
     "kind": "team",
-    "subteam_of": null,
+    "subteam_of": "leadership-council",
     "members": [
       {
         "name": "Zeroth user",
@@ -92,10 +92,21 @@
     "roles": [],
     "discord": []
   },
+  "leadership-council": {
+    "name": "leadership-council",
+    "kind": "team",
+    "subteam_of": null,
+    "members": [],
+    "alumni": [],
+    "github": null,
+    "website_data": null,
+    "roles": [],
+    "discord": []
+  },
   "leads-permissions": {
     "name": "leads-permissions",
     "kind": "team",
-    "subteam_of": null,
+    "subteam_of": "leadership-council",
     "members": [
       {
         "name": "Sixth user",
@@ -125,7 +136,7 @@
   "wg-test": {
     "name": "wg-test",
     "kind": "working_group",
-    "subteam_of": null,
+    "subteam_of": "leadership-council",
     "members": [
       {
         "name": "Second user",

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -20,7 +20,8 @@
   "foo": {
     "name": "foo",
     "kind": "team",
-    "subteam_of": "leadership-council",
+    "subteam_of": null,
+    "top_level": true,
     "members": [
       {
         "name": "Zeroth user",
@@ -77,7 +78,8 @@
   "leaderless": {
     "name": "leaderless",
     "kind": "team",
-    "subteam_of": "leadership-council",
+    "subteam_of": null,
+    "top_level": true,
     "members": [
       {
         "name": "Zeroth user",
@@ -106,7 +108,8 @@
   "leads-permissions": {
     "name": "leads-permissions",
     "kind": "team",
-    "subteam_of": "leadership-council",
+    "subteam_of": null,
+    "top_level": true,
     "members": [
       {
         "name": "Sixth user",
@@ -136,7 +139,8 @@
   "wg-test": {
     "name": "wg-test",
     "kind": "working_group",
-    "subteam_of": "leadership-council",
+    "subteam_of": null,
+    "top_level": true,
     "members": [
       {
         "name": "Second user",

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -139,8 +139,7 @@
   "wg-test": {
     "name": "wg-test",
     "kind": "working_group",
-    "subteam_of": null,
-    "top_level": true,
+    "subteam_of": "foo",
     "members": [
       {
         "name": "Second user",

--- a/tests/static-api/_expected/v1/teams/alumni.json
+++ b/tests/static-api/_expected/v1/teams/alumni.json
@@ -1,6 +1,6 @@
 {
   "name": "alumni",
-  "kind": "team",
+  "kind": "marker_team",
   "subteam_of": null,
   "members": [
     {

--- a/tests/static-api/_expected/v1/teams/foo.json
+++ b/tests/static-api/_expected/v1/teams/foo.json
@@ -1,7 +1,8 @@
 {
   "name": "foo",
   "kind": "team",
-  "subteam_of": "leadership-council",
+  "subteam_of": null,
+  "top_level": true,
   "members": [
     {
       "name": "Zeroth user",

--- a/tests/static-api/_expected/v1/teams/foo.json
+++ b/tests/static-api/_expected/v1/teams/foo.json
@@ -1,7 +1,7 @@
 {
   "name": "foo",
   "kind": "team",
-  "subteam_of": null,
+  "subteam_of": "leadership-council",
   "members": [
     {
       "name": "Zeroth user",

--- a/tests/static-api/_expected/v1/teams/leaderless.json
+++ b/tests/static-api/_expected/v1/teams/leaderless.json
@@ -1,7 +1,8 @@
 {
   "name": "leaderless",
   "kind": "team",
-  "subteam_of": "leadership-council",
+  "subteam_of": null,
+  "top_level": true,
   "members": [
     {
       "name": "Zeroth user",

--- a/tests/static-api/_expected/v1/teams/leaderless.json
+++ b/tests/static-api/_expected/v1/teams/leaderless.json
@@ -1,7 +1,7 @@
 {
   "name": "leaderless",
   "kind": "team",
-  "subteam_of": null,
+  "subteam_of": "leadership-council",
   "members": [
     {
       "name": "Zeroth user",

--- a/tests/static-api/_expected/v1/teams/leadership-council.json
+++ b/tests/static-api/_expected/v1/teams/leadership-council.json
@@ -1,0 +1,11 @@
+{
+  "name": "leadership-council",
+  "kind": "team",
+  "subteam_of": null,
+  "members": [],
+  "alumni": [],
+  "github": null,
+  "website_data": null,
+  "roles": [],
+  "discord": []
+}

--- a/tests/static-api/_expected/v1/teams/leads-permissions.json
+++ b/tests/static-api/_expected/v1/teams/leads-permissions.json
@@ -1,7 +1,8 @@
 {
   "name": "leads-permissions",
   "kind": "team",
-  "subteam_of": "leadership-council",
+  "subteam_of": null,
+  "top_level": true,
   "members": [
     {
       "name": "Sixth user",

--- a/tests/static-api/_expected/v1/teams/leads-permissions.json
+++ b/tests/static-api/_expected/v1/teams/leads-permissions.json
@@ -1,7 +1,7 @@
 {
   "name": "leads-permissions",
   "kind": "team",
-  "subteam_of": null,
+  "subteam_of": "leadership-council",
   "members": [
     {
       "name": "Sixth user",

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -1,7 +1,8 @@
 {
   "name": "wg-test",
   "kind": "working_group",
-  "subteam_of": "leadership-council",
+  "subteam_of": null,
+  "top_level": true,
   "members": [
     {
       "name": "Second user",

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -1,7 +1,7 @@
 {
   "name": "wg-test",
   "kind": "working_group",
-  "subteam_of": null,
+  "subteam_of": "leadership-council",
   "members": [
     {
       "name": "Second user",

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -1,8 +1,7 @@
 {
   "name": "wg-test",
   "kind": "working_group",
-  "subteam_of": null,
-  "top_level": true,
+  "subteam_of": "foo",
   "members": [
     {
       "name": "Second user",

--- a/tests/static-api/teams/alumni.toml
+++ b/tests/static-api/teams/alumni.toml
@@ -1,4 +1,5 @@
 name = "alumni"
+kind = "marker-team"
 
 [people]
 leads = []

--- a/tests/static-api/teams/foo.toml
+++ b/tests/static-api/teams/foo.toml
@@ -1,4 +1,5 @@
 name = "foo"
+subteam-of = "leadership-council"
 
 [people]
 leads = ["user-0"]

--- a/tests/static-api/teams/foo.toml
+++ b/tests/static-api/teams/foo.toml
@@ -1,5 +1,5 @@
 name = "foo"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = ["user-0"]

--- a/tests/static-api/teams/leaderless.toml
+++ b/tests/static-api/teams/leaderless.toml
@@ -1,5 +1,5 @@
 name = "leaderless"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = []

--- a/tests/static-api/teams/leaderless.toml
+++ b/tests/static-api/teams/leaderless.toml
@@ -1,4 +1,5 @@
 name = "leaderless"
+subteam-of = "leadership-council"
 
 [people]
 leads = []

--- a/tests/static-api/teams/leadership-council.toml
+++ b/tests/static-api/teams/leadership-council.toml
@@ -1,0 +1,6 @@
+name = "leadership-council"
+
+[people]
+leads = []
+members = []
+alumni = []

--- a/tests/static-api/teams/leads-permissions.toml
+++ b/tests/static-api/teams/leads-permissions.toml
@@ -1,4 +1,5 @@
 name = "leads-permissions"
+subteam-of = "leadership-council"
 
 [people]
 leads = ["user-6"]

--- a/tests/static-api/teams/leads-permissions.toml
+++ b/tests/static-api/teams/leads-permissions.toml
@@ -1,5 +1,5 @@
 name = "leads-permissions"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = ["user-6"]

--- a/tests/static-api/teams/wg-test.toml
+++ b/tests/static-api/teams/wg-test.toml
@@ -1,5 +1,6 @@
 name = "wg-test"
 kind = "working-group"
+subteam-of = "leadership-council"
 
 [people]
 leads = ["user-2"]

--- a/tests/static-api/teams/wg-test.toml
+++ b/tests/static-api/teams/wg-test.toml
@@ -1,6 +1,6 @@
 name = "wg-test"
 kind = "working-group"
-subteam-of = "leadership-council"
+top-level = true
 
 [people]
 leads = ["user-2"]

--- a/tests/static-api/teams/wg-test.toml
+++ b/tests/static-api/teams/wg-test.toml
@@ -1,6 +1,6 @@
 name = "wg-test"
 kind = "working-group"
-top-level = true
+subteam-of = "foo"
 
 [people]
 leads = ["user-2"]


### PR DESCRIPTION
This changes it so that Teams, Working Groups, and Project Groups set the `subteam-of` field. Marker teams do not require it.

The reason is to ensure that teams are connected, and to make it a little easier to connect the top-level teams to the leadership-council.
