### PR TITLE
Add email alias for hiring

### DIFF
--- a/teams/hiring.toml
+++ b/teams/hiring.toml
@@ -1,0 +1,14 @@
+name = "hiring"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "JoelMarcey",
+    "ehuss",
+    "nikomatsakis",
+    "traviscross",
+]
+
+[[lists]]
+address = "hiring@rust-lang.org"


### PR DESCRIPTION
Sometimes we need to give people a place to email us about open positions.  Let's create a marker team for this.  The members of the marker team will be those people currently interested in seeing the resumes coming in the door.

This is related to:

- https://github.com/rust-lang/leadership-council/issues/161
- https://github.com/rust-lang/leadership-council/issues/151
