### PR TITLE
feat: add mo8it to rustlings team

### DIFF
--- a/people/mo8it.toml
+++ b/people/mo8it.toml
@@ -1,0 +1,3 @@
+name = "Mo"
+github = "mo8it"
+github-id = 76752051

--- a/teams/rustlings.toml
+++ b/teams/rustlings.toml
@@ -3,7 +3,10 @@ kind = "marker-team"
 
 [people]
 leads = ["shadows-withal"]
-members = ["shadows-withal"]
+members = [
+    "shadows-withal",
+    "mo8it",
+]
 alumni = []
 
 [[github]]


### PR DESCRIPTION
Adding @mo8it to co-maintain Rustlings :tada: 

Sidenote: I assume this change will automatically invite them to the `rust-lang` org? Or does that need to be done manually by someone with permissions?