### PR TITLE
macros: add the permission to run performance

### DIFF
--- a/teams/wg-macros.toml
+++ b/teams/wg-macros.toml
@@ -26,3 +26,7 @@ zulip-stream = "wg-macros"
 
 [[zulip-groups]]
 name = "wg-macros"
+
+[permissions]
+perf = true
+bors.rust.try = true


### PR DESCRIPTION
While working on macros ofter is good to ask "we are introducing a regression in terms of performance?"

So this commit is allowing the macros wg to use the perf bot.

Link: https://github.com/rust-lang/rust/pull/125828

cc @rust-lang/wg-macros 