### PR TITLE
Switch cargo from bors to merge-queue

### DIFF
--- a/people/Mark-Simulacrum.toml
+++ b/people/Mark-Simulacrum.toml
@@ -5,6 +5,3 @@ zulip-id = 116122
 irc = "simulacrum"
 email = "mark.simulacrum@gmail.com"
 discord-id = 442403469580566528
-
-[permissions]
-bors.cargo.review = true

--- a/people/steveklabnik.toml
+++ b/people/steveklabnik.toml
@@ -3,6 +3,3 @@ github = "steveklabnik"
 github-id = 27786
 email = "steve@steveklabnik.com"
 discord-id = 271866667292819456
-
-[permissions]
-bors.cargo.review = true

--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -2,13 +2,15 @@ org = "rust-lang"
 name = "cargo"
 description = "The Rust package manager"
 homepage = "https://doc.rust-lang.org/cargo"
-bots = ["bors", "rustbot", "rfcbot", "renovate"]
+bots = ["rustbot", "rfcbot", "renovate"]
 
 [access.teams]
 cargo = "write"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["conclusion"]
 
 [[branch-protections]]
 pattern = "rust-1.*"
+ci-checks = ["conclusion"]

--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -25,7 +25,6 @@ alumni = [
 
 [permissions]
 bors.rust.review = true
-bors.cargo.review = true
 crater = true
 perf = true
 


### PR DESCRIPTION
Accompanying PR: https://github.com/rust-lang/cargo/pull/14718

**Merge should be synchronized with an infra-admin switching the repo to merge queues!**