### PR TITLE
Switch to merge queues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
     concurrency: deploy
     permissions:
       id-token: write
+      pages: write
     if: github.event_name == 'merge_group'
     steps:
       - name: Download built JSON API and sync-team
@@ -69,13 +70,17 @@ jobs:
         with:
           name: team-api-output
           path: build
+
+      - name: Disable Jekyll
+        run: touch build/.nojekyll
+
+      - name: Upload GitHub pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
       - name: Deploy to GitHub Pages
-        run: |
-          touch build/.nojekyll
-          curl -LsSf https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs | rustc - -o /tmp/deploy
-          (cd build && /tmp/deploy)
-        env:
-          GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
+        uses: actions/deploy-pages@v4
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -100,7 +105,7 @@ jobs:
 
   # Summary job for the merge queue.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
-  conclusion:
+  CI:
     needs: [ test, deploy ]
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [ push, pull_request ]
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   ci:
@@ -61,24 +63,23 @@ jobs:
         run: touch build/.nojekyll
 
       - name: Upload GitHub pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v3
         with:
           path: build
 
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'merge_group'
         uses: actions/deploy-pages@v4
 
       - name: Configure AWS credentials
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'merge_group'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--team
           aws-region: us-west-1
 
       - name: Start the synchronization tool
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'merge_group'
         run: |
           # Introduce some artificial delay to help github pages propagate.
           sleep 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,7 @@ jobs:
       id-token: write
       pages: write
     steps:
-
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,10 @@ on:
   merge_group:
 
 jobs:
-  ci:
-    name: CI
+  test:
+    name: Test
     runs-on: ubuntu-latest
     if: github.repository == 'rust-lang/team'
-    permissions:
-      id-token: write
-      pages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,23 +50,32 @@ jobs:
         run: echo "${{ github.event.pull_request.number }}" > build/pr.txt
 
       - name: Upload the built JSON as a GitHub artifact
-        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: team-api-output
           path: build
-
-      - name: Disable Jekyll
-        run: touch build/.nojekyll
-
-      - name: Upload GitHub pages artifact
-        uses: actions/upload-pages-artifact@v3
+  deploy:
+    name: Deploy
+    needs: [ test ]
+    runs-on: ubuntu-latest
+    environment: deploy
+    concurrency: deploy
+    permissions:
+      id-token: write
+    if: github.event_name == 'merge_group'
+    steps:
+      - name: Download built JSON API
+        uses: actions/download-artifact@v4
         with:
+          name: team-api-output
           path: build
-
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'merge_group'
-        uses: actions/deploy-pages@v4
+        run: |
+          touch build/.nojekyll
+          curl -LsSf https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs | rustc - -o /tmp/deploy
+          (cd build && /tmp/deploy)
+        env:
+          GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
 
       - name: Configure AWS credentials
         if: github.event_name == 'merge_group'
@@ -85,3 +91,22 @@ jobs:
           sleep 60
           aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
           cat output.json | python3 -m json.tool
+
+  # Summary job for the merge queue.
+  # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+  conclusion:
+    needs: [ test, deploy ]
+    # We need to ensure this job does *not* get skipped if its dependencies fail,
+    # because a skipped job is considered a success by GitHub. So we have to
+    # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run
+    # when the workflow is canceled manually.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      # Manually check the status of all dependencies. `if: failure()` does not work.
+      - name: Conclusion
+        run: |
+          # Print the dependent jobs to see them in the CI log
+          jq -C <<< '${{ toJson(needs) }}'
+          # Check if all jobs that we depend on (in the needs array) were successful.
+          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,13 +95,90 @@ jobs:
           aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
           cat output.json | python3 -m json.tool
 
