### PR TITLE
exclude inactive member from Types Team FCPs

### DIFF
--- a/teams/types.toml
+++ b/teams/types.toml
@@ -27,6 +27,7 @@ zulip-stream = "t-types"
 label = "T-types"
 name = "Types"
 ping = "rust-lang/types"
+exclude-members = ["aliemjay"]
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]


### PR DESCRIPTION
@aliemjay has not been online recently and we were not able to contact them zulip. Given that we're unable to reach them, @jackh726 and I decided to remove them from the FCP rotation for now. We hope they are doing well and remain thankful for their existing contributions to the Types Team.

They are still a member of the team and are able to register concerns as blocking. This change can be reverted once they are active again.

r? @jackh726 cc @rust-lang/types 