### PR TITLE
manage rust-project-goals in teams repository

### DIFF
--- a/repos/rust-lang/rust-project-goals.toml
+++ b/repos/rust-lang/rust-project-goals.toml
@@ -1,0 +1,16 @@
+org = "rust-lang"
+name = "rust-project-goals"
+description = "Rust Project Goals tracker"
+homepage = "https://rust-lang.github.io/rust-project-goals/"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+lang = "maintain"
+lang-ops = "maintain"
+lang-docs = "maintain"
+types = "maintain"
+release = "maintain"
+leadership-council = "maintain"
+libs = "maintain"
+libs-api = "maintain"
+project-edition-2024 = "maintain"


### PR DESCRIPTION
I opted to just give a bunch of teams access rather than creating a new WG given that (right now) it'd just be me.