### PR TITLE
Fix concurrency group in dry-run

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -18,15 +18,14 @@ on:
     types:
       - completed
 
-concurrency:
-  # Only run this once at a time on any given PR
-  group: dry-run-${{ github.event.workflow_run.pull_requests[0].number }}
-  cancel-in-progress: true
-
 jobs:
   dry-run:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    concurrency:
+      # Only run this once at a time on any given PR
+      group: dry-run-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: true
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
The PR number is again unavailable on PRs from forks. We should also apply the concurrency group only to the job, not the whole workflow, so that it doesn't race with the workflow being executed from master.