### PR TITLE
Add review permissions for rustfmt team members

### DIFF
--- a/teams/rustfmt.toml
+++ b/teams/rustfmt.toml
@@ -16,7 +16,7 @@ alumni = [
 [[github]]
 orgs = ["rust-lang"]
 
-[leads-permissions]
+[permissions]
 # Primarily for subtree syncs and other rustfmt-related review.
 bors.rust.review = true
 


### PR DESCRIPTION
These review permissions will only be used for rustfmt subtree syncs and the occasional in-tree rustfmt PR.