### PR TITLE
Join and lead the Rust 2024 edition project

### DIFF
--- a/teams/project-edition-2024.toml
+++ b/teams/project-edition-2024.toml
@@ -4,15 +4,17 @@ subteam-of = "leadership-council"
 
 [people]
 leads = [
-    "bstrie",
+    "traviscross",
     "ehuss",
 ]
 members = [
-    "bstrie",
+    "traviscross",
     "ehuss",
     "m-ou-se",
 ]
-alumni = []
+alumni = [
+    "bstrie",
+]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
In the lang design meeting on 2024-04-10 (with Eric Huss and Mara present), there formed a consensus that I would take on responsibility for the project management of getting the Rust 2024 edition released.

We understand that bstrie is stepping away from this effort, and we thank him for all the good work he's done to this point.

Correspondingly, in this commit, we add me (TC) to the Rust 2024 edition project as a member and a lead, and we remove bstrie.

cc @ehuss @m-ou-se @bstrie