### PR TITLE
teams/mods: Add `T-mods` Zulip group

### DIFF
--- a/teams/mods.toml
+++ b/teams/mods.toml
@@ -46,3 +46,6 @@ extra-teams = [
     "mods-discord",
     "mods-discourse",
 ]
+
+[[zulip-groups]]
+name = "T-mods"


### PR DESCRIPTION
I assume this means we can start using `@T-mods` on Zulip and it will ping the current members of the mods team.

r? @rust-lang/mods 