### PR TITLE
Drop required approvals for Crater

### DIFF
--- a/repos/rust-lang/crater.toml
+++ b/repos/rust-lang/crater.toml
@@ -10,3 +10,4 @@ infra = "write"
 [[branch-protections]]
 pattern = "master"
 ci-checks = ["conclusion"]
+required-approvals = 0


### PR DESCRIPTION
This restores the previous state pre-merge-queues, where most PRs were self-approved via bors.