### PR TITLE
update and archive project-thir-unsafeck

### DIFF
--- a/repos/archive/rust-lang/project-thir-unsafeck.toml
+++ b/repos/archive/rust-lang/project-thir-unsafeck.toml
@@ -4,4 +4,3 @@ description = "Tracking the project to refactor the unsafe check to operate on T
 bots = []
 
 [access.teams]
-project-thir-unsafeck = "maintain"

--- a/teams/archive/project-thir-unsafeck.toml
+++ b/teams/archive/project-thir-unsafeck.toml
@@ -4,8 +4,8 @@ subteam-of = "compiler"
 
 [people]
 leads = ["nikomatsakis"]
-members = ["nikomatsakis", "matthewjasper"]
-alumni = ["LeSeulArtichaut"]
+members = []
+alumni = ["nikomatsakis", "matthewjasper", "LeSeulArtichaut"]
 
 [website]
 name = "THIR Unsafety Checker Project Group"

--- a/teams/project-thir-unsafeck.toml
+++ b/teams/project-thir-unsafeck.toml
@@ -4,8 +4,8 @@ subteam-of = "compiler"
 
 [people]
 leads = ["nikomatsakis"]
-members = ["nikomatsakis"]
-alumni = []
+members = ["nikomatsakis", "matthewjasper"]
+alumni = ["LeSeulArtichaut"]
 
 [website]
 name = "THIR Unsafety Checker Project Group"


### PR DESCRIPTION
THIR unsafeck is now stable since 1.77 (https://github.com/rust-lang/rust/pull/117673/) and MIR unsafeck has since been removed (https://github.com/rust-lang/rust/pull/123322) :tada: I think we should therefore archive the working group.

It was also outdated. I added @LeSeulArtichaut to alumni, which afaict was not possible when they left the project in https://github.com/rust-lang/team/pull/621. I also added @matthewjasper as a member as they've been doing most of the work towards actually getting it stabilized.

Unsure what to do with the afaict dead zulip stream (https://rust-lang.zulipchat.com/#narrow/stream/278509-project-thir-unsafeck). Ideally it should be archived and locked.

cc @nikomatsakis 