### PR TITLE
Add yosh as a wasm wg alumnus

### DIFF
--- a/teams/wg-wasm.toml
+++ b/teams/wg-wasm.toml
@@ -12,6 +12,7 @@ alumni = [
     "alexcrichton",
     "ashleygwilliams",
     "aturon",
+    "yoshuawuyts",
 ]
 
 [[lists]]


### PR DESCRIPTION
I used to be part of the Rust Wasm WG, but no longer am. It seems likely I was missed by https://github.com/rust-lang/team/issues/1125. Thanks!