### PR TITLE
Add `pentest-2019` repository under automation (private)

### DIFF
--- a/repos/rust-lang/pentest-2019.toml
+++ b/repos/rust-lang/pentest-2019.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "pentest-2019"
+description = "Primarily security-related bug tracking"
+bots = []
+private-non-synced = true
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/pentest-2019

This is a **private** repository.

Extracted from GH:
```toml
org = "rust-lang"
name = "pentest-2019"
description = "Primarily security-related bug tracking"
bots = []

[access.teams]
infra = "write"
security = "pull"
core = "admin"

[access.individuals]
kennytm = "write"
Mark-Simulacrum = "admin"
jdno = "admin"
shepmaster = "write"
sgrif = "write"
Kobzol = "write"
rust - lang - owner = "admin"
rylev = "admin"
pietroalbini = "admin"
QuietMisdreavus = "write"
badboy = "admin"
```