### PR TITLE
Remove `conduit-rust` org from this repository

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,6 @@ allowed-mailing-lists-domains = [
 ]
 
 allowed-github-orgs = [
-    "conduit-rust",
     "rust-lang",
     "rust-lang-ci",
     "rust-lang-nursery",

--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -32,7 +32,7 @@ alumni = [
 crates-io-admin = true
 
 [[github]]
-orgs = ["rust-lang", "conduit-rust"]
+orgs = ["rust-lang"]
 
 [rfcbot]
 label = "T-crates-io"


### PR DESCRIPTION
The https://github.com/conduit-rust project has been deprecated.
We are removing the org from this repository to simplify some automations in sync-team.
For more details, see the [thread](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/sync-team.20dry.20run.20workflow/near/497647101) in zulip.