### PR TITLE
Add branch protection to `glob`

### DIFF
--- a/repos/rust-lang/glob.toml
+++ b/repos/rust-lang/glob.toml
@@ -6,3 +6,8 @@ bots = []
 
 [access.teams]
 crate-maintainers = 'maintain'
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["success"]
+required-approvals = 0


### PR DESCRIPTION
CI now has a `success` job that we can protect on, which should make auto-merge possible.