### PR TITLE
Add a website page for the launching pad

### DIFF
--- a/teams/launching-pad.toml
+++ b/teams/launching-pad.toml
@@ -6,3 +6,9 @@ top-level = true
 leads = []
 members = []
 alumni = []
+
+[website]
+page = "launching-pad"
+name = "Launching pad"
+description = "An interim home for teams"
+zulip-stream = "t-launching-pad"


### PR DESCRIPTION
This adds a dedicated website page for the launching pad. See https://github.com/rust-lang/www.rust-lang.org/pull/2105 for more information.