### PR TITLE
Create a `rustc_codegen_c` repository

### DIFF
--- a/repos/rust-lang/rustc_codegen_c.toml
+++ b/repos/rust-lang/rustc_codegen_c.toml
@@ -1,0 +1,9 @@
+org = "rust-lang"
+name = "rustc_codegen_c"
+description = "C based backend for rustc"
+bots = []
+
+[access.teams]
+codegen-c-maintainers = "maintain"
+compiler = "maintain"
+compiler-contributors = "write"

--- a/teams/codegen-c-maintainers.toml
+++ b/teams/codegen-c-maintainers.toml
@@ -1,0 +1,13 @@
+name = "codegen-c-maintainers"
+subteam-of = "compiler"
+
+[people]
+leads = []
+members = [
+    "Amanieu",
+    "tgross35"
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
One of the OSPP projects this year is a C codegen backend. Create a repository where this will be developed, modeled off the codegen_cranelift repo file.

r? @Kobzol since I think you are in the loop with this