### PR TITLE
Add types-fcp team and remove exclusion list from types team

### DIFF
--- a/teams/types-fcp.toml
+++ b/teams/types-fcp.toml
@@ -1,0 +1,20 @@
+name = "types-fcp"
+subteam-of = "types"
+
+[people]
+leads = []
+members = [
+    "BoxyUwU",
+    "compiler-errors",
+    "jackh726",
+    "lcnr",
+    "nikomatsakis",
+    "oli-obk",
+    "spastorino",
+]
+alumni = []
+
+[rfcbot]
+label = "T-types"
+name = "Types"
+ping = "rust-lang/types-fcp"

--- a/teams/types.toml
+++ b/teams/types.toml
@@ -23,12 +23,6 @@ description = "Working to implement and formally define the semantics of the Rus
 repo = "https://github.com/rust-lang/types-team"
 zulip-stream = "t-types"
 
-[rfcbot]
-label = "T-types"
-name = "Types"
-ping = "rust-lang/types"
-exclude-members = ["aliemjay"]
-
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 


### PR DESCRIPTION
As discussed in today's T-types meeting. This mirrors the structure the compiler team uses.