### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# This is an automatically generated file
+# Run `cargo run ci generate-codeowners` to regenerate it.
+
+/.github/ @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/src/ @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/rust_team_data/ @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/repos/rust-lang/team.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/repos/rust-lang/sync-team.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/teams/infra-admins.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/teams/team-repo-admins.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+.cargo @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+target @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+Cargo.lock @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+Cargo.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+config.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/Mark-Simulacrum.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/pietroalbini.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/jdno.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/marcoieni.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
+      - name: Check CODEOWNERS
+        run: cargo run ci check-codeowners
+
       - name: Build the contents of the static API
         run: |
           cargo run -- static-api build

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -1,0 +1,77 @@
+use crate::schema::Team;
+use anyhow::Context;
+use std::path::{Path, PathBuf};
+
+/// Generates the contents of `.github/CODEOWNERS`, based on
+/// the infra admins in `infra-admins.toml`.
+pub fn generate_codeowners_file() -> anyhow::Result<()> {
+    let admins = load_infra_admins()?;
+    let codeowners_content = generate_codeowners_content(admins);
+    std::fs::write(codeowners_path(), codeowners_content).context("cannot write CODEOWNERS")?;
+    Ok(())
+}
+
+fn generate_codeowners_content(admins: Vec<String>) -> String {
+    use std::fmt::Write;
+
+    let mut output = String::new();
+    writeln!(
+        output,
+        r#"# This is an automatically generated file
+# Run `cargo run ci generate-codeowners` to regenerate it.
+"#
+    )
+    .unwrap();
+
+    let admin_list = admins
+        .iter()
+        .map(|admin| format!("@{admin}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    // Set of paths that should only be modifiable by infra-admins
+    let mut secure_paths = vec![
+        "/.github/".to_string(),
+        "/src/".to_string(),
+        "/rust_team_data/".to_string(),
+        "/repos/rust-lang/team.toml".to_string(),
+        "/repos/rust-lang/sync-team.toml".to_string(),
+        "/teams/infra-admins.toml".to_string(),
+        "/teams/team-repo-admins.toml".to_string(),
+        ".cargo".to_string(),
+        "target".to_string(),
+        "Cargo.lock".to_string(),
+        "Cargo.toml".to_string(),
+        "config.toml".to_string(),
+    ];
+    for admin in admins {
+        secure_paths.push(format!("/people/{admin}.toml"));
+    }
+
+    for path in secure_paths {
+        writeln!(output, "{path} {admin_list}").unwrap();
+    }
+    output
+}
+
+fn codeowners_path() -> PathBuf {
+    Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join(".github")
+        .join("CODEOWNERS")
+}
+
+fn load_infra_admins() -> anyhow::Result<Vec<String>> {
+    let admins = std::fs::read_to_string(
+        Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("teams")
+            .join("infra-admins.toml"),
+    )
+    .context("cannot load infra-admins.toml")?;
+    let team: Team = toml::from_str(&admins).context("cannot deserialize infra-admins")?;
+    Ok(team
+        .raw_people()
+        .members
+        .iter()
+        .map(|member| member.github.clone())
+        .collect())
+}

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -11,6 +11,20 @@ pub fn generate_codeowners_file() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Check if `.github/CODEOWNERS` are up-to-date, based on the
+/// `infra-admins.toml` file.
+pub fn check_codeowners() -> anyhow::Result<()> {
+    let admins = load_infra_admins()?;
+    let expected_codeowners = generate_codeowners_content(admins);
+    let actual_codeowners =
+        std::fs::read_to_string(codeowners_path()).context("cannot read CODEOWNERS")?;
+    if expected_codeowners != actual_codeowners {
+        return Err(anyhow::anyhow!("CODEOWNERS content is not up-to-date. Regenerate it using `cargo run ci generate-codeowners`."));
+    }
+
+    Ok(())
+}
+
 fn generate_codeowners_content(admins: Vec<String>) -> String {
     use std::fmt::Write;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod data;
 #[macro_use]
 mod permissions;
+mod ci;
 mod github;
 mod schema;
 mod static_api;
@@ -15,6 +16,7 @@ use data::Data;
 use schema::{Email, Team, TeamKind};
 use zulip::ZulipApi;
 
+use crate::ci::generate_codeowners_file;
 use crate::schema::RepoPermission;
 use anyhow::{bail, format_err, Error};
 use log::{error, info, warn};
@@ -111,6 +113,14 @@ enum Cli {
     EncryptEmail,
     #[structopt(name = "decrypt-email", help = "decrypt an email address")]
     DecryptEmail,
+    #[structopt(name = "ci", help = "CI scripts")]
+    Ci(CiOpts),
+}
+
+#[derive(structopt::StructOpt)]
+enum CiOpts {
+    #[structopt(help = "Generate the .github/CODEOWNERS file")]
+    GenerateCodeowners,
 }
 
 fn main() {
@@ -422,6 +432,9 @@ fn run() -> Result<(), Error> {
                 rust_team_data::email_encryption::try_decrypt(&key, &encrypted)?
             );
         }
+        Cli::Ci(opts) => match opts {
+            CiOpts::GenerateCodeowners => generate_codeowners_file()?,
+        },
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use data::Data;
 use schema::{Email, Team, TeamKind};
 use zulip::ZulipApi;
 
-use crate::ci::generate_codeowners_file;
+use crate::ci::{check_codeowners, generate_codeowners_file};
 use crate::schema::RepoPermission;
 use anyhow::{bail, format_err, Error};
 use log::{error, info, warn};
@@ -121,6 +121,8 @@ enum Cli {
 enum CiOpts {
     #[structopt(help = "Generate the .github/CODEOWNERS file")]
     GenerateCodeowners,
+    #[structopt(help = "Check if the .github/CODEOWNERS file is up-to-date")]
+    CheckCodeowners,
 }
 
 fn main() {
@@ -434,6 +436,7 @@ fn run() -> Result<(), Error> {
         }
         Cli::Ci(opts) => match opts {
             CiOpts::GenerateCodeowners => generate_codeowners_file()?,
+            CiOpts::CheckCodeowners => check_codeowners()?,
         },
     }
 


### PR DESCRIPTION
This PR contains the first step towards merging the `team` and `sync-team` repositories. It adds a `.github/CODEOWNERS` file that checks that changes to secure files and directories have to be approved by the `infra-admins` team.

Instead of hardcoding the contents of the file, I created a command that generates the file dynamically, and another command that checks that the file is up-to-date. The contents are generated based on the contents of `infra-admins.toml`. Currently, the `CODEOWNERS` file expands the names of infra-admins, an alternative is to use the `@rust-lang/infra-admins` team instead. I'm not sure which approach is more secure/better.

This PR doesn't really change the behavior of this repo in any way. As a follow-up, we should modify the branch protection of this repository to require an approval from codeowners for the files specified in `CODEOWNERS`, to require infra-admins approval when code or CI is being changed.