### PR TITLE
Set dev guide approvals to 0

### DIFF
--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -14,3 +14,4 @@ libs-contributors = "write"
 [[branch-protections]]
 pattern = "master"
 ci-checks = ["ci"]
+required-approvals = 0


### PR DESCRIPTION
When a subject matter expert writes some docs, there's no point in blocking them. They should just merge their stuff, we can always fix it later. If someone does want a review for their PR, they can always get it still.

discussed this with @BoxyUwU and @jieyouxu, @rust-lang/wg-rustc-dev-guide 