### PR TITLE
Update nomicon ci job name

### DIFF
--- a/repos/rust-lang/nomicon.toml
+++ b/repos/rust-lang/nomicon.toml
@@ -10,4 +10,4 @@ lang-docs = "write"
 
 [[branch-protections]]
 pattern = "master"
-ci-checks = ["Test"]
+ci-checks = ["Success gate"]


### PR DESCRIPTION
In https://github.com/rust-lang/nomicon/pull/459 we are switching to merge queue, which includes a "consolidation" job.
