### PR TITLE
Also print sync-team output to CI logs

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -135,7 +135,7 @@ jobs:
           # Perform build and execution separately to avoid any potential output from
           # cargo leaking into the output file.
           cargo build --release
-          ./target/release/sync-team print-plan --services github --team-json team-api 2> output.txt
+          ./target/release/sync-team print-plan --services github --team-json team-api 2>&1 | tee -a output.txt
 
       - name: Prepare comment
         run: |


### PR DESCRIPTION
So that we can debug [errors](https://github.com/rust-lang/team/actions/runs/13705594955/job/38329976933).