### PR TITLE
Give access to rustwide to docs.rs maintainers

### DIFF
--- a/repos/rust-lang/rustwide.toml
+++ b/repos/rust-lang/rustwide.toml
@@ -5,3 +5,4 @@ bots = []
 
 [access.teams]
 infra = "write"
+docs-rs = "write"


### PR DESCRIPTION
Context: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/getting.20changes.20into.20rustwide.20.2F.20helping.20with.20maintenance.3F