### PR TITLE
Add rustdoc-types repo under automation

### DIFF
--- a/repos/rust-lang/rustdoc-types.toml
+++ b/repos/rust-lang/rustdoc-types.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "rustdoc-types"
+description = "Rustdoc's JSON output interface"
+bots = []
+
+[access.teams]
+rustdoc = "write"


### PR DESCRIPTION
Part of implementing RFC [3505](https://rust-lang.github.io/rfcs/3673-rustdoc-types-maintainers.html)

CC @rust-lang/rustdoc 