### PR TITLE
Add `codegen-{cranelift,gcc}` marker teams for custom codegen backend ping groups

### DIFF
--- a/teams/codegen-cranelift.toml
+++ b/teams/codegen-cranelift.toml
@@ -1,0 +1,8 @@
+name = "codegen-cranelift"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "bjorn3",
+]

--- a/teams/codegen-gcc.toml
+++ b/teams/codegen-gcc.toml
@@ -1,0 +1,9 @@
+name = "codegen-gcc"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "antoyo",
+    "GuillaumeGomez",
+]


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/138116.
Discussion: [#t-infra > Triagebot ping groups for GCC and cranelift backends](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Triagebot.20ping.20groups.20for.20GCC.20and.20cranelift.20backends/with/503862444).
rust-lang/rust side triagebot configuration + docs: https://github.com/rust-lang/rust/pull/138120

cc @GuillaumeGomez @bjorn3 @antoyo