### PR TITLE
Add `async-crashdump-debugging-initiative` under automation

### DIFF
--- a/repos/rust-lang/async-crashdump-debugging-initiative.toml
+++ b/repos/rust-lang/async-crashdump-debugging-initiative.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "async-crashdump-debugging-initiative"
+description = ""
+bots = []
+
+[access.teams]
+initiative-async-crashdump-debugging = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/async-crashdump-debugging-initiative

Confirmed with @mw that this is still active.

Extracted from GH:
```toml
org = "rust-lang"
name = "async-crashdump-debugging-initiative"
description = ""
bots = []

[access.teams]
initiative-async-crashdump-debugging = "maintain"
security = "pull"

[access.individuals]
jdno = "admin"
pietroalbini = "admin"
michaelwoerister = "maintain"
Mark-Simulacrum = "admin"
rust-lang-owner = "admin"
badboy = "admin"
rylev = "admin"
```