### PR TITLE
Remove mentions of the bors-rs organization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,6 @@ allowed-mailing-lists-domains = [
 ]
 
 allowed-github-orgs = [
-    "bors-rs",
     "conduit-rust",
     "rust-lang",
     "rust-lang-ci",

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -32,10 +32,6 @@ alumni = [
 [[github]]
 orgs = ["rust-lang", "rust-lang-ci", "rust-lang-nursery"]
 
-[[github]]
-team-name = "rust-infra"
-orgs = ["bors-rs"]
-
 [permissions]
 perf = true
 crater = true


### PR DESCRIPTION
So that `sync-team` is not required to access it. It should be unused anyway.