### PR TITLE
repos/rfcs: Remove approvals requirement

### DIFF
--- a/repos/rust-lang/rfcs.toml
+++ b/repos/rust-lang/rfcs.toml
@@ -9,3 +9,4 @@ all = "write"
 
 [[branch-protections]]
 pattern = "master"
+required-approvals = 0


### PR DESCRIPTION
RFCs already go through the FCP flow where (almost) all team members need to check their approval checkbox. Requiring an additional GitHub-based PR approval seems like an unnecessary burden to get the RFC merged once the FCP period has concluded.

This PR sets number of required GitHub-based approvals (back?) to zero, which AFAIU matches that value that had been used in the past for this repository.

Related:

- https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/rfcs.20repo.20review.20requirement