### PR TITLE
Update rust-analyzer{-contributors}

### DIFF
--- a/people/ShoyuVanilla.toml
+++ b/people/ShoyuVanilla.toml
@@ -1,0 +1,5 @@
+name = "Shoyu Vanilla"
+github = "ShoyuVanilla"
+github-id = 10542892
+email = "modulo641@gmail.com"
+zulip-id = 685469

--- a/teams/rust-analyzer-contributors.toml
+++ b/teams/rust-analyzer-contributors.toml
@@ -6,11 +6,11 @@ leads = []
 members = [
     "alibektas",
     "bjorn3",
-    "davidbarsky",
-    "Nadrieril",
-    "Young-Flash",
-    "roife",
     "DropDemBits",
+    "Nadrieril",
+    "roife",
+    "ShoyuVanilla",
+    "Young-Flash",
 ]
 alumni = []
 

--- a/teams/rust-analyzer.toml
+++ b/teams/rust-analyzer.toml
@@ -4,16 +4,17 @@ subteam-of = "compiler"
 [people]
 leads = ["Veykril"]
 members = [
+    "davidbarsky",
+    "flodiebold",
+    "HKalbasi",
     "lnicola",
     "Veykril",
-    "flodiebold",
-    "lowr",
-    "HKalbasi",
 ]
 alumni = [
     "edwin0cheng",
-    "SomeoneToIgnore",
+    "lowr",
     "matklad",
+    "SomeoneToIgnore",
 ]
 
 [website]


### PR DESCRIPTION
This moves @davidbarsky to the main team, adds @ShoyuVanilla to the contributors team and moves @lowr to alumni (they are welcome to move back up anytime, moving them down to general inactivity).

@rust-lang/rust-analyzer

@ShoyuVanilla and @davidbarsky please approve if you are okay with this (haven't asked either)