### PR TITLE
Enable auto-merge feature on rustc_codegen_gcc repository

### DIFF
--- a/repos/rust-lang/rustc_codegen_gcc.toml
+++ b/repos/rust-lang/rustc_codegen_gcc.toml
@@ -6,3 +6,8 @@ bots = []
 [access.teams]
 compiler = "write"
 wg-gcc-backend = "maintain"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["success"]
+required-approvals = 0


### PR DESCRIPTION
As discussed on [zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Enable.20auto-merge.20PR.20for.20rustc_codegen_gcc). Hopefully this should be enough. :)

cc @tgross35 