### PR TITLE
Don't include rustdoc members in rustdoc-frontend

### DIFF
--- a/teams/rustdoc-frontend.toml
+++ b/teams/rustdoc-frontend.toml
@@ -18,7 +18,6 @@ perf = true
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
-extra-teams = ["rustdoc"]
 
 [website]
 name = "Rustdoc web frontend"


### PR DESCRIPTION
Rustdoc frontend was created so that rustdoc people who didn't work on the HTML output didn't need to block FCP's to that. However, they're still pinged when @rust-lang/rustdoc-frontend is pinged, because their still part of the github team.

CC @rust-lang/rustdoc, if you want pings for @rust-lang/rustdoc-frontend after this, you should add yourself (or speak up here if you think this is a bad idea).

[zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/We.E2.80.99re.20all.20on.20T-rustdoc-frontend.3F.3F)