### PR TITLE
Redirect stderr to file in dry-run workflow

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -135,7 +135,7 @@ jobs:
           # Perform build and execution separately to avoid any potential output from
           # cargo leaking into the output file.
           cargo build --release
-          ./target/release/sync-team print-plan --services github --team-json team-api > output.txt
+          ./target/release/sync-team print-plan --services github --team-json team-api 2> output.txt
 
       - name: Prepare comment
         run: |


### PR DESCRIPTION
sync-team outputs everything through logs to stderr.