### PR TITLE
Add graydon to a `initial-designer` marker team

### DIFF
--- a/people/graydon.toml
+++ b/people/graydon.toml
@@ -1,0 +1,3 @@
+name = 'Graydon Hoare'
+github = 'graydon'
+github-id = 14097

--- a/teams/archive/initial-designer.toml
+++ b/teams/archive/initial-designer.toml
@@ -1,0 +1,9 @@
+name = "initial-designer"
+kind = "marker-team"
+
+[people]
+leads = []
+members = []
+alumni = [
+    "graydon",
+]


### PR DESCRIPTION
This commit adds graydon hoare to a dedicated `initial-designer` marker team alumni to give credit to their initial contributions

cc #319