### PR TITLE
Give the spec team write-access to the reference.

### DIFF
--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -7,6 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 lang = "write"
 lang-docs = "write"
+spec = "write"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
This gives the spec team permissions for the reference repository.

cc @rust-lang/spec 
