### PR TITLE
Remove chalk branch protection

### DIFF
--- a/repos/rust-lang/chalk.toml
+++ b/repos/rust-lang/chalk.toml
@@ -6,7 +6,3 @@ bots = ["rustbot"]
 
 [access.teams]
 types = "write"
-
-[[branch-protections]]
-pattern = "master"
-ci-checks = ["conclusion"]


### PR DESCRIPTION
This is the easiest way to allow the auto releases.