### PR TITLE
Fix branch protection of `rustc-demangle`

### DIFF
--- a/repos/rust-lang/rustc-demangle.toml
+++ b/repos/rust-lang/rustc-demangle.toml
@@ -9,4 +9,11 @@ compiler-contributors = "write"
 
 [[branch-protections]]
 pattern = "main"
-ci-checks = ["test"]
+ci-checks = [
+    "Test (stable)",
+    "Test (beta)",
+    "Test (nightly)",
+    "Fuzz Targets",
+    "Rustfmt",
+    "Publish Documentation"
+]


### PR DESCRIPTION
Mentioned [here](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/.22test.22.20job.20not.20completing).