### PR TITLE
crates-io: Alumnize JohnTitor

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -7,7 +7,6 @@ members = [
     "carols10cents",
     "jtgeibel",
     "Turbo87",
-    "JohnTitor",
     "LawnGnome",
     "mdtro",
     "Rustin170506",
@@ -26,6 +25,7 @@ alumni = [
     "pichfl",
     "locks",
     "wycats",
+    "JohnTitor",
 ]
 
 [permissions]


### PR DESCRIPTION
@JohnTitor quoting from our email thread last year:

> I think it's fine to remove me and I'm happy to become an alumni.

If you changed your mind, let me know, otherwise: welcome to the land of unlimited power without any responsibilities :D

btw the reason for doing this now is that we're often struggling lately to have enough FCP checkboxes ticked on crates.io RFCs, and the fewer inactive team members we have, the easier it becomes to reach the necessary numbers :)