### PR TITLE
Add `datafrog` under automation

### DIFF
--- a/repos/rust-lang/datafrog.toml
+++ b/repos/rust-lang/datafrog.toml
@@ -1,0 +1,9 @@
+org = "rust-lang"
+name = "datafrog"
+description = "A lightweight Datalog engine in Rust"
+bots = []
+
+[access.teams]
+wg-polonius = "write"
+compiler = "write"
+compiler-contributors = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/datafrog

CC @lqd, looks good?

Extracted from GH:
```toml
org = "rust-lang"
name = "datafrog"
description = "A lightweight Datalog engine in Rust"
bots = []

[access.teams]
compiler = "admin"
core = "admin"
infra = "admin"
wg-polonius = "write"
security = "pull"

[access.individuals]
lcnr = "admin"
davidtwco = "admin"
pietroalbini = "admin"
nagisa = "admin"
pnkfelix = "admin"
compiler-errors = "admin"
badboy = "admin"
ecstatic-morse = "write"
michaelwoerister = "admin"
oli-obk = "admin"
kennytm = "admin"
rust-lang-owner = "admin"
lqd = "write"
cjgillot = "admin"
shepmaster = "admin"
amandasystems = "write"
Kobzol = "admin"
petrochenkov = "admin"
jackh726 = "admin"
wesleywiser = "admin"
nikomatsakis = "write"
rylev = "admin"
eddyb = "admin"
estebank = "admin"
Mark-Simulacrum = "admin"
jdno = "admin"
Aaron1011 = "admin"
matthewjasper = "admin"
```