### PR TITLE
Move docker team to infra

### DIFF
--- a/teams/docker.toml
+++ b/teams/docker.toml
@@ -1,8 +1,8 @@
 name = "docker"
-subteam-of = "launching-pad"
+subteam-of = "infra"
 
 [people]
-leads = []
+leads = ["Muscraft"]
 members = [
     "sfackler",
     "Muscraft",


### PR DESCRIPTION
This enacts the consensus I think we reached in https://github.com/rust-lang/leadership-council/issues/124. It moves the docker team to infra, and makes @Muscraft the lead.

cc @rust-lang/infra @rust-lang/docker @rust-lang/leadership-council 

Closes https://github.com/rust-lang/leadership-council/issues/124