### PR TITLE
Add branch protection for the `master-old` branch in `rustc-dev-guide`

### DIFF
--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -16,3 +16,9 @@ libs-contributors = "write"
 pattern = "master"
 ci-checks = ["ci"]
 required-approvals = 0
+
+# This branch protection exists for historical reasons
+# We had to force-push the whole commit history of rustc-dev-guide
+# This branch contains the old commit graph, to keep commit references working
+[[branch-protections]]
+pattern = "master-old"


### PR DESCRIPTION
Needed because of the force-push of rustc-dev-guide (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Force-pushing.20to.20rustc-dev-guide).