### PR TITLE
Add a Zulip group for `wg-embedded`

### DIFF
--- a/teams/wg-embedded.toml
+++ b/teams/wg-embedded.toml
@@ -59,3 +59,6 @@ matrix-room = "#rust-embedded:matrix.org"
 
 [[lists]]
 address = "embedded-wg@rust-lang.org"
+
+[[zulip-groups]]
+name = "WG-embedded"


### PR DESCRIPTION
So that we can ping the embedded WG on Zulip.