### PR TITLE
Add `odht` under automation

### DIFF
--- a/repos/rust-lang/odht.toml
+++ b/repos/rust-lang/odht.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "odht"
+description = "An on-disk hash table implementation"
+bots = []
+
+[access.teams]
+compiler = "write"
+compiler-contributors = "write"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = ["Required Checks Passed"]


### PR DESCRIPTION
Repo: https://github.com/rust-lang/odht

Confirmed with @michaelwoerister that this is still maintained by `t-compiler`.

Extracted from GH:
```toml
org = "rust-lang"
name = "odht"
description = "An on-disk hash table implementation"
bots = []

[access.teams]
security = "pull"
compiler = "maintain"
compiler-contributors = "write"

[access.individuals]
Nadrieril = "write"
eholk = "write"
BoxyUwU = "write"
cuviper = "write"
wesleywiser = "maintain"
the8472 = "write"
estebank = "maintain"
apiraino = "write"
badboy = "admin"
eddyb = "maintain"
jdno = "admin"
Mark-Simulacrum = "admin"
b-naber = "write"
nikomatsakis = "write"
lqd = "write"
RalfJung = "write"
nagisa = "maintain"
flodiebold = "write"
cjgillot = "maintain"
TaKO8Ki = "write"
pietroalbini = "admin"
chenyukang = "write"
rylev = "admin"
michaelwoerister = "maintain"
spastorino = "write"
Nilstrieb = "write"
nikic = "write"
tmiasko = "write"
compiler-errors = "maintain"
matthewjasper = "maintain"
petrochenkov = "maintain"
durin42 = "write"
bjorn3 = "write"
lcnr = "maintain"
Aaron1011 = "maintain"
tmandry = "write"
WaffleLapkin = "write"
oli-obk = "maintain"
saethlin = "write"
pnkfelix = "maintain"
jackh726 = "maintain"
nnethercote = "write"
davidtwco = "maintain"
fmease = "write"
fee1-dead = "write"
rust-lang-owner = "admin"
SparrowLii = "write"
est31 = "write"

[[branch-protections]]
pattern = "main"
ci-checks = ["Required Checks Passed"]
```