### PR TITLE
Restore branch protections for `llvm-project`

### DIFF
--- a/repos/rust-lang/llvm-project.toml
+++ b/repos/rust-lang/llvm-project.toml
@@ -5,3 +5,11 @@ bots = []
 
 [access.teams]
 wg-llvm = "maintain"
+
+[[branch-protections]]
+pattern = "rustc/*"
+pr-required = false
+
+[[branch-protections]]
+pattern = "master"
+pr-required = false


### PR DESCRIPTION
This essentially reverts rust-lang/team#1346, now that we have the ability to specify that PRs are not required for protected branches.