### PR TITLE
Add TC to goals team

### DIFF
--- a/teams/goals.toml
+++ b/teams/goals.toml
@@ -9,6 +9,7 @@ members = [
     "lqd",
     "nandsh",
     "davidtwco",
+    "traviscross",
     "spastorino",
 ]
 alumni = [


### PR DESCRIPTION
We recently created the goals team.  Niko and I had talked, and we had meant for me to be on this.  Niko had put up an [edit](https://github.com/rust-lang/team/pull/1641#discussion_r1919042575) on the PR page to add me.  But apparently this didn't actually make it into a commit, and then we both missed it on review.  Anyway, this commit adds me to the goals team.

cc @nikomatsakis
