### PR TITLE
grant ability to merge rustfmt PRs

### DIFF
--- a/repos/rust-lang/rustfmt.toml
+++ b/repos/rust-lang/rustfmt.toml
@@ -9,6 +9,7 @@ rustfmt = "write"
 
 [[branch-protections]]
 pattern = "master"
+required-approvals = 0
 ci-checks = [
     "(x86_64-unknown-linux-gnu, nightly)",
     "(x86_64-unknown-linux-gnu, stable)",


### PR DESCRIPTION
The rustfmt repo doesn't have bors enabled, the rustfmt team only consists of 2 people, myself and Yacin (who's on vacation for the next couple weeks), and we've got a branch protection policy that requires a review.

I've got some sequential work for the rustfmt 2024 items that's predicated on getting [some things](https://github.com/rust-lang/rustfmt/pull/6253) merged, which means I'm completely blocked at the moment. I previously had the ability to override this as an admin, but based on some [discussion in Zulip] my understanding is that the repo permissions were changed and the way to "override" this now is to temporarily disable the review requirement.

[discussion in Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/357797-t-rustfmt/topic/new.20syntax.20support/near/446195934