### PR TITLE
Grant try and perf access to gsoc-contributors

### DIFF
--- a/teams/gsoc-contributors.toml
+++ b/teams/gsoc-contributors.toml
@@ -17,6 +17,8 @@ members = [
 
 [permissions]
 dev-desktop = true
+bors.rust.try = true
+perf = true
 
 [[zulip-groups]]
 name = "gsoc-contributors"


### PR DESCRIPTION
Contributors may potentially work on performance, or on other things
that benefit from try access. We trust gsoc-contributors to not abuse
this access.