### PR TITLE
Add literal-escaper repository permissions

### DIFF
--- a/repos/rust-lang/literal-escaper.toml
+++ b/repos/rust-lang/literal-escaper.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "literal-escaper"
+description = "Provides code to unescape string literals. It is used by rustc_lexer and proc_macro."
+bots = []
+
+[access.teams]
+compiler = "write"


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/136355 which was reverted in https://github.com/rust-lang/rust/pull/138661 because the rustc-dev component needs it.

As discussed on [zulip](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Sharing.20the.20literal-escaper.20crate/with/506941204), the best solution seems to be to make it published on crates.io.

r? @davidtwco 