### PR TITLE
Adopt rust-by-example as a subteam of lang-docs

### DIFF
--- a/repos/rust-lang/rust-by-example.toml
+++ b/repos/rust-lang/rust-by-example.toml
@@ -5,4 +5,4 @@ homepage = "https://doc.rust-lang.org/stable/rust-by-example/"
 bots = ["rustbot"]
 
 [access.teams]
-wg-rust-by-example = "write"
+rust-by-example = "write"

--- a/teams/rust-by-example.toml
+++ b/teams/rust-by-example.toml
@@ -1,6 +1,5 @@
-name = "wg-rust-by-example"
-subteam-of = "launching-pad"
-kind = "working-group"
+name = "rust-by-example"
+subteam-of = "lang-docs"
 
 [people]
 leads = ["marioidival"]
@@ -16,6 +15,6 @@ alumni = [
 orgs = ["rust-lang"]
 
 [website]
-name = "Rust by Example working group"
+name = "Rust by Example team"
 description = "Maintaining and updating the official Rust by Example book"
 repo = "https://github.com/rust-lang/rust-by-example"


### PR DESCRIPTION
We're working to move things out from under the launching-pad team to more appropriate places.  It makes the most sense for the rust-by-example working group to be adopted as a subteam of lang-docs, so let's do that.

Note that, in doing this, we'll make it a proper subteam rather than a working group.

See:

- https://github.com/rust-lang/leadership-council/issues/139

cc @ehuss @marioidival @jamesmunns
