### PR TITLE
Add `infra` repository under automation (private)

### DIFF
--- a/repos/rust-lang/infra.toml
+++ b/repos/rust-lang/infra.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "infra"
+description = ""
+bots = []
+private-non-synced = true
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/infra

This is a **private** repository.

Extracted from GH:
```toml
org = "rust-lang"
name = "infra"
description = ""
bots = []

[access.teams]
infra = "write"
security = "pull"

[access.individuals]
rylev = "admin"
rust-lang-owner = "admin"
badboy = "admin"
shepmaster = "write"
Kobzol = "write"
Mark-Simulacrum = "admin"
kennytm = "write"
pietroalbini = "admin"
jdno = "admin"
```