### PR TITLE
Remove branch protection from staging branch of `bors`

### DIFF
--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -12,8 +12,3 @@ mods = "maintain"
 pattern = "main"
 ci-checks = ["Test", "Test Docker"]
 required-approvals = 0
-
-[[branch-protections]]
-pattern = "staging"
-ci-checks = ["Test", "Test Docker"]
-required-approvals = 0


### PR DESCRIPTION
I need to force-push into `staging` to fix a bad rebase that I did before. And frankly, force-pushing from main into staging seems like the simplest deployment option for now anyway, to avoid additional merge commits.