### PR TITLE
Set up mentorship team "properly"

### DIFF
--- a/teams/mentors.toml
+++ b/teams/mentors.toml
@@ -1,11 +1,9 @@
-name = "mentorship-programs"
-subteam-of = "launching-pad"
+name = "mentors"
+kind = "marker-team"
+subteam-of = "mentorship"
 
 [people]
-leads = [
-    "Kobzol",
-    "jackh726"
-]
+leads = []
 members = [
     "Kobzol",
     "jackh726",

--- a/teams/mentorship.toml
+++ b/teams/mentorship.toml
@@ -1,0 +1,29 @@
+name = "mentorship"
+subteam-of = "launching-pad"
+
+[people]
+leads = [
+    "Kobzol",
+    "jackh726"
+]
+members = [
+    "Kobzol",
+    "jackh726",
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]
+
+[rfcbot]
+label = "T-mentorship"
+name = "Mentorship"
+ping = "rust-lang/mentorship"
+
+[website]
+name = "Mentorship team"
+description = "Manages involvement of Rust in mentorship and internship programs"
+zulip-stream = "gsoc"
+
+[[zulip-groups]]
+name = "T-mentorship"


### PR DESCRIPTION
To facilitate getting out a blog post, we added the mentorship team (previously chartered under the name "internship team") under the name "mentorship-programs".  Let's now make some edits to set this up more "properly" (in my view, of course).

First, let's rename it to just "mentorship".  Probably I understand the hesitancy to claim such a broad mandate by calling it that rather than "mentorship-programs", but it just seems unlikely to me that we'd ever have both a "mentorship-programs" team and a "mentorship" team, so we should just use the shorter name.  (My guess is that if we ever wanted some other kind of mentorship, it's more likely that this team would expand its mandate than that we'd add a second team.)  If that really makes us uncomfortable, then probably I'd suggest going back to the "internship" name, as that is actually rather unambiguous here.

Second, as we discussed on the chartering thread, let's not include the mentors as members of the mentorship team and instead break that out into a separate marker team.  It's good for teams to have a clear charter and purpose for which the members are responsible.  If there really is a divide where the mentors aren't responsible for the work stated in the charter of organizing and administering this program, then the membership should be split out.  That is, we should ask, "who would be on an FCP for a given decision?"  Having such clarity, e.g., helps the council in cleanly delegating matters to teams, which we prefer doing, rather than having to specify a delegation to just the leads.

In this PR, that marker team is marked as a subteam of T-mentorship.  I don't see us doing this anywhere else in this repository -- making a marker team a subteam -- but neither do I see it documented as not working, and it seems appropriate in this case, so we'll see if it passes CI.

Third, let's set up all the other normal accoutrements of such a team, including a repository for the team's documents and website, a Zulip stream and group for the team itself, etc.

---

(It goes without saying, I hope, that this is simply a proposal for what would clean this up a bit, in my view -- in the spirit of avoiding organizational debt -- and seeking by this PR input from others.  I helped draft the charter, and I'm interested in how we set up teams generally in a consistent way as a council matter, but I'm not a member of this team or otherwise involved.)

cc @Kobzol @jackh726 (leads) @jamesmunns (council rep) @Mark-Simulacrum
