### PR TITLE
Add infra-smoke-tests repository

### DIFF
--- a/repos/rust-lang/infra-smoke-tests.toml
+++ b/repos/rust-lang/infra-smoke-tests.toml
@@ -1,0 +1,21 @@
+org = "rust-lang"
+name = "infra-smoke-tests"
+description = "Smoke tests for the infrastructure of the Rust project"
+bots = ["renovate"]
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "main"
+required-approvals = 0
+ci-checks = [
+    "Check Markdown style",
+    "Check JSON style",
+    "Check Rust style",
+    "Check YAML style",
+    "Lint Markdown files",
+    "Lint Rust code",
+    "Lint YAML files",
+    "Run tests",
+]


### PR DESCRIPTION
The infra-smoke-tests[^1] repository is an internal tool by the infra-team to implement smoke tests for its cloud-based infrastructure.

[^1]: https://github.com/rust-lang/infra-smoke-tests