### PR TITLE
Promote jswrenn to lead of wg-safe-transmute, and retire rylev

### DIFF
--- a/people/jswrenn.toml
+++ b/people/jswrenn.toml
@@ -1,3 +1,4 @@
 name = 'Jack Wrenn'
 github = 'jswrenn'
 github-id = 3820879
+email = "jack@wrenn.fyi"

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -359,15 +359,17 @@ fn validate_inactive_members(data: &Data, errors: &mut Vec<String>) {
 /// Ensure every member of a team with a mailing list has an email address
 fn validate_list_email_addresses(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, |team, errors| {
-        if team.lists(data)?.is_empty() {
+        let lists = team.lists(data)?;
+        if lists.is_empty() {
             return Ok(());
         }
         wrapper(team.members(data)?.iter(), errors, |member, _| {
             if let Some(member) = data.person(member) {
                 if let Email::Missing = member.email() {
                     bail!(
-                        "person `{}` is a member of a mailing list but has no email address",
-                        member.github()
+                        "person `{}` is a member of at least one mailing list ({}) but has no email address",
+                        member.github(),
+                        lists.iter().map(|l| l.address()).collect::<Vec<_>>().join(", "),
                     );
                 }
             }

--- a/teams/wg-safe-transmute.toml
+++ b/teams/wg-safe-transmute.toml
@@ -3,12 +3,12 @@ subteam-of = "lang"
 kind = "working-group"
 
 [people]
-leads = ["rylev"]
+leads = ["jswrenn"]
 members = [
-    "rylev",
     "jswrenn",
 ]
 alumni = [
+    "rylev",
     "joshtriplett",
 ]
 


### PR DESCRIPTION
Make @jswrenn the lead and retire @rylev from the working group.

This also adds an email for @jswrenn and improves the error message when a required email address is missing. 

r? @rust-lang/team-repo-admins 