### PR TITLE
Rust for Linux: add Danilo

### DIFF
--- a/people/dakr.toml
+++ b/people/dakr.toml
@@ -1,0 +1,4 @@
+name = "Danilo Krummrich"
+github = "dakr"
+github-id = 3908202
+email = "dakr@kernel.org"

--- a/teams/rust-for-linux.toml
+++ b/teams/rust-for-linux.toml
@@ -6,6 +6,7 @@ leads = []
 members = [
     "alex",
     "bjorn3",
+    "dakr",
     "Darksonn",
     "dingxiangfei2009",
     "fbq",


### PR DESCRIPTION
Danilo has recently joined the Rust for Linux core team, thus add him to the ping group.

Cc: @dakr