### PR TITLE
Add RenovateBot

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -181,6 +181,7 @@ pub enum Bot {
     Rustbot,
     RustTimer,
     Rfcbot,
+    Renovate,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -760,6 +760,7 @@ pub(crate) enum Bot {
     Rustbot,
     RustTimer,
     Rfcbot,
+    Renovate,
 }
 
 #[derive(serde_derive::Deserialize, Debug)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -69,6 +69,7 @@ impl<'a> Generator<'a> {
                         Bot::RustTimer => v1::Bot::RustTimer,
                         Bot::Rustbot => v1::Bot::Rustbot,
                         Bot::Rfcbot => v1::Bot::Rfcbot,
+                        Bot::Renovate => v1::Bot::Renovate,
                     })
                     .collect(),
                 teams: r


### PR DESCRIPTION
Adds a new Renovate bot entry. This bot works through a GitHub app, I'll implement syncing for GH apps in `sync-team` as a follow-up step.

Previous discussion: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Add.20GitHub.20Apps.20in.20team.20repo