### PR TITLE
Add crates.io-index-archive repository under automation

### DIFF
--- a/repos/rust-lang/crates.io-index-archive.toml
+++ b/repos/rust-lang/crates.io-index-archive.toml
@@ -1,0 +1,15 @@
+org = "rust-lang"
+name = "crates.io-index-archive"
+description = "Archive of the crates.io-index commit history after squashes"
+bots = []
+
+[access.teams]
+crates-io = "admin"
+
+[[branch-protections]]
+pattern = "snapshot-*"
+pr-required = false
+
+[[branch-protections]]
+pattern = "main"
+pr-required = false


### PR DESCRIPTION
Repo: https://github.com/rust-lang/crates.io-index-archive

I modeled the PR after https://github.com/rust-lang/team/pull/1306.

Not sure if the admin access is needed, but probably doesn't hurt in this backup repo

CC @Turbo87

Extracted from GH:
```
org = "rust-lang"
name = "crates.io-index-archive"
description = "Archive of the crates.io-index commit history after squashes"
bots = []

[access.teams]
crates-io = "admin"
security = "pull"

[access.individuals]
carols10cents = "admin"
MarcoIeni = "admin"
jtgeibel = "admin"
jdno = "admin"
mdtro = "admin"
Turbo87 = "admin"
Rustin170506 = "admin"
eth3lbert = "admin"
pietroalbini = "admin"
rust-lang-owner = "admin"
Mark-Simulacrum = "admin"
LawnGnome = "admin"

[[branch-protections]]
pattern = "snapshot-*"
required-approvals = 0
pr-required = false

[[branch-protections]]
pattern = "main"
required-approvals = 0
pr-required = false
```