### PR TITLE
Correct nomicon CI name

### DIFF
--- a/repos/rust-lang/nomicon.toml
+++ b/repos/rust-lang/nomicon.toml
@@ -9,4 +9,4 @@ lang-docs = "write"
 
 [[branch-protections]]
 pattern = "master"
-ci-checks = ["test"]
+ci-checks = ["Test"]


### PR DESCRIPTION
It should be upper-cased: https://github.com/rust-lang/nomicon/blob/6bc2415218d4dd0cb01433d8320f5ccf79c343a1/.github/workflows/main.yml#L6