### PR TITLE
Add a Rust for Linux marker team

### DIFF
--- a/teams/rust-for-linux.toml
+++ b/teams/rust-for-linux.toml
@@ -1,0 +1,9 @@
+name = "rust-for-linux"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "ojeda",
+    "Darksonn"
+]


### PR DESCRIPTION
So that we can ping the RfL maintainers.