### PR TITLE
add zoxc to wg-compiler-performance

### DIFF
--- a/teams/wg-compiler-performance.toml
+++ b/teams/wg-compiler-performance.toml
@@ -11,6 +11,7 @@ members = [
     "Kobzol",
     "lqd",
     "nnethercote",
+    "Zoxc",
 ]
 alumni = [
     "michaelwoerister",


### PR DESCRIPTION
@Zoxc has been doing a lot of great work on compiler performance recently. And this will also help them continue to do that more easily with access to `try`, the perfbot, and the >= 32 cores dev desktop machines.

r? @Mark-Simulacrum 