### PR TITLE
Add `surveys-private` repository under automation (private)

### DIFF
--- a/repos/rust-lang/surveys-private.toml
+++ b/repos/rust-lang/surveys-private.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "surveys-private"
+description = "A private repository for survey data that is only accessible to the survey working group (and admins)"
+bots = []
+private-non-synced = true
+
+[access.teams]
+community-survey = "maintain"


### PR DESCRIPTION
Repo: https://github.com/rust-lang/surveys-private

This is a **private** repository.

Extracted from GH:
```toml
org = "rust-lang"
name = "surveys-private"
description = "A private repository for survey data that is only accessible to the survey working group (and admins)"
bots = []

[access.teams]
community-survey = "maintain"
security = "pull"

[access.individuals]
badboy = "admin"
rust-lang-owner = "admin"
Kobzol = "maintain"
rylev = "admin"
pietroalbini = "admin"
apiraino = "maintain"
Mark-Simulacrum = "admin"
jdno = "admin"
```