### PR TITLE
Remove unused cloud compute entries and add hkBst

### DIFF
--- a/people/hkBst.toml
+++ b/people/hkBst.toml
@@ -1,0 +1,5 @@
+name = "Marijn Schouten"
+github = "hkBst"
+github-id = 25009929
+email = "mhkbst@gmail.com"
+zulip-id = 878204

--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -7,18 +7,18 @@ leads = []
 # to true in its team toml file, then you do not need to be added to this list.
 # For example, T-compiler and T-infra both have `dev-desktop = true`
 members = [
-    "albertlarsan68",
     "asquared31415",
-    "Dajamante",
-    "jhpratt",
     "JoelMarcey",
     "nellshamrell",
-    "ouz-a",
     "Sp00ph",
     "yaahc",
-    "WaffleLapkin",
     "JulianKnodt",
     "vincenzopalazzo",
+    "hkBst",
+]
+
+alumni = [
+    "Dajamante",
 ]
 
 [permissions]


### PR DESCRIPTION
Eagerly adding @hkBst so once they need it they have access instead of needing to wait through another team PR cycle. This was discussed in the compiler team and had a few approvals and no disagreements. For context see https://github.com/rust-lang/rust/pull/136931#issuecomment-2658498224

The others are either already team members (@WaffleLapkin), or are not contributing anymore