### PR TITLE
Remove bors from `hashbrown`

### DIFF
--- a/repos/rust-lang/hashbrown.toml
+++ b/repos/rust-lang/hashbrown.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "hashbrown"
 description = "Rust port of Google's SwissTable hash map"
 homepage = "https://rust-lang.github.io/hashbrown"
-bots = ["bors"]
+bots = []
 
 [access.teams]
 libs = "write"
@@ -10,3 +10,4 @@ libs-contributors = "write"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["conclusion"]


### PR DESCRIPTION
This should be accompanied by configuring a merge queue for `hashbrown`. Accompanying PR: https://github.com/rust-lang/hashbrown/pull/575.