### PR TITLE
Rename `macos` team to `apple`, and add `apple` Zulip group

### DIFF
--- a/people/hkratz.toml
+++ b/people/hkratz.toml
@@ -2,3 +2,4 @@ name = 'Hans Kratz'
 github = 'hkratz'
 github-id = 3736990
 email = 'hans@appfour.com'
+zulip-id = 407656

--- a/people/inflation.toml
+++ b/people/inflation.toml
@@ -1,3 +1,4 @@
 name = 'Inflation'
 github = 'inflation'
 github-id = 2375962
+zulip-id = 332463

--- a/people/nvzqz.toml
+++ b/people/nvzqz.toml
@@ -2,3 +2,4 @@ name = 'Nikolai Vazquez'
 github = 'nvzqz'
 github-id = 10367662
 email = 'rust@nikolaivazquez.com'
+zulip-id = 298781

--- a/teams/apple.toml
+++ b/teams/apple.toml
@@ -12,3 +12,6 @@ members = [
     "nvzqz",
     "madsmtm",
 ]
+
+[[zulip-groups]]
+name = "apple"

--- a/teams/apple.toml
+++ b/teams/apple.toml
@@ -1,4 +1,5 @@
-name = "macos"
+# macOS/iOS/tvOS/watchOS/visionOS
+name = "apple"
 kind = "marker-team"
 
 [people]


### PR DESCRIPTION
We discussed today [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/I'd.20like.20to.20contribute.20more.20.28to.20Apple-specific.20stuff.29/near/434259421) that it might make sense to expand the scope of this team to include the other Apple platforms, namely iOS, tvOS, watchOS and visionOS.

Pinging current members of the team; @hkratz, @inflation, @shepmaster, @thomcc, @nvzqz.

Are you fine with the expanded scope of the team, and being on the ping list for `@rustbot ping apple`?

Additionally, I've introduced the `apple` Zulip ping group, does this make sense, and are you fine with being in that ping group? (if not, I'll add you to the `excluded-people`).

(Note that this is not officially affiliated with Apple, it's just the name that makes the most sense).

---

~I will make the corresponding PR to update `triagebot.toml` in `rust-lang/rust` soon~ EDIT: [Done](https://github.com/rust-lang/rust/pull/124146)