### PR TITLE
Add missing rustbot to the blog repository

### DIFF
--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "blog.rust-lang.org"
 description = "Home of the Rust and Inside Rust blogs"
 homepage = "https://blog.rust-lang.org"
-bots = ["renovate"]
+bots = ["rustbot", "renovate"]
 
 [access.teams]
 inside-rust-reviewers = "write"


### PR DESCRIPTION
Add missing `rustbot` bot to the [blog.rust-lang.org repo](https://github.com/rust-lang/blog.rust-lang.org) config. The repo already contains a [triagebot.toml](https://github.com/rust-lang/blog.rust-lang.org/blob/master/triagebot.toml) config (from 4 years ago, so it probably worked in the past).

This change is mainly motivated by https://github.com/rust-lang/triagebot/pull/1839, which I was expecting to work given the existing config. 