### PR TITLE
Project team for the Rust Vision Doc 2025 effort

### DIFF
--- a/people/baumanj.toml
+++ b/people/baumanj.toml
@@ -1,0 +1,4 @@
+name = "Jon Bauman"
+github = "baumanj"
+github-id = 5906042
+zulip-id = 726131

--- a/people/baumanj.toml
+++ b/people/baumanj.toml
@@ -2,3 +2,4 @@ name = "Jon Bauman"
 github = "baumanj"
 github-id = 5906042
 zulip-id = 726131
+email = "jonbauman@rustfoundation.org"

--- a/people/ernestkissiedu.toml
+++ b/people/ernestkissiedu.toml
@@ -1,0 +1,4 @@
+name = "Ernest Kissiedu "
+github = "ernestkissiedu"
+github-id = 31829361
+zulip-id = 395791

--- a/people/ernestkissiedu.toml
+++ b/people/ernestkissiedu.toml
@@ -2,3 +2,4 @@ name = "Ernest Kissiedu"
 github = "ernestkissiedu"
 github-id = 31829361
 zulip-id = 395791
+email = "ernestkissiedu@rustfoundation.org"

--- a/people/ernestkissiedu.toml
+++ b/people/ernestkissiedu.toml
@@ -1,4 +1,4 @@
-name = "Ernest Kissiedu "
+name = "Ernest Kissiedu"
 github = "ernestkissiedu"
 github-id = 31829361
 zulip-id = 395791

--- a/people/timClicks.toml
+++ b/people/timClicks.toml
@@ -1,0 +1,3 @@
+name = "Tim McNamara"
+github = "timClicks"
+github-id = 27889

--- a/people/timClicks.toml
+++ b/people/timClicks.toml
@@ -1,3 +1,4 @@
 name = "Tim McNamara"
 github = "timClicks"
 github-id = 27889
+email = "tim@accelerant.dev"

--- a/repos/rust-lang/project-vision-doc.toml
+++ b/repos/rust-lang/project-vision-doc.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "project-vision-doc"
+description = "Project Vision Doc"
+homepage = "https://rust-lang.github.io/project-vision-doc/"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+project-vision-doc-2025 = "maintain"

--- a/teams/project-vision-doc-2025.toml
+++ b/teams/project-vision-doc-2025.toml
@@ -1,0 +1,25 @@
+name = "project-vision-doc-2025"
+kind = "project-group"
+subteam-of = "leadership-council"
+
+[people]
+leads = ["nikomatsakis", "jackh726"]
+members = [
+    "nikomatsakis",
+    "jackh726",
+    "Nadrieril",
+    "ernestkissiedu",
+    "baumanj",
+]
+alumni = [
+]
+
+[[github]]
+team-name = "project-vision-doc-2025"
+orgs = ["rust-lang"]
+
+[website]
+name = "Vision doc"
+description = "Authoring the Rust 2025 Vision doc"
+zulip-stream = "vision-doc-2025"
+repo = "https://github.com/rust-lang/vision-doc-2025"

--- a/teams/project-vision-doc-2025.toml
+++ b/teams/project-vision-doc-2025.toml
@@ -10,6 +10,10 @@ members = [
     "Nadrieril",
     "ernestkissiedu",
     "baumanj",
+    "spastorino",
+    "joshtriplett",
+    "workingjubilee",
+    "timClicks",
 ]
 alumni = [
 ]

--- a/teams/project-vision-doc-2025.toml
+++ b/teams/project-vision-doc-2025.toml
@@ -28,3 +28,6 @@ name = "Vision doc"
 description = "Authoring the Rust 2025 Vision doc"
 zulip-stream = "vision-doc-2025"
 repo = "https://github.com/rust-lang/vision-doc-2025"
+
+[[lists]]
+address = "project-vision-doc-2025@rust-lang.org"

--- a/teams/project-vision-doc-2025.toml
+++ b/teams/project-vision-doc-2025.toml
@@ -1,6 +1,6 @@
 name = "project-vision-doc-2025"
 kind = "project-group"
-subteam-of = "leadership-council"
+subteam-of = "launching-pad"
 
 [people]
 leads = ["nikomatsakis", "jackh726"]

--- a/teams/project-vision-doc-2025.toml
+++ b/teams/project-vision-doc-2025.toml
@@ -14,6 +14,7 @@ members = [
     "joshtriplett",
     "workingjubilee",
     "timClicks",
+    "traviscross",
 ]
 alumni = [
 ]


### PR DESCRIPTION
[Context](https://rust-lang.zulipchat.com/#narrow/channel/486265-vision-doc-2025/topic/vision.20doc.20plan/near/505781528); [this hackmd contains charter, expectations, and other info](https://hackmd.io/@rust-vision-doc/SyfqOGGhye).

cc @jackh726 

### Charter

To author the Rust 2025 Vision RFC. See the [Project Goal](https://rust-lang.github.io/rust-project-goals/2025h1/rust-vision-doc.html) for more details.

### Membership plan

Initial leads, charged with generally running the group and determining members and membership expectations.

* nikomatsakis
* jackh726

### Expectations of membership

The expectation of a team member is that you will be an active participant in gathering and analyzing data. This means that you'll setup and drive at least 2 or 3 interviews and discussions during April -- can of course be way more! There are no pre-defined focus areas, it's up to you to identify the kinds of things you want to focus on.

Time expectation: 2-3h/wk

* Identify at least 2 or 3 interviews you would like to lead
    * Attend others as shadow interviewer
* Conduct interviews in alignment with our guidelines
* Attend regular sync meetings to discuss
* Actively paticipate in editoral discussions
