### PR TITLE
Archive the core team

### DIFF
--- a/repos/archive/rust-lang/core-team.toml
+++ b/repos/archive/rust-lang/core-team.toml
@@ -4,4 +4,3 @@ description = "A place to house minutes and other documents related to the core 
 bots = []
 
 [access.teams]
-core = "maintain"

--- a/teams/archive/core.toml
+++ b/teams/archive/core.toml
@@ -1,15 +1,9 @@
 # Core has been replaced by the leadership council with RFC#3392
-# While we untangle the remaining parts of infrastructure that are
-# tied to core, we'll leave the team here with just the members of
-# the council that were previously core team members.
 name = "core"
 
 [people]
 leads = []
-members = [
-    "Mark-Simulacrum",
-    "rylev",
-]
+members = []
 alumni = [
     "alexcrichton",
     "aturon",
@@ -29,6 +23,8 @@ alumni = [
     "sophiajt",
     "badboy",
     "wycats",
+    "Mark-Simulacrum",
+    "rylev",
 ]
 
 [[github]]


### PR DESCRIPTION
This archives the core team and the core-team repo.

I am not aware of any infrastructure still depending on this. If there is, it would be good to know so it can be resolved.

None of the mailing list aliases look like they are particularly important to keep around. I do not see `legal@crates.io` used anywere, and I assume Mark and Ryan have not been getting any significant email as of recently. If anyone really cares, I'm fine with moving them to council instead.
