### PR TITLE
Define a team for Project Directors on the Foundation board

### DIFF
--- a/teams/foundation-board-project-directors.toml
+++ b/teams/foundation-board-project-directors.toml
@@ -1,4 +1,4 @@
-name = "project-directors"
+name = "foundation-board-project-directors"
 kind = "marker-team"
 
 [people]
@@ -15,7 +15,7 @@ alumni = [
 ]
 
 [website]
-name = "Project Directors"
+name = "Foundation Board Project Directors"
 description = "Charged with representing the project on the Board of the Rust Foundation"
 email = "project-directors@rust-lang.org"
 

--- a/teams/foundation-board-project-directors.toml
+++ b/teams/foundation-board-project-directors.toml
@@ -11,7 +11,10 @@ members = [
   "spastorino",
 ]
 alumni = [
+  "cuviper",
   "Mark-Simulacrum",
+  "tmandry",
+  "yaahc",
 ]
 
 [website]

--- a/teams/project-directors.toml
+++ b/teams/project-directors.toml
@@ -1,0 +1,22 @@
+name = "project-directors"
+
+[people]
+leads = []
+members = [
+  "carols10cents",
+  "JakobDegen",
+  "rylev",
+  "scottmcm",
+  "spastorino",
+]
+alumni = [
+  "Mark-Simulacrum",
+]
+
+[website]
+name = "Project Directors"
+description = "Charged with representing the project on the Board of the Rust Foundation"
+email = "project-directors@rust-lang.org"
+
+[[lists]]
+address = "project-directors@rust-lang.org"

--- a/teams/project-directors.toml
+++ b/teams/project-directors.toml
@@ -1,4 +1,5 @@
 name = "project-directors"
+kind = "marker-team"
 
 [people]
 leads = []


### PR DESCRIPTION
So that:

- Project Directors can post to Inside Rust as "on behalf of the Project Directors team"
- We can have an email address for people to contact all of us
- ~~We can be listed on rust-lang.org~~ I don't think this is true now that I've changed the team to be type marker-team

I've probably forgotten something that should be set in the toml or that needs to be done when adding a new team. Please let me know and I'm happy to fix! ❤️ 