### PR TITLE
Give try permissions to Fuchsia team

### DIFF
--- a/teams/fuchsia.toml
+++ b/teams/fuchsia.toml
@@ -12,3 +12,6 @@ alumni = [
     "ComputerDruid",
     "djkoloski",
 ]
+
+[permissions]
+bors.rust.try = true


### PR DESCRIPTION
This is so they can update the Fuchsia pin (e.g. https://github.com/rust-lang/rust/pull/132294, which is only practical because of my status as compiler team member). For the same reason this was done for the Rust for Linux team in #1512.

cc @erickt @P1n3appl3