### PR TITLE
Adopt wg-async as a subteam (WG) of lang

### DIFF
--- a/teams/wg-async.toml
+++ b/teams/wg-async.toml
@@ -1,5 +1,5 @@
 name = "wg-async"
-subteam-of = "launching-pad"
+subteam-of = "lang"
 kind = "working-group"
 
 [people]


### PR DESCRIPTION
We're working to move things out from under the launching-pad team to more appropriate places.  It makes the most sense for the async working group to be adopted as a subteam of lang, so let's do that.

Note that there are ongoing discussions of how we on lang might want to further refactor this working group.  This PR doesn't seek to resolve those.  It just puts the working group in our domain.  We can later adjust as we deem proper.

See:

- https://github.com/rust-lang/leadership-council/issues/137

cc @nikomatsakis @tmandry @eholk @yoshuawuyts @compiler-errors @jamesmunns
