### PR TITLE
Update WG-Embedded Resources subteam with current members

### DIFF
--- a/people/BartMassey.toml
+++ b/people/BartMassey.toml
@@ -1,0 +1,5 @@
+name = "Bart Massey"
+github = "BartMassey"
+github-id = 117151
+email = "bart@cs.pdx.edu"
+zulip-id = 317761

--- a/people/hdoordt.toml
+++ b/people/hdoordt.toml
@@ -1,0 +1,4 @@
+name = "Henk Oordt"
+github = "hdoordt"
+github-id = 17907879
+zulip-id = 666154

--- a/teams/wg-embedded-resources.toml
+++ b/teams/wg-embedded-resources.toml
@@ -6,13 +6,16 @@ kind = "working-group"
 leads = []
 members = [
     "adamgreig",
-    "andre-richter",
+    "BartMassey",
     "eldruin",
     "hargoniX",
+    "hdoordt",
     "jamesmunns",
     "therealprof",
 ]
-alumni = []
+alumni = [
+    "andre-richter",
+]
 
 [website]
 name = "Embedded resources working group"


### PR DESCRIPTION
This PR adds two new members, @hdoordt and @bartmassey, and moves Andre to the alumni section.

This matches our current team enrollment: https://github.com/rust-embedded/wg?tab=readme-ov-file#the-resources-team