### PR TITLE
Make T-rustdoc{,-frontend} members have write access to rustc-dev-guide

### DIFF
--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -7,7 +7,6 @@ bots = ["rustbot"]
 [access.teams]
 bootstrap = "write"
 compiler = "write"
-wg-rustc-dev-guide = "maintain"
 edition = "write"
 infra = "write"
 lang = "write"
@@ -15,6 +14,9 @@ lang-ops = "write"
 libs = "write"
 libs-api = "write"
 libs-contributors = "write"
+rustdoc = "write"
+rustdoc-frontend = "write"
+wg-rustc-dev-guide = "maintain"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
There's quite a bit of rustdoc docs that also live inside rustc-dev-guide, and T-rustdoc{,-frontend} maintainers really ought to be able to make changes / approve changes to them.

cc @rust-lang/rustdoc
r? @JohnTitor @spastorino 