### PR TITLE
Allow T-bootstrap to have write access to rustc-dev-guide repo

### DIFF
--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -5,6 +5,7 @@ homepage = "https://rustc-dev-guide.rust-lang.org"
 bots = ["rustbot"]
 
 [access.teams]
+bootstrap = "write"
 compiler = "write"
 wg-rustc-dev-guide = "maintain"
 infra = "write"


### PR DESCRIPTION
T-bootstrap maintains the build system, it makes no sense why bootstrap doesn't have write acccess (unless this is covered by T-infra...?)

cc @spastorino and @onur-ozkan

I guess also cc @rust-lang/bootstrap for FYI.