### PR TITLE
Rotate eholk out of Leadership Council and rotate cuviper in

### DIFF
--- a/teams/leadership-council.toml
+++ b/teams/leadership-council.toml
@@ -3,7 +3,7 @@ name = "leadership-council"
 [people]
 leads = []
 members = [
-    { github = "eholk", roles = ["council-rep-compiler"] },
+    { github = "cuviper", roles = ["council-rep-compiler"] },
     { github = "ehuss", roles = ["council-rep-devtools"] },
     { github = "traviscross", roles = ["council-rep-lang"] },
     { github = "jamesmunns", roles = ["council-rep-launching-pad"] },

--- a/teams/leadership-council.toml
+++ b/teams/leadership-council.toml
@@ -11,7 +11,7 @@ members = [
     { github = "m-ou-se", roles = ["council-rep-libs"] },
     { github = "oli-obk", roles = ["council-rep-mods"] },
 ]
-alumni = ["khionu", "rylev", "carols10cents", "jonathanpallant", "jackh726", "technetos"]
+alumni = ["khionu", "rylev", "carols10cents", "jonathanpallant", "jackh726", "technetos", "eholk"]
 
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]


### PR DESCRIPTION
I am leaving the Leadership Council and @cuviper is taking my place as the Compiler Team representative. This PR makes that official in the team repo.