### PR TITLE
Graduate @giraffate and @m-rph to Clippy/Contributor alumni

### DIFF
--- a/teams/clippy-contributors.toml
+++ b/teams/clippy-contributors.toml
@@ -6,11 +6,12 @@ leads = []
 members = [
     "GuillaumeGomez",
     "J-ZhengLi",
-    "m-rph",
     "pitaj",
     "samueltardieu",
 ]
-alumni = []
+alumni = [
+    "m-rph",
+]
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/clippy.toml
+++ b/teams/clippy.toml
@@ -8,7 +8,6 @@ members = [
     "Manishearth",
     "matthiaskrgr",
     "flip1995",
-    "giraffate",
     "xFrednet",
     "Alexendoo",
     "dswij",
@@ -26,6 +25,7 @@ alumni = [
     "phansch",
     "camsteffen",
     "birkenfeld",
+    "giraffate",
 ]
 
 [permissions]


### PR DESCRIPTION
This moves @giraffate and @m-rph to their respective Clippy alumni teams.

---

I believe, I speak for the team, when I say:

Thank you for the work you've done! If you ever want to come back, just reach out, we'd be happy to have you!

---

r? @flip1995 || @Manishearth