### PR TITLE
Enable rustbot on the git2 repo

### DIFF
--- a/repos/rust-lang/git2-rs.toml
+++ b/repos/rust-lang/git2-rs.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "git2-rs"
 description = "libgit2 bindings for Rust"
 homepage = "https://docs.rs/git2"
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 cargo = "write"


### PR DESCRIPTION
I would like to enable this bot on the git2 repo.
