### PR TITLE
Add validation for `allowed-merge-teams`

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -350,6 +350,8 @@ required-approvals = 1
 # Which GitHub teams have access to push/merge to this branch.
 # If unspecified, all teams/contributors with write or higher access
 # can push/merge to the branch.
+# Teams mentioned in this array must also have access to the repo
+# in [access.teams].
 # (optional)
 allowed-merge-teams = ["awesome-team"]
 # Determines the merge queue bot(s) that manage pushes to this branch.

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -840,6 +840,15 @@ but that team does not seem to exist"#,
                         team
                     );
                 }
+                if !repo.access.teams.contains_key(team) {
+                    bail!(
+                        r#"repo '{}' uses a branch protection for {} that has an allowed merge team '{}',
+but that team is not mentioned in [access.teams]"#,
+                        repo.name,
+                        protection.pattern,
+                        team
+                    );
+                }
             }
 
             if !protection.pr_required {


### PR DESCRIPTION
It seems that teams mentioned in this array have to also have explicit access to the repository, otherwise configuration of the allowed merge teams will not work in `sync-team`.