### PR TITLE
Remove alex's individual repo access.

### DIFF
--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -7,8 +7,5 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[access.individuals]
-alexcrichton = 'write'
-
 [[branch-protections]]
 pattern = 'master'

--- a/repos/rust-lang/flate2-rs.toml
+++ b/repos/rust-lang/flate2-rs.toml
@@ -7,9 +7,5 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[access.individuals]
-alexcrichton = 'maintain'
-brson = 'write'
-
 [[branch-protections]]
 pattern = 'main'


### PR DESCRIPTION
As part of [RFC 2872](https://rust-lang.github.io/rfcs/2872-github-access-policy.html), this removes a few individuals from repository access.

This removes @alexcrichton's individual access to backtrace-rs and flate2-rs. For example, in https://github.com/rust-lang/flate2-rs/pull/325#issuecomment-1329548584 he has mentioned handing maintenance off.

This also removes `brson`'s access to flate2-rs, since I don't think he has ever been directly involved in that project, and has generally not been involved in rust-lang projects for many years.

cc #749