### PR TITLE
Add `rfcbot` to compiler-team repo

### DIFF
--- a/repos/rust-lang/compiler-team.toml
+++ b/repos/rust-lang/compiler-team.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "compiler-team"
 description = "A home for compiler team planning documents, meeting minutes, and other such things."
 homepage = "https://rust-lang.github.io/compiler-team/"
-bots = ["rustbot"]
+bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 compiler = "write"


### PR DESCRIPTION
Add `rfcbot` to the list of bots to the compiler-team reposiroty so that the bot can edit labels.

cf. https://www.github.com/rust-lang/compiler-team/issues/785#issuecomment-2544090585