### PR TITLE
Add mailing list for ospp@rust-lang.org

### DIFF
--- a/teams/ospp.toml
+++ b/teams/ospp.toml
@@ -1,0 +1,9 @@
+name = "ospp"
+kind = "marker-team"
+
+[people]
+leads = []
+members = ["Amanieu"]
+
+[[lists]]
+address = "ospp@rust-lang.org"


### PR DESCRIPTION
Registration for [OSPP](https://summer-ospp.ac.cn/) requires a public email address for the project.