### PR TITLE
Implement RFC#3595 Moving crates.io under devtools

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -1,5 +1,5 @@
 name = "crates-io"
-top-level = true
+subteam-of = "devtools"
 
 [people]
 leads = ["jtgeibel", "Turbo87"]

--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -52,6 +52,7 @@ extra-teams = [
     "rustfmt",
     "rustup",
     "wg-bindgen",
+    "crates-io",
 ]
 extra-people = ["spacekookie"]
 

--- a/teams/leadership-council.toml
+++ b/teams/leadership-council.toml
@@ -3,7 +3,6 @@ name = "leadership-council"
 [people]
 leads = []
 members = [
-    { github = "carols10cents", roles = ["council-rep-crates-io"] },
     { github = "eholk", roles = ["council-rep-compiler"] },
     { github = "ehuss", roles = ["council-rep-devtools"] },
     { github = "jackh726", roles = ["council-rep-lang"] },
@@ -12,7 +11,7 @@ members = [
     { github = "m-ou-se", roles = ["council-rep-libs"] },
     { github = "technetos", roles = ["council-rep-mods"] },
 ]
-alumni = ["khionu", "rylev"]
+alumni = ["khionu", "rylev", "carols10cents"]
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
@@ -33,10 +32,6 @@ repo = "https://github.com/rust-lang/leadership-council"
 [[roles]]
 id = "council-rep-compiler"
 description = "Compiler team"
-
-[[roles]]
-id = "council-rep-crates-io"
-description = "Crates.io team"
 
 [[roles]]
 id = "council-rep-devtools"


### PR DESCRIPTION
This implements [RFC#3595], which entails:

- Moving the crates.io team to be a subteam of devtools
- Removing @carols10cents from Leadership Council

[RFC#3595]: https://github.com/rust-lang/rfcs/pull/3595

Bye council! Have fun! 👋🏻 