### PR TITLE
Extend the triagebot team

### DIFF
--- a/teams/triagebot.toml
+++ b/teams/triagebot.toml
@@ -7,6 +7,8 @@ members = [
     "Mark-Simulacrum",
     "ehuss",
     "jackh726",
+    "apiraino",
+    "Kobzol"
 ]
 alumni = [
     "spastorino",


### PR DESCRIPTION
@apiraino has been making a lot of improvements to triagebot lately (not to mention that he is kind of a human form of a triagebot himself). I would like to help with reviewing his work, and also to improve triagebot mostly in the area of tests (https://github.com/rust-lang/triagebot/pull/1892).