### PR TITLE
Add `spec-contributors` team

### DIFF
--- a/people/chorman0773.toml
+++ b/people/chorman0773.toml
@@ -1,4 +1,5 @@
 name = 'Connor Horman'
 github = 'chorman0773'
 github-id = 5026283
+email = false
 zulip-id = 257758

--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -8,6 +8,7 @@ bots = ["rustbot"]
 lang = "write"
 lang-docs = "write"
 spec = "write"
+spec-contributors = "write"
 
 [[branch-protections]]
 pattern = "master"

--- a/repos/rust-lang/spec.toml
+++ b/repos/rust-lang/spec.toml
@@ -5,3 +5,4 @@ bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 spec = 'maintain'
+spec-contributors = "write"

--- a/teams/spec-contributors.toml
+++ b/teams/spec-contributors.toml
@@ -1,0 +1,22 @@
+name = "spec-contributors"
+subteam-of = "spec"
+
+[people]
+leads = []
+members = [
+    "chorman0773",
+]
+alumni = []
+
+[website]
+name = "Specification team contributors"
+description = "Regular contributors to the Rust specification"
+repo = "https://github.com/rust-lang/spec"
+zulip-stream = "t-spec"
+
+[[github]]
+orgs = ["rust-lang"]
+extra-teams = ["spec"]
+
+[[zulip-groups]]
+name = "T-spec-contributors"


### PR DESCRIPTION
In our meeting on 2024-07-11, the spec team decided to create a `spec-contributors` team and to add Connor Horman to it given his new role as a contractor hired by the Rust Foundation to do work on the specification.

cc @ehuss @JoelMarcey @pnkfelix @m-ou-se @chorman0773
