### PR TITLE
Rust for Linux: remove Wedson

### DIFF
--- a/people/wedsonaf.toml
+++ b/people/wedsonaf.toml
@@ -1,3 +1,0 @@
-name = "Wedson Almeida Filho"
-github = "wedsonaf"
-github-id = 7494395

--- a/teams/rust-for-linux.toml
+++ b/teams/rust-for-linux.toml
@@ -15,7 +15,6 @@ members = [
     "ojeda",
     "tgross35",
     "vincenzopalazzo",
-    "wedsonaf",
     "y86-dev",
 ]
 


### PR DESCRIPTION
Wedson does not work on Rust for Linux anymore, thus remove him from the ping group.

Cc: @wedsonaf