### PR TITLE
Add staging.crates.io-index repository under automation

### DIFF
--- a/repos/rust-lang/staging.crates.io-index.toml
+++ b/repos/rust-lang/staging.crates.io-index.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "staging.crates.io-index"
+description = "Registry index for staging.crates.io"
+bots = []
+
+[access.teams]
+crates-io = "write"
+crates-io-on-call = "write"
+
+[[branch-protections]]
+pattern = "master"
+pr-required = false


### PR DESCRIPTION
Repo: https://github.com/rust-lang/staging.crates.io-index

Modeled after https://github.com/rust-lang/team/pull/1306.

CC @Turbo87

Extracted from GH:
```
org = "rust-lang"
name = "staging.crates.io-index"
description = "Registry index for staging.crates.io"
bots = []

[access.teams]
security = "pull"
crates-io = "write"
crates-io-on-call = "write"

[access.individuals]
jdno = "admin"
pietroalbini = "admin"
tshepang = "write"
carols10cents = "write"
Xylakant = "write"
LawnGnome = "write"
eth3lbert = "write"
listochkin = "write"
Rustin170506 = "write"
jtgeibel = "write"
Turbo87 = "write"
mdtro = "write"
skade = "write"
rust-lang-owner = "admin"
MarcoIeni = "admin"
Mark-Simulacrum = "admin"
justahero = "write"
Veykril = "write"

[[branch-protections]]
pattern = "master"
required-approvals = 0
pr-required = false
```