### PR TITLE
Adopt the book team as a subteam of lang-docs

### DIFF
--- a/teams/book.toml
+++ b/teams/book.toml
@@ -1,5 +1,5 @@
 name = "book"
-subteam-of = "launching-pad"
+subteam-of = "lang-docs"
 
 [people]
 leads = ["carols10cents", "chriskrycho"]


### PR DESCRIPTION
We're working to move things out from under the launching-pad team to more appropriate places.  It makes the most sense for the book team to be adopted as a subteam of lang-docs, so let's do that.

See:

- https://github.com/rust-lang/leadership-council/issues/123

cc @ehuss @chriskrycho @carols10cents @jamesmunns
