### PR TITLE
remove required approvals from docs.rs repo

### DIFF
--- a/repos/rust-lang/docs.rs.toml
+++ b/repos/rust-lang/docs.rs.toml
@@ -10,3 +10,4 @@ docs-rs-reviewers = 'write'
 
 [[branch-protections]]
 pattern = 'master'
+required-approvals = 0


### PR DESCRIPTION
with the current state of the team I need to be able to merge PRs without approval. 

