### PR TITLE
Add Alex Crichton as compiler contributor

### DIFF
--- a/teams/compiler-contributors.toml
+++ b/teams/compiler-contributors.toml
@@ -4,6 +4,7 @@ subteam-of = "compiler"
 [people]
 leads = []
 members = [
+    "alexcrichton",
     "apiraino",
     "b-naber",
     "bjorn3",


### PR DESCRIPTION
As discussed on the T-compiler mailing list, alumni can just be readded without waiting for team consensus