### PR TITLE
Update edition-guide branch protection

### DIFF
--- a/repos/rust-lang/edition-guide.toml
+++ b/repos/rust-lang/edition-guide.toml
@@ -6,3 +6,8 @@ bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 project-edition-2024 = "maintain"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["Success gate"]
+required-approvals = 0


### PR DESCRIPTION
In https://github.com/rust-lang/edition-guide/pull/333 we are switching to merge queue, which includes a "consolidation" job.