### PR TITLE
Remove bors from chalk

### DIFF
--- a/repos/rust-lang/chalk.toml
+++ b/repos/rust-lang/chalk.toml
@@ -2,7 +2,11 @@ org = "rust-lang"
 name = "chalk"
 description = "An implementation and definition of the Rust trait system using a PROLOG-like logic solver"
 homepage = "https://rust-lang.github.io/chalk/book/"
-bots = ["rustbot", "bors"]
+bots = ["rustbot"]
 
 [access.teams]
 types = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["conclusion"]


### PR DESCRIPTION
It shouldn't really be needed on this repo.

Accompanying PR: https://github.com/rust-lang/chalk/pull/818

`wg-traits` also had bors merge rights for chalk, but that WG has been archived, so I don't think that we need to deal with it further.