### PR TITLE
Add Veykril to crates-io-on-call team

### DIFF
--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -12,6 +12,7 @@ members = [
     "pietroalbini",
     "listochkin",
     "tshepang",
+    "Veykril",
 ]
 
 [[github]]


### PR DESCRIPTION
Veykril is being added to the on-call rotation for crates.io.

cc @pietroalbini @Veykril 