### PR TITLE
Remove review requirement for relnotes tooling

### DIFF
--- a/repos/rust-lang/relnotes.toml
+++ b/repos/rust-lang/relnotes.toml
@@ -19,3 +19,4 @@ ci-checks = [
     "build (windows-latest, nightly)",
     "build (windows-latest, stable)",
 ]
+required-approvals = 0


### PR DESCRIPTION
This is a purely internal repo, which doesn't even deploy to any infrastructure. Drop review requirements for the time being.