### PR TITLE
Add all teams to the website

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -119,7 +119,7 @@ ping = "rust-lang/cargo"
 # Team members to be excluded from FCPs
 exclude-members = ["some-team-member"]
 
-# Information about the team to display on the www.rust-lang.org website.
+# Information about the team to display on the www.rust-lang.org website (required except marker teams).
 [website]
 # The name of the team to display on the website (required).
 name = "Language team"

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -51,6 +51,7 @@ static CHECKS: &[Check<fn(&Data, &mut Vec<String>)>] = checks![
     validate_repos,
     validate_branch_protections,
     validate_member_roles,
+    validate_website,
 ];
 
 #[allow(clippy::type_complexity)]
@@ -1039,4 +1040,17 @@ where
             errors.push(err.to_string());
         }
     }
+}
+
+fn validate_website(data: &Data, errors: &mut Vec<String>) {
+    wrapper(data.teams(), errors, |team, _| {
+        match team.kind() {
+            TeamKind::MarkerTeam => return Ok(()),
+            TeamKind::Team | TeamKind::WorkingGroup | TeamKind::ProjectGroup => {}
+        };
+        if team.website_data().is_none() {
+            bail!("team `{}` should have a `[website]` table", team.name());
+        }
+        Ok(())
+    })
 }

--- a/teams/book.toml
+++ b/teams/book.toml
@@ -11,3 +11,8 @@ alumni = []
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Book team"
+description = "Maintains The Rust Programming Language book"
+repo = "https://github.com/rust-lang/book"

--- a/teams/codegen-c-maintainers.toml
+++ b/teams/codegen-c-maintainers.toml
@@ -11,3 +11,8 @@ alumni = []
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Codegen C Maintainers"
+description = "Developing the C based backend for rustc"
+repo = "https://github.com/rust-lang/rustc_codegen_c"

