### PR TITLE
Add madsmtm as maintainer of cc-rs

### DIFF
--- a/repos/rust-lang/cc-rs.toml
+++ b/repos/rust-lang/cc-rs.toml
@@ -9,6 +9,7 @@ crate-maintainers = 'maintain'
 
 [access.individuals]
 NobodyXu = 'write'
+madsmtm = 'write'
 
 [[branch-protections]]
 pattern = 'main'


### PR DESCRIPTION
@madsmtm  has been contributing to cc-rs for a while and is knowledgeable about compilation on macOS and rust compiler internals.

@madsmtm  has consented to become a maintainer of cc-rs, as the maintainer of cc-rs I believe Mads is capable of and well-fit to become maintainer of cc-rs