### PR TITLE
feat: add missing license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust-team"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Pietro Albini <pietro@pietroalbini.org>"]
 edition = '2018'
+license.workspace = true
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
@@ -33,3 +34,6 @@ walkdir = "2.3.1"
 members = [
     "rust_team_data",
 ]
+
+[workspace.package]
+license = "MIT OR Apache-2.0"

--- a/rust_team_data/Cargo.toml
+++ b/rust_team_data/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust_team_data"
 version = "1.0.0"
 authors = ["Pietro Albini <pietro@pietroalbini.org>"]
 edition = "2018"
+license.workspace = true
 
 [dependencies]
 chacha20poly1305 = { version = "0.9.0", optional = true }

--- a/rust_team_data/LICENSE-APACHE
+++ b/rust_team_data/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rust_team_data/LICENSE-MIT
+++ b/rust_team_data/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
We have put two license files in the repo root,
but never declared them in Cargo.toml.
This PR fills in the `workspace.package.license` field,
so that every workspace members can just inherit from it.

This was found during the course of vendoring rustc-perf in rust-lang/rust: <https://github.com/rust-lang/rust/pull/125465#issuecomment-2130745904>.