### PR TITLE
:ice_cube:  Put glacier on ice :ice_cube:

### DIFF
--- a/repos/archive/rust-lang/glacier.toml
+++ b/repos/archive/rust-lang/glacier.toml
@@ -4,4 +4,3 @@ description = "A big 'ol pile of ICE."
 bots = []
 
 [access.teams]
-wg-triage = "write"


### PR DESCRIPTION
Archives [rust-lang/glacier](https://github.com/rust-lang/glacier/), @rust-lang/wg-triage.

Glacier has been considered dead for a while now. See also [this Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/where.20to.20mass-add.20known.20ices.20.2F.20merging.20glacier.20into.20rust/near/429082963).

It's been partially superseded by `tests/crashes` in [rust-lang/rust](https://github.com/rust-lang/rust/).
Thanks, @matthiaskrgr, for the work you put into the new system!
See also rust-lang/rust#122997.