### PR TITLE
Add explicit `--repo` argument in dry-run workflow

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -171,11 +171,11 @@ jobs:
 
           # --edit-last doesn't work if there is no previous comment, so we have to figure out
           # if we should create a comment or not
-          if gh issue view ${PR} --json comments \
+          if gh issue view ${PR} --repo rust-lang/team --json comments \
             --jq '.comments.[].author.login' | grep --quiet --fixed-strings "github-actions"; then
             echo "Editing comment"
-            gh pr comment ${PR} --body-file comment.txt --edit-last
+            gh pr comment ${PR} --repo rust-lang/team --body-file comment.txt --edit-last
           else
             echo "Creating new comment"
-            gh pr comment ${PR} --body-file comment.txt
+            gh pr comment ${PR} --repo rust-lang/team --body-file comment.txt
           fi


### PR DESCRIPTION
Because we don't checkout the source code of the `team` repo in the workflow, it tried to work with the `sync-team` repo instead.

I thought that this is only required on my fork, I didn't realize it's because of the missing checkout.