### PR TITLE
Create `relnotes-interest-group` ping group

### DIFF
--- a/teams/relnotes-interest-group.toml
+++ b/teams/relnotes-interest-group.toml
@@ -1,0 +1,14 @@
+# Intended to be a ping group on rust-lang/rust for release notes for people who
+# would like to be notified of new relnotes PR and want to double-check.
+
+name = "relnotes-interest-group"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "alex-semenyuk",
+    "jieyouxu",
+    "joshtriplett",
+    "traviscross",
+]


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/133334

This ping group is intended for contributors who would like to get pinged on release notes PRs (PR modifying `RELEASES.md` and the release blog post), intended to help double-check release notes. As @BoxyUwU [said](https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release/topic/Please.20CC.20lang/near/483592257):

> If we're going to do this I'd probably prefer having new ping group or something rather than pinging lang directly. This isn't really lang teams area so it's mostly just a "here are some people interested in knowing the release is happening" ping at which point why not do something that other people can use if they want to take an early look at the release posts

For more context, see https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release/topic/Please.20CC.20lang.

I don't know if this needs sign-off from anyone... Maybe T-release lead... so I guess

r? @Mark-Simulacrum