### PR TITLE
Update CI job name for the reference.

### DIFF
--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -12,4 +12,4 @@ spec-contributors = "write"
 
 [[branch-protections]]
 pattern = "master"
-ci-checks = ["Test"]
+ci-checks = ["Success gate"]


### PR DESCRIPTION
More CI jobs are being added in https://github.com/rust-lang/reference/pull/1542. To make it easier to manage, I'm switching it to a summary job which will have a different name.
