### PR TITLE
Add lang team to reference and nomicon repos

### DIFF
--- a/repos/rust-lang/nomicon.toml
+++ b/repos/rust-lang/nomicon.toml
@@ -5,6 +5,7 @@ homepage = "https://doc.rust-lang.org/nomicon/"
 bots = []
 
 [access.teams]
+lang = "write"
 lang-docs = "write"
 
 [[branch-protections]]

--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -5,6 +5,7 @@ homepage = "https://doc.rust-lang.org/nightly/reference/"
 bots = ["rustbot"]
 
 [access.teams]
+lang = "write"
 lang-docs = "write"
 
 [[branch-protections]]


### PR DESCRIPTION
The lang team previously had permissions on the reference, but that was removed in https://github.com/rust-lang/team/pull/1253, which was an oversight on my part. This adds it back, as well to the nomicon since it is spiritually similar, though I don't expect much participation.

cc @rust-lang/lang-docs @rust-lang/lang