### PR TITLE
Switch clippy from bors to merge queue

### DIFF
--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "rust-clippy"
 description = "A bunch of lints to catch common mistakes and improve your Rust code. Book: https://doc.rust-lang.org/clippy/"
 homepage = "https://rust-lang.github.io/rust-clippy/"
-bots = ["bors", "rustbot"]
+bots = ["rustbot"]
 
 [access.teams]
 clippy = "write"
@@ -10,3 +10,8 @@ clippy-contributors = "triage"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = [
+    "conclusion",
+    "conclusion_dev",
+    "conclusion_remark",
+]

--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -15,3 +15,4 @@ ci-checks = [
     "conclusion_dev",
     "conclusion_remark",
 ]
+required-approvals = 0

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -30,7 +30,6 @@ alumni = [
 
 [permissions]
 perf = true
-bors.clippy.review = true
 bors.rust.review = true
 dev-desktop = true
 


### PR DESCRIPTION
Accompanying PR: https://github.com/rust-lang/rust-clippy/pull/13587

I forgot to mark https://github.com/rust-lang/team/pull/1589 as a draft, so it was accidentally merged (and later reverted in https://github.com/rust-lang/team/pull/1591). This should not be merged until we configure the clippy repo properly.