--- a/teams/community.toml
+++ b/teams/community.toml
@@ -79,3 +79,8 @@ extra-people = [
 [[discord-roles]]
 name = "community-team"
 color = "#c27c0e"
+
+[website]
+name = "Community team"
+description = "Engagement with the Rust community"
+repo = "https://github.com/rust-community/team"

--- a/teams/compiler-fcp.toml
+++ b/teams/compiler-fcp.toml
@@ -24,3 +24,9 @@ alumni = []
 label = "T-compiler"
 name = "Compiler"
 ping = "rust-lang/compiler-fcp"
+
+[website]
+name = "Compiler FCP team"
+description = "Compiler team members with responsibility for signing off on major compiler changes"
+repo = "http://github.com/rust-lang/compiler-team"
+zulip-stream = "t-compiler"

--- a/teams/docker.toml
+++ b/teams/docker.toml
@@ -11,3 +11,8 @@ alumni = []
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Docker team"
+description = "Maintains the official Docker images published to Docker Hub"
+repo = "https://github.com/rust-lang/docker-rust/"

--- a/teams/docs-rs-reviewers.toml
+++ b/teams/docs-rs-reviewers.toml
@@ -13,3 +13,9 @@ alumni = [
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Docs.rs reviewers"
+description = "Docs.rs team members responsible for reviews"
+repo = "https://github.com/rust-lang/docs.rs"
+zulip-stream = "t-docs-rs"

--- a/teams/infra-bors.toml
+++ b/teams/infra-bors.toml
@@ -12,3 +12,8 @@ alumni = []
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Bors team"
+description = "Develops the bors merge bot"
+repo = "https://github.com/rust-lang/bors"

--- a/teams/mentors.toml
+++ b/teams/mentors.toml
@@ -21,5 +21,5 @@ alumni = []
 name = "gsoc-mentors"
 
 [website]
-name = "Mentorship Programs"
-description = "Organizes involvement in internship programs such as Google Summer of Code"
+name = "Mentors team"
+description = "Mentors for the mentorship and internship programs"

--- a/teams/mentors.toml
+++ b/teams/mentors.toml
@@ -19,3 +19,7 @@ alumni = []
 
 [[zulip-groups]]
 name = "gsoc-mentors"
+
+[website]
+name = "Mentorship Programs"
+description = "Organizes involvement in internship programs such as Google Summer of Code"

--- a/teams/project-const-traits.toml
+++ b/teams/project-const-traits.toml
@@ -16,3 +16,9 @@ alumni = []
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Const Traits Project Group"
+description = "Project group working on const traits"
+repo = "https://github.com/rust-lang/project-const-traits"
+zulip-stream = "t-compiler/project-const-traits"

--- a/teams/release-publishers.toml
+++ b/teams/release-publishers.toml
@@ -15,3 +15,9 @@ alumni = []
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Release Publishers"
+description = "Release team members with permissions for crate publishing"
+repo = "https://github.com/rust-lang/release-team"
+zulip-stream = "t-release"

--- a/teams/rustlings.toml
+++ b/teams/rustlings.toml
@@ -11,3 +11,9 @@ alumni = []
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Rustlings team"
+description = "Maintains the Rustlings site"
+repo = "https://github.com/rust-lang/rustlings/"
+zulip-stream = "rustlings"

--- a/teams/social-media.toml
+++ b/teams/social-media.toml
@@ -8,3 +8,7 @@ alumni = []
 
 [[lists]]
 address = "social@rust-lang.org"
+
+[website]
+name = "Social media team"
+description = "Handles posting on social media sites"

--- a/teams/twir-reviewers.toml
+++ b/teams/twir-reviewers.toml
@@ -19,3 +19,8 @@ alumni = []
 [[github]]
 orgs = ["rust-lang"]
 team-name = "twir-reviewers"
+
+[website]
+name = "TWiR reviewers"
+description = "Reviewers for This Week in Rust"
+repo = "https://github.com/rust-lang/this-week-in-rust"

--- a/teams/twir.toml
+++ b/teams/twir.toml
@@ -20,3 +20,8 @@ orgs = ["rust-lang"]
 
 [[lists]]
 address = "twir@rust-lang.org"
+
+[website]
+name = "TWiR team"
+description = "Publishes This Week in Rust"
+repo = "https://github.com/rust-lang/this-week-in-rust"

--- a/teams/types-fcp.toml
+++ b/teams/types-fcp.toml
@@ -18,3 +18,9 @@ alumni = []
 label = "T-types"
 name = "Types"
 ping = "rust-lang/types-fcp"
+
+[website]
+name = "Types FCP team"
+description = "Types team members with responsibility for signing off on major compiler changes"
+repo = "https://github.com/rust-lang/types-team"
+zulip-stream = "t-types"

--- a/teams/web-presence.toml
+++ b/teams/web-presence.toml
@@ -18,3 +18,7 @@ extra-people = [
     "shepmaster",
     "pichfl",
 ]
+
+[website]
+name = "Web Presence team"
+description = "Manages the Rust websites"

--- a/teams/website.toml
+++ b/teams/website.toml
@@ -15,3 +15,8 @@ alumni = [
 
 [[github]]
 orgs = ["rust-lang"]
+
+[website]
+name = "Website team"
+description = "Manages the www.rust-lang.org website"
+repo = "https://github.com/rust-lang/www.rust-lang.org/"

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -90,7 +90,17 @@
     ],
     "alumni": [],
     "github": null,
-    "website_data": null,
+    "website_data": {
+      "name": "Leaderless",
+      "description": "Test",
+      "page": "leaderless",
+      "email": null,
+      "repo": null,
+      "discord": null,
+      "zulip_stream": null,
+      "matrix_room": null,
+      "weight": 0
+    },
     "roles": [],
     "discord": []
   },
@@ -101,7 +111,17 @@
     "members": [],
     "alumni": [],
     "github": null,
-    "website_data": null,
+    "website_data": {
+      "name": "Leadership council",
+      "description": "test",
+      "page": "leadership-council",
+      "email": null,
+      "repo": null,
+      "discord": null,
+      "zulip_stream": null,
+      "matrix_room": null,
+      "weight": 0
+    },
     "roles": [],
     "discord": []
   },
@@ -132,7 +152,17 @@
     ],
     "alumni": [],
     "github": null,
-    "website_data": null,
+    "website_data": {
+      "name": "Leads permissions",
+      "description": "Test",
+      "page": "leads-permissions",
+      "email": null,
+      "repo": null,
+      "discord": null,
+      "zulip_stream": null,
+      "matrix_room": null,
+      "weight": 0
+    },
     "roles": [],
     "discord": []
   },
