### PR TITLE
Fix elided-named-lifetimes

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -151,7 +151,7 @@ impl Data {
     pub(crate) fn subteams_of<'a>(
         &'a self,
         team_name: &'a str,
-    ) -> impl Iterator<Item = &Team> + 'a {
+    ) -> impl Iterator<Item = &'a Team> + 'a {
         self.team(team_name).into_iter().flat_map(move |team| {
             self.teams()
                 .filter(move |maybe_subteam| team.is_parent_of(self, maybe_subteam))


### PR DESCRIPTION
Rust has recently started warning about the missing lifetime here (via https://github.com/rust-lang/rust/pull/129207).

```
warning: elided lifetime has a name
   --> src/data.rs:154:31
    |
151 |     pub(crate) fn subteams_of<'a>(
    |                               -- lifetime `'a` declared here
...
154 |     ) -> impl Iterator<Item = &Team> + 'a {
    |                               ^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
```
