### PR TITLE
Add `crates.io-infra` repository under automation (private)

### DIFF
--- a/repos/rust-lang/crates.io-infra.toml
+++ b/repos/rust-lang/crates.io-infra.toml
@@ -1,0 +1,10 @@
+org = "rust-lang"
+name = "crates.io-infra"
+description = "is ur crates.io running?"
+bots = []
+private-non-synced = true
+
+[access.teams]
+infra = "write"
+crates-io-on-call = "write"
+crates-io = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/crates.io-infra

This is a **private** repository.
I'm not sure if it should be archived or not, the linked website doesn't seem to work.

CC @pietroalbini

Extracted from GH:
```toml
org = "rust-lang"
name = "crates.io-infra"
description = "is ur crates.io running?"
bots = []

[access.teams]
infra = "pull"
crates-io-on-call = "write"
crates-io = "write"
security = "pull"

[access.individuals]
badboy = "admin"
hi-rustin = "write"
mdtro = "write"
JohnTitor = "write"
rust-lang-owner = "admin"
carols10cents = "write"
Mark-Simulacrum = "admin"
Xylakant = "write"
rylev = "admin"
tshepang = "write"
justahero = "write"
jtgeibel = "write"
Turbo87 = "write"
skade = "write"
LawnGnome = "write"
listochkin = "write"
jdno = "admin"
pietroalbini = "admin"
```