@@ -166,7 +196,17 @@
       }
     ],
     "github": null,
-    "website_data": null,
+    "website_data": {
+      "name": "WG Test",
+      "description": "test",
+      "page": "wg-test",
+      "email": null,
+      "repo": null,
+      "discord": null,
+      "zulip_stream": null,
+      "matrix_room": null,
+      "weight": 0
+    },
     "roles": [
       {
         "id": "convener",

--- a/tests/static-api/_expected/v1/teams/leaderless.json
+++ b/tests/static-api/_expected/v1/teams/leaderless.json
@@ -13,7 +13,17 @@
   ],
   "alumni": [],
   "github": null,
-  "website_data": null,
+  "website_data": {
+    "name": "Leaderless",
+    "description": "Test",
+    "page": "leaderless",
+    "email": null,
+    "repo": null,
+    "discord": null,
+    "zulip_stream": null,
+    "matrix_room": null,
+    "weight": 0
+  },
   "roles": [],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/leadership-council.json
+++ b/tests/static-api/_expected/v1/teams/leadership-council.json
@@ -5,7 +5,17 @@
   "members": [],
   "alumni": [],
   "github": null,
-  "website_data": null,
+  "website_data": {
+    "name": "Leadership council",
+    "description": "test",
+    "page": "leadership-council",
+    "email": null,
+    "repo": null,
+    "discord": null,
+    "zulip_stream": null,
+    "matrix_room": null,
+    "weight": 0
+  },
   "roles": [],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/leads-permissions.json
+++ b/tests/static-api/_expected/v1/teams/leads-permissions.json
@@ -25,7 +25,17 @@
   ],
   "alumni": [],
   "github": null,
-  "website_data": null,
+  "website_data": {
+    "name": "Leads permissions",
+    "description": "Test",
+    "page": "leads-permissions",
+    "email": null,
+    "repo": null,
+    "discord": null,
+    "zulip_stream": null,
+    "matrix_room": null,
+    "weight": 0
+  },
   "roles": [],
   "discord": []
 }

--- a/tests/static-api/_expected/v1/teams/wg-test.json
+++ b/tests/static-api/_expected/v1/teams/wg-test.json
@@ -28,7 +28,17 @@
     }
   ],
   "github": null,
-  "website_data": null,
+  "website_data": {
+    "name": "WG Test",
+    "description": "test",
+    "page": "wg-test",
+    "email": null,
+    "repo": null,
+    "discord": null,
+    "zulip_stream": null,
+    "matrix_room": null,
+    "weight": 0
+  },
   "roles": [
     {
       "id": "convener",

--- a/tests/static-api/teams/leaderless.toml
+++ b/tests/static-api/teams/leaderless.toml
@@ -5,3 +5,7 @@ top-level = true
 leads = []
 members = ["user-0"]
 alumni = []
+
+[website]
+name = "Leaderless"
+description = "Test"

--- a/tests/static-api/teams/leadership-council.toml
+++ b/tests/static-api/teams/leadership-council.toml
@@ -4,3 +4,7 @@ name = "leadership-council"
 leads = []
 members = []
 alumni = []
+
+[website]
+name = "Leadership council"
+description = "test"

--- a/tests/static-api/teams/leads-permissions.toml
+++ b/tests/static-api/teams/leads-permissions.toml
@@ -8,3 +8,7 @@ alumni = []
 
 [leads-permissions]
 bors.crates-io.review = true
+
+[website]
+name = "Leads permissions"
+description = "Test"

--- a/tests/static-api/teams/wg-test.toml
+++ b/tests/static-api/teams/wg-test.toml
@@ -12,3 +12,7 @@ alumni = ["user-0", "user-5"]
 [[roles]]
 id = "convener"
 description = "Convener"
+
+[website]
+name = "WG Test"
+description = "test"


### PR DESCRIPTION
This updates all teams that do not have website entries to add them.

This also requires that new teams to be included on the website.

The intention here is to help make sure information about Rust's governance is available and publicly transparent.

cc @rust-lang/leadership-council This affects almost all of you via subteams you represent.
