### PR TITLE
Add `ferris` to the WASI team

### DIFF
--- a/teams/wasi.toml
+++ b/teams/wasi.toml
@@ -6,4 +6,5 @@ leads = []
 members = [
     "alexcrichton",
     "juntyr",
+    "ferris",
 ]


### PR DESCRIPTION
This PR is meant to serve as an example! To add yourself to the WASI team, just create a commit like this one, but adding your own username to the file instead of `ferris`.

Also, if you are not already a member of a Rust team then -- in addition to adding your name to this file -- you have to checkout the repository, run the command below and commit the new file it creates

```sh
cargo run add-person $your_user_name
```