### PR TITLE
Add `gsoc-contributors` team

### DIFF
--- a/people/Oneirical.toml
+++ b/people/Oneirical.toml
@@ -1,0 +1,4 @@
+name = "Julien Robert"
+github = "Oneirical"
+github-id = 96022417
+zulip-id = 693959

--- a/teams/gsoc-contributors.toml
+++ b/teams/gsoc-contributors.toml
@@ -1,0 +1,11 @@
+name = "gsoc-contributors"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "Oneirical"
+]
+
+[permissions]
+dev-desktop = true


### PR DESCRIPTION
Adds a `gsoc-contributors` team with access to dev desktops. Eventually we should add all the GSoC participants, but for now it would be great if we could unblock people that need access to dev desktops.

CC @Oneirical if you want me to modify your details or name (we can also do that later).