### PR TITLE
move varkor to Project Const Generics alumni

### DIFF
--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -7,12 +7,12 @@ leads = ["BoxyUwU", "lcnr"]
 members = [
     "lcnr",
     "nikomatsakis",
-    "varkor",
     "davidtwco",
     "oli-obk",
     "BoxyUwU",
 ]
 alumni = [
+    "varkor",
     "withoutboats",
 ]
 


### PR DESCRIPTION
While their work on const generics has been invaluable, they haven't been active recently. Mirroring #1074, let's move them to alumni status to accurately reflect the status quo.

Thank you for your work @varkor and you're welcome to join again if/once you decide to contribute again!

r? @BoxyUwU