+      # GitHub tokens generated from GitHub Apps can access resources from one organization,
+      # so we need to generate a token for each organization.
+      - name: Generate GitHub token (rust-lang)
+        uses: actions/create-github-app-token@v1
+        id: rust-lang-token
+        with:
+          # GitHub App ID secret name
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          # GitHub App private key secret name
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          # Set the owner, so the token can be used in all repositories
+          owner: rust-lang
+
+      - name: Generate GitHub token (rust-lang-ci)
+        uses: actions/create-github-app-token@v1
+        id: rust-lang-ci-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          owner: rust-lang-ci
+
+      - name: Generate GitHub token (rust-lang-deprecated)
+        uses: actions/create-github-app-token@v1
+        id: rust-lang-deprecated-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          owner: rust-lang-deprecated
+
+      - name: Generate GitHub token (rust-lang-nursery)
+        uses: actions/create-github-app-token@v1
+        id: rust-lang-nursery-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          owner: rust-lang-nursery
+
+      - name: Generate GitHub token (bors-rs)
+        uses: actions/create-github-app-token@v1
+        id: bors-rs-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          owner: bors-rs
+
+      - name: Generate GitHub token (rust-analyzer)
+        uses: actions/create-github-app-token@v1
+        id: rust-analyzer-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          owner: rust-analyzer
+
+      - name: Generate GitHub token (rust-embedded)
+        uses: actions/create-github-app-token@v1
+        id: rust-embedded-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          owner: rust-embedded
+
+      - name: Generate GitHub token (rust-dev-tools)
+        uses: actions/create-github-app-token@v1
+        id: rust-dev-tools-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_READ_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_READ_PRIVATE_KEY }}
+          owner: rust-dev-tools
+
       - uses: actions/checkout@v4
 
-      - name: Run sync-team dry-run
+      - name: Run sync-team (dry-run)
+        env:
+          GITHUB_TOKEN_RUST_LANG: ${{ steps.rust-lang-token.outputs.token }}
+          GITHUB_TOKEN_RUST_LANG_CI: ${{ steps.rust-lang-ci-token.outputs.token }}
+          GITHUB_TOKEN_RUST_LANG_DEPRECATED: ${{ steps.rust-lang-deprecated-token.outputs.token }}
+          GITHUB_TOKEN_RUST_LANG_NURSERY: ${{ steps.rust-lang-nursery-token.outputs.token }}
+          GITHUB_TOKEN_BORS_RS: ${{ steps.bors-rs-token.outputs.token }}
+          GITHUB_TOKEN_RUST_ANALYZER: ${{ steps.rust-analyzer-token.outputs.token }}
+          GITHUB_TOKEN_RUST_EMBEDDED: ${{ steps.rust-embedded-token.outputs.token }}
+          GITHUB_TOKEN_RUST_DEV_TOOLS: ${{ steps.rust-dev-tools-token.outputs.token }}
         run: |
           cargo run --manifest-path sync-team/Cargo.toml \
-            print-plan \
-            --team-json build
+            print-plan --team-json build
 
   # Summary job for the merge queue.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       id-token: write
     if: github.event_name == 'merge_group'
     steps:
-      - name: Download built JSON API
+      - name: Download built JSON API and sync-team
         uses: actions/download-artifact@v4
         with:
           name: team-api-output
@@ -78,19 +78,25 @@ jobs:
           GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
 
       - name: Configure AWS credentials
-        if: github.event_name == 'merge_group'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--team
           aws-region: us-west-1
 
       - name: Start the synchronization tool
-        if: github.event_name == 'merge_group'
         run: |
           # Introduce some artificial delay to help github pages propagate.
           sleep 60
           aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
           cat output.json | python3 -m json.tool
+
+      - uses: actions/checkout@v4
+
+      - name: Run sync-team dry-run
+        run: |
+          cargo run --manifest-path sync-team/Cargo.toml \
+            print-plan \
+            --team-json build
 
   # Summary job for the merge queue.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           rustup default stable
           rustc -vV
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 
       - name: Build the validation tool
         run: cargo build


### PR DESCRIPTION
Once we start deploying sync-team from this repo, we really should be using merge queues (ideally configured in a way where they never test more than one PR at the same time). This PR switches to merge queues, and also starts preparing some CI hardening that will be required for the GitHub deploys.