### PR TITLE
Add infra-admins explicitly to sync-team

### DIFF
--- a/repos/rust-lang/sync-team.toml
+++ b/repos/rust-lang/sync-team.toml
@@ -5,6 +5,7 @@ bots = []
 
 [access.teams]
 infra = "write"
+infra-admins = "admin"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
We're encountering a weird situation in sync-team:
1) sync-team thinks that the allowed push actors of `sync-team` is empty
2) Therefore, it tries to set it to `infra-admins`, according to the configuration set in the [team](https://github.com/rust-lang/team/blob/master/repos/rust-lang/sync-team.toml#L12) repo. This succeeds.
3) However, on the next sync it still thinks it is empty. And in the GitHub UI, there is not an `infra-admins` team set in the allowed push actors, but it contains "organization admins".

![image](https://github.com/user-attachments/assets/992bf090-72d0-4339-b532-3566655b867d)

I'm not sure if sync-team is somehow configured specially for this (?). Maybe @Mark-Simulacrum or @pietroalbini will know.

This PR tries to explicitly add infra-admins as a team with admin permissions for the sync-team repo, to test if it will fix this issue.