### PR TITLE
Switch rust-analyzer from bors to merge-queue

### DIFF
--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "rust-analyzer"
 description = "A Rust compiler front-end for IDEs"
 homepage = "https://rust-analyzer.github.io/"
-bots = ["bors", "rustbot"]
+bots = ["rustbot"]
 
 [access.teams]
 rust-analyzer = "write"
@@ -10,3 +10,5 @@ rust-analyzer-contributors = "triage"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["conclusion"]
+required-approvals = 0

--- a/teams/rust-analyzer.toml
+++ b/teams/rust-analyzer.toml
@@ -25,7 +25,6 @@ repo = "https://github.com/rust-lang/rust-analyzer"
 
 [permissions]
 bors.rust.review = true
-bors.rust-analyzer.review = true
 
 [[github]]
 orgs = ["rust-lang", "rust-analyzer"]


### PR DESCRIPTION
Accompanying PR: https://github.com/rust-lang/rust-analyzer/pull/18372.

@Veykril asked for PRs to not require approvals, so I reflected that here.