### PR TITLE
update membership for t-compiler/meeting

### DIFF
--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -110,3 +110,17 @@ name = "T-compiler"
 
 [[zulip-groups]]
 name = "T-compiler/meeting"
+include-team-members = false
+extra-people = [
+    "davidtwco",
+    "wesleywiser",
+    "apiraino",
+    "bjorn3",
+    "SparrowLii",
+    "estebank",
+    "BoxyUwU",
+    "jieyouxu",
+    "jswrenn",
+    "spastorino",
+    "tmiasko"
+]


### PR DESCRIPTION
It is preferred that the membership of this Zulip ping group be managed in an ad-hoc way, some members do not attend, and some members prefer not to be pinged so they get notified about subsequent direct pings, etc.