### PR TITLE
Add email field to `chorman0773`

### DIFF
--- a/people/chorman0773.toml
+++ b/people/chorman0773.toml
@@ -1,5 +1,5 @@
 name = 'Connor Horman'
 github = 'chorman0773'
 github-id = 5026283
-email = false
+email = 'chorman@lcdev.xyz'
 zulip-id = 257758


### PR DESCRIPTION
I assuming this is required to recieve the `all` emails, so I've added my email address to the `email` field of `people/chorman0773.toml` instead of `false`.