### PR TITLE
add my zulip id for automated pings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cargo run add-person <github-username>
 You can also add additional information, such as someone's Discord or Zulip ID by adding additional fields to their `.toml` file.
 
 To determine someone's Zulip ID, find them in the list of people on the
-right-hand side in Zulip, click the "three dots" menu, and copy the 'User ID'
+right-hand side in Zulip, click the "three dots" menu and then "View profile", and copy the 'User ID'
 into the toml file:
 
 ```

--- a/people/lqd.toml
+++ b/people/lqd.toml
@@ -2,3 +2,4 @@ name = "Rémy Rakic"
 github = "lqd"
 github-id = 247183
 email = "remy.rakic+rust@gmail.com"
+zulip-id = 116113


### PR DESCRIPTION
This adds my zulip id so that [project goal pings](https://rust-lang.zulipchat.com/#narrow/stream/435869-project-goals/topic/Scalable.20Polonius.20support.20on.20nightly.20.28goals.23118.29/near/454329533) work on zulip.

I've also updated the instructions to get the zulip id, as there's a new step to do since this was written.