### PR TITLE
Move social-media to launching-pad

### DIFF
--- a/teams/social-media.toml
+++ b/teams/social-media.toml
@@ -1,5 +1,5 @@
 name = "social-media"
-subteam-of = "leadership-council"
+subteam-of = "launching-pad"
 
 [people]
 leads = ["m-ou-se"]


### PR DESCRIPTION
This moves the social-media team underneath the launching pad. This is done for a few reasons:

* Stay consistent with other communication and cross-team teams like website, twir, and edition.
* Remove the only direct subteam of the council.
* Prepare for (possibly) adding teams to the website governance.

cc @rust-lang/leadership-council 