### PR TITLE
Add wasm | wasi | emscripten notification groups

### DIFF
--- a/people/hoodmane.toml
+++ b/people/hoodmane.toml
@@ -1,0 +1,4 @@
+name = "Hood Chatham"
+github = "hoodmane"
+github-id = 8739626
+zulip-id = 627382

--- a/people/juntyr.toml
+++ b/people/juntyr.toml
@@ -1,0 +1,4 @@
+name = "Juniper Tyree"
+github = "juntyr"
+github-id = 50025784
+zulip-id = 688155

--- a/teams/emscripten.toml
+++ b/teams/emscripten.toml
@@ -4,5 +4,6 @@ kind = "marker-team"
 [people]
 leads = []
 members = [
+    "hoodmane",
     "juntyr",
 ]

--- a/teams/emscripten.toml
+++ b/teams/emscripten.toml
@@ -1,0 +1,8 @@
+name = "emscripten"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "juntyr",
+]

--- a/teams/wasi.toml
+++ b/teams/wasi.toml
@@ -1,0 +1,9 @@
+name = "wasi"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "alexcrichton",
+    "juntyr",
+]

--- a/teams/wasm.toml
+++ b/teams/wasm.toml
@@ -5,5 +5,6 @@ kind = "marker-team"
 leads = []
 members = [
     "alexcrichton",
+    "hoodmane",
     "juntyr",
 ]

--- a/teams/wasm.toml
+++ b/teams/wasm.toml
@@ -1,0 +1,9 @@
+name = "wasm"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "alexcrichton",
+    "juntyr",
+]


### PR DESCRIPTION
The MCP for creating WASM, WASI, and Emscripten [notification groups](https://rustc-dev-guide.rust-lang.org/notification-groups/about.html) (https://github.com/rust-lang/compiler-team/issues/794) was accepted. This PR creates the notification group with the initial group members.

(note to self: this is part two of the steps in https://forge.rust-lang.org/compiler/notification-groups.html#notification-groups)

@alexcrichton Are you alright with being an initial member in the WASM and WASI groups?

@hoodmane Do you want to be part of the Emscripten group? If so, what details should I add for you?

cc @jieyouxu