### PR TITLE
Update branch protections for `cmake-rs` and `libm`

### DIFF
--- a/repos/rust-lang/cmake-rs.toml
+++ b/repos/rust-lang/cmake-rs.toml
@@ -9,3 +9,5 @@ crate-maintainers = 'maintain'
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ['success']
+required-approvals = 0

--- a/repos/rust-lang/libm.toml
+++ b/repos/rust-lang/libm.toml
@@ -8,3 +8,5 @@ crate-maintainers = 'maintain'
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ['success']
+required-approvals = 0


### PR DESCRIPTION
Requires:

- https://github.com/rust-lang/cmake-rs/pull/218
- https://github.com/rust-lang/libm/pull/299

Unfortunately I can't merge either of those since https://github.com/rust-lang/team/pull/1524, so I think somebody else needs to approve them before this can merge.