### PR TITLE
project const generics: BoxyUwU as lead

### DIFF
--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -3,7 +3,7 @@ kind = "project-group"
 subteam-of = "lang"
 
 [people]
-leads = ["lcnr", "nikomatsakis"]
+leads = ["BoxyUwU", "lcnr"]
 members = [
     "lcnr",
     "nikomatsakis",


### PR DESCRIPTION
@BoxyUwU has recently started to do a lot of work on const-generics again and is currently taking over pretty much all of the responsibilities of the lead.

This PR therefore adjusts the organizational structure to match reality and promotes her as the new lead, moving @lcnr to co-lead and @nikomatsakis to an ordinary member.

r? @nikomatsakis cc @rust-lang/project-const-generics 