### PR TITLE
Add repo for Rust-specific soft fork of Enzyme

### DIFF
--- a/repos/rust-lang/enzyme.toml
+++ b/repos/rust-lang/enzyme.toml
@@ -1,0 +1,22 @@
+org = "rust-lang"
+name = "enzyme"
+description = "Rust-specific fork of Enzyme."
+bots = []
+
+[access.teams]
+bootstrap = "maintain"
+compiler = "maintain"
+lang = "maintain"
+lang-ops = "maintain"
+libs = "maintain"
+libs-api = "maintain"
+release = "maintain"
+wg-llvm = "maintain"
+
+[[branch-protections]]
+pattern = "rustc/*"
+pr-required = false
+
+[[branch-protections]]
+pattern = "master"
+pr-required = false


### PR DESCRIPTION
Currently our submodule for Enzyme in `rust-lang/rust` points to an external repository outside of our organization.  As we do for LLVM, it would be useful for us to maintain a Rust-specific soft fork of Enzyme within `rust-lang/`.  Let's create a repository for this.

In particular, this would unblock some work being held up by CI issues on the upstream project, and it'd allow us to make some changes that might better facilitate upstreaming of this work into LLVM.

Probably we should also create a `wg-enzyme` or whatnot team that could maintain this.  Alternatively or in addition, we could formalize `wg-autodiff`, for which we have a Zulip stream but no entry here. But let's handle that separately.  For the moment, we just give access to the normal teams that would be likely to need to touch it, review PRs for it, manage issues on it, etc.

CC @oli-obk who seconded the compiler MCP for this work and is overseeing it on that side.

I'm the lang liaison for our approved experiment for this work.

CC @Mark-Simulacrum, @cuviper, @ehuss for thoughts on release and bootstrap and whatnot here.

CC @nikic on the LLVM aspect.

CC @ZuseZ4 who is the owner for this work (and for whom we should find a team at some point).

CC @wsmoses from upstream Enzyme with whom @ZuseZ4 talked this over.
