### PR TITLE
Use local `sync-team` code for performing dry runs

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -31,7 +31,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: rust-lang/sync-team
+          # Always checkout the master branch to avoid checking out
+          # code of untrusted PRs.
+          # This might break the dry-run if code or schema modifications
+          # are performed, we can selectively allow that in the future
+          # e.g. if the author of the PR is trusted.
+          ref: 'master'
           persist-credentials: false
 
       - name: Install Rust Stable
@@ -136,8 +141,10 @@ jobs:
         run: |
           # Perform build and execution separately to avoid any potential output from
           # cargo leaking into the output file.
-          cargo build --release
-          ./target/release/sync-team print-plan --services github --team-json team-api 2>&1 | tee -a output.txt
+          cargo build --manifest-path sync-team/Cargo.toml --release
+          ./sync-team/target/release/sync-team print-plan \
+            --services github \
+            --team-json team-api 2>&1 | tee -a output.txt
 
       - name: Prepare comment
         run: |

--- a/sync-team/Cargo.toml
+++ b/sync-team/Cargo.toml
@@ -22,3 +22,5 @@ secrecy = "0.10"
 indexmap = "2.6.0"
 derive_builder = "0.20.2"
 insta = "1.40.0"
+
+[workspace]

--- a/sync-team/Cargo.toml
+++ b/sync-team/Cargo.toml
@@ -9,7 +9,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12.8", features = ["blocking", "json", "rustls-tls", "charset", "http2", "macos-system-configuration"], default-features = false }
 log = "0.4"
 env_logger = "0.11"
-rust_team_data = { git = "https://github.com/rust-lang/team", features = ["email-encryption"] }
+rust_team_data = { path = "../rust_team_data", features = ["email-encryption"] }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 base64 = "0.22"


### PR DESCRIPTION
First incremental step towards merging the code.