### PR TITLE
Use the build job name instead of success in ci-checks for rustc_codegen_gcc

### DIFF
--- a/repos/rust-lang/rustc_codegen_gcc.toml
+++ b/repos/rust-lang/rustc_codegen_gcc.toml
@@ -9,5 +9,5 @@ wg-gcc-backend = "maintain"
 
 [[branch-protections]]
 pattern = "master"
-ci-checks = ["success"]
+ci-checks = ["success", "success_gcc12", "success_release", "success_failures", "success_m68k", "success_stdarch"]
 required-approvals = 0


### PR DESCRIPTION
The job name should be `build` and not `success`.