### PR TITLE
Add renovate bot to managed repositories that use it

### DIFF
--- a/repos/rust-lang/annotate-snippets-rs.toml
+++ b/repos/rust-lang/annotate-snippets-rs.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "annotate-snippets-rs"
 description = "Library for snippet annotations"
-bots = []
+bots = ["renovate"]
 
 [access.teams]
 cargo = "write"

--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "blog.rust-lang.org"
 description = "Home of the Rust and Inside Rust blogs"
 homepage = "https://blog.rust-lang.org"
-bots = []
+bots = ["renovate"]
 
 [access.teams]
 inside-rust-reviewers = "write"

--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "cargo"
 description = "The Rust package manager"
 homepage = "https://doc.rust-lang.org/cargo"
-bots = ["bors", "rustbot", "rfcbot"]
+bots = ["bors", "rustbot", "rfcbot", "renovate"]
 
 [access.teams]
 cargo = "write"

--- a/repos/rust-lang/rfcs.toml
+++ b/repos/rust-lang/rfcs.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "rfcs"
 description = "RFCs for changes to Rust"
 homepage = "https://rust-lang.github.io/rfcs/"
-bots = ["rustbot", "rfcbot"]
+bots = ["rustbot", "rfcbot", "renovate"]
 
 [access.teams]
 all = "write"

--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "rustup"
 description = "The Rust toolchain installer"
 homepage = "https://rust-lang.github.io/rustup/"
-bots = ["rustbot"]
+bots = ["rustbot", "renovate"]
 
 [access.teams]
 rustup = "maintain"


### PR DESCRIPTION
This PR adds Renovate bot to all managed repositories that currently use it (source: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Repos.20that.20use.20renovatebot/near/427884837).

We need to merge this before https://github.com/rust-lang/sync-team/pull/75 is merged, otherwise `sync-team` would uninstall the bot from the repositories.