### PR TITLE
give the `mods` team write access to `team` repo

### DIFF
--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -4,7 +4,7 @@ description = "Rust teams structure"
 bots = []
 
 [access.teams]
-mods = "maintain"
+mods = "write"
 team-repo-admins = "write"
 infra = "triage"
 


### PR DESCRIPTION
Hey @rust-lang/mods, I was wondering if `write` permission is sufficient for this repository, or whether you need `maintain` for certain settings.

I'm asking because this repo will soon run [sync-team](https://github.com/rust-lang/sync-team) in CI, so we are making sure everyone has the least permissions as possible to mitigate the risk of account compromised and similar issues 👍
