### PR TITLE
Switch edition-guide homepage link to nightly

### DIFF
--- a/repos/rust-lang/edition-guide.toml
+++ b/repos/rust-lang/edition-guide.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "edition-guide"
 description = "A guide to changes between various editions of Rust"
-homepage = "https://doc.rust-lang.org/stable/edition-guide/"
+homepage = "https://doc.rust-lang.org/nightly/edition-guide/"
 bots = ["rustbot", "rfcbot"]
 
 [access.teams]


### PR DESCRIPTION
The nightly copy is updated more frequently, so it provides a more current version.