### PR TITLE
Remove bors from miri

### DIFF
--- a/repos/rust-lang/miri.toml
+++ b/repos/rust-lang/miri.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "miri"
 description = "An interpreter for Rust's mid-level intermediate representation"
-bots = ["rustbot", "bors"]
+bots = ["rustbot"]
 
 [access.teams]
 compiler = "write"
@@ -9,3 +9,4 @@ miri = "write"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["conclusion"]


### PR DESCRIPTION
Accompanying PR: https://github.com/rust-lang/miri/pull/3981