### PR TITLE
Add `rustc-stable-hash` repo

### DIFF
--- a/repos/rust-lang/rustc-stable-hash.toml
+++ b/repos/rust-lang/rustc-stable-hash.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "rustc-stable-hash"
+description = "A stable hashing algorithm used by rustc: cross-platform, deterministic, not secure"
+bots = []
+
+[access.teams]
+compiler = "write"
+compiler-contributors = "write"
+
+[[branch-protections]]
+pattern = "main"


### PR DESCRIPTION
This PR add/create the `rustc-stable-hash` repository, so that we can extract `rustc` stable hashing algorithm into it's own crate and use it in other projects (like Cargo).

cc @davidtwco @WaffleLapkin @weihanglo