### PR TITLE
Remove legacy bors permissions

### DIFF
--- a/people/BurntSushi.toml
+++ b/people/BurntSushi.toml
@@ -4,6 +4,3 @@ github-id = 456674
 irc = "burntsushi"
 email = "jamslam@gmail.com"
 zulip-id = 222471
-
-[permissions]
-bors.regex.review = true

--- a/people/Diggsey.toml
+++ b/people/Diggsey.toml
@@ -1,3 +1,0 @@
-name = "Diggory Blake"
-github = "Diggsey"
-github-id = 451321

--- a/people/Diggsey.toml
+++ b/people/Diggsey.toml
@@ -1,6 +1,3 @@
 name = "Diggory Blake"
 github = "Diggsey"
 github-id = 451321
-
-[permissions]
-bors.rustup-rs.review = true

--- a/people/JohnTitor.toml
+++ b/people/JohnTitor.toml
@@ -4,6 +4,3 @@ github-id = 25030997
 email = "huyuumi.dev@gmail.com"
 discord-id = 362122860673892353
 zulip-id = 217081
-
-[permissions]
-bors.semverver.review = true

--- a/people/Manishearth.toml
+++ b/people/Manishearth.toml
@@ -4,6 +4,3 @@ github-id = 1617736
 email = "manishsmail@gmail.com"
 zulip-id = 132040
 discord-id = 278623213448331265
-
-[permissions]
-bors.semverver.review = true

--- a/people/Xanewok.toml
+++ b/people/Xanewok.toml
@@ -3,8 +3,3 @@ github = "Xanewok"
 github-id = 3093213
 email = "xanewok@gmail.com"
 zulip-id = 153740
-
-[permissions]
-bors.rls.review = true
-bors.semverver.review = true
-bors.vscode-rust.review = true

--- a/people/alexheretic.toml
+++ b/people/alexheretic.toml
@@ -2,6 +2,3 @@ name = "Alex Butler"
 github = "alexheretic"
 github-id = 2331607
 email = "alexheretic@gmail.com"
-
-[permissions]
-bors.rls.review = true

--- a/people/gnzlbg.toml
+++ b/people/gnzlbg.toml
@@ -2,6 +2,3 @@ name = "gnzlbg"
 github = "gnzlbg"
 github-id = 904614
 zulip-id = 132920
-
-[permissions]
-bors.stdarch.review = true

--- a/people/ibabushkin.toml
+++ b/people/ibabushkin.toml
@@ -2,6 +2,3 @@ name = "Inokentiy Babushkin"
 github = "ibabushkin"
 github-id = 10811417
 email = "twk@twki.de"
-
-[permissions]
-bors.semverver.review = true

--- a/people/ibabushkin.toml
+++ b/people/ibabushkin.toml
@@ -1,4 +1,0 @@
-name = "Inokentiy Babushkin"
-github = "ibabushkin"
-github-id = 10811417
-email = "twk@twki.de"

--- a/people/japaric.toml
+++ b/people/japaric.toml
@@ -4,5 +4,4 @@ github-id = 5018213
 email = "jorge@japaric.io"
 
 [permissions]
-bors.compiler-builtins.review = true
 bors.rust.review = true

--- a/people/matklad.toml
+++ b/people/matklad.toml
@@ -3,6 +3,3 @@ github = "matklad"
 github-id = 1711539
 email = "aleksey.kladov@gmail.com"
 zulip-id = 133169
-
-[permissions]
-bors.vscode-rust.review = true

--- a/people/nrc.toml
+++ b/people/nrc.toml
@@ -3,7 +3,3 @@ github = "nrc"
 github-id = 762626
 email = "nrc@ncameron.org"
 zulip-id = 256841
-
-[permissions]
-bors.rustup-rs.review = true
-bors.rls.review = true

--- a/teams/archive/wg-traits.toml
+++ b/teams/archive/wg-traits.toml
@@ -35,6 +35,3 @@ zulip-stream = "wg-traits"
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
-
-[permissions]
-bors.chalk.review = true

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -38,7 +38,6 @@ perf = true
 crater = true
 dev-desktop = true
 bors.rust.review = true
-bors.miri.review = true
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]

--- a/teams/crate-maintainers.toml
+++ b/teams/crate-maintainers.toml
@@ -19,10 +19,6 @@ members = [
 ]
 alumni = []
 
-[permissions]
-bors.stdarch.review = true
-bors.compiler-builtins.review = true
-
 [[github]]
 orgs = ["rust-lang"]
 

--- a/teams/libs-api.toml
+++ b/teams/libs-api.toml
@@ -32,8 +32,6 @@ orgs = ["rust-lang", "rust-lang-nursery"]
 perf = true
 crater = true
 bors.rust.review = true
-bors.hashbrown.review = true
-bors.stdarch.review = true
 
 [rfcbot]
 label = "T-libs-api"

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -25,9 +25,7 @@ orgs = ["rust-lang", "rust-lang-nursery"]
 perf = true
 crater = true
 dev-desktop = true
-bors.hashbrown.review = true
 bors.rust.review = true
-bors.stdarch.review = true
 
 [rfcbot]
 label = "T-libs"

--- a/teams/miri.toml
+++ b/teams/miri.toml
@@ -7,7 +7,6 @@ members = ["RalfJung", "oli-obk", "saethlin"]
 alumni = ["solson"]
 
 [permissions]
-bors.miri.review = true
 bors.rust.try = true
 perf = true
 

--- a/teams/types.toml
+++ b/teams/types.toml
@@ -40,7 +40,6 @@ name = "T-types/meetings"
 extra-people = ["eholk"]
 
 [permissions]
-bors.chalk.review = true
 bors.rust.review = true
 perf = true
 crater = true


### PR DESCRIPTION
This PR removes bors review/try permissions for repositories that are no longer managed by bors.