### PR TITLE
remove branch protection for `chalk`repository

### DIFF
--- a/repos/rust-lang/chalk.toml
+++ b/repos/rust-lang/chalk.toml
@@ -6,6 +6,3 @@ bots = ["rustbot", "bors"]
 
 [access.teams]
 types = "write"
-
-[[branch-protections]]
-pattern = "master"


### PR DESCRIPTION
The [chalk](https://github.com/rust-lang/chalk/) repository used an automated process to cut releases, but Jack told me the branch protection added when initially putting chalk under `team/repos` prevents this from working (for example, as seen in https://github.com/rust-lang/chalk/issues/814). 

So this PR removes the branch protection to help with future releases, in particular for `rust-analyzer` to use.

Have a safe flight home @jackh726 <3.