### PR TITLE
Add compiler-errors to project-const-generics

### DIFF
--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -11,6 +11,7 @@ members = [
     "oli-obk",
     "BoxyUwU",
     "camelid",
+    "compiler-errors",
 ]
 alumni = [
     "varkor",


### PR DESCRIPTION
Already spoke with lcnr and they agree'd with adding errs to the group :3 

@compiler-errors  has done a lot of work implementing and reviewing const generic PRs, and has also been invaluable to consult with about various decisions and parts of the compiler when working on const generics stuff :3 
