### PR TITLE
fix: archive repo correctly

### DIFF
--- a/repos/archive/rust-lang/crates.io-infra.toml
+++ b/repos/archive/rust-lang/crates.io-infra.toml
@@ -5,6 +5,3 @@ bots = []
 private-non-synced = true
 
 [access.teams]
-infra = "write"
-crates-io-on-call = "write"
-crates-io = "write"


### PR DESCRIPTION
This PR:

- moves the file in the correct directory
- removes team access, as requested in https://github.com/rust-lang/team/pull/1521#issuecomment-2296688402