### PR TITLE
feat: convert rustlings membership to a team

### DIFF
--- a/repos/rust-lang/rustlings.toml
+++ b/repos/rust-lang/rustlings.toml
@@ -5,7 +5,4 @@ homepage = "https://rustlings.cool"
 bots = []
 
 [access.teams]
-
-[access.individuals]
-# This repository probably needs a separate team?
-shadows-withal = "write"
+rustlings = "maintain"

--- a/teams/rustlings.toml
+++ b/teams/rustlings.toml
@@ -1,0 +1,10 @@
+name = "rustlings"
+kind = "team"
+
+[people]
+leads = ["shadows-withal"]
+members = ["shadows-withal"]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]

--- a/teams/rustlings.toml
+++ b/teams/rustlings.toml
@@ -1,5 +1,5 @@
 name = "rustlings"
-kind = "team"
+kind = "marker-team"
 
 [people]
 leads = ["shadows-withal"]


### PR DESCRIPTION
I want to add a co-maintainer to Rustlings (which will be done in a later step), so I'm converting the single person repo permission into a team permission. This is not a formal team or anything, just a convenience to let multiple people have the same permission, hence why the team itself is very minimal.