### PR TITLE
Remove individual bors permissions

### DIFF
--- a/people/apasel422.toml
+++ b/people/apasel422.toml
@@ -1,6 +1,3 @@
 name = "Andrew Paseltiner"
 github = "apasel422"
 github-id = 8644784
-
-[permissions]
-bors.rust.review = true

--- a/people/apasel422.toml
+++ b/people/apasel422.toml
@@ -1,3 +1,0 @@
-name = "Andrew Paseltiner"
-github = "apasel422"
-github-id = 8644784

--- a/people/arielb1.toml
+++ b/people/arielb1.toml
@@ -3,6 +3,3 @@ github = "arielb1"
 github-id = 1830974
 zulip-id = 126804
 email = "ariel.byd@gmail.com"
-
-[permissions]
-bors.rust.review = true

--- a/people/bluss.toml
+++ b/people/bluss.toml
@@ -1,6 +1,3 @@
 name = "bluss"
 github = "bluss"
 github-id = 3209739
-
-[permissions]
-bors.rust.review = true

--- a/people/bluss.toml
+++ b/people/bluss.toml
@@ -1,3 +1,0 @@
-name = "bluss"
-github = "bluss"
-github-id = 3209739

--- a/people/fitzgen.toml
+++ b/people/fitzgen.toml
@@ -2,6 +2,3 @@ name = "Nick Fitzgerald"
 github = "fitzgen"
 github-id = 74571
 email = "nfitzgerald@mozilla.com"
-
-[permissions]
-bors.rust.review = true

--- a/people/japaric.toml
+++ b/people/japaric.toml
@@ -2,6 +2,3 @@ name = "Jorge Aparicio"
 github = "japaric"
 github-id = 5018213
 email = "jorge@japaric.io"
-
-[permissions]
-bors.rust.review = true

--- a/people/ljedrz.toml
+++ b/people/ljedrz.toml
@@ -1,6 +1,3 @@
 name = "ljedrz"
 github = "ljedrz"
 github-id = 3750347
-
-[permissions]
-bors.rust.try = true

--- a/people/ljedrz.toml
+++ b/people/ljedrz.toml
@@ -1,3 +1,0 @@
-name = "ljedrz"
-github = "ljedrz"
-github-id = 3750347

--- a/people/nox.toml
+++ b/people/nox.toml
@@ -2,6 +2,3 @@ name = "Anthony Ramine"
 github = "nox"
 github-id = 123095
 email = "n.oxyde@gmail.com"
-
-[permissions]
-bors.rust.try = true

--- a/people/nox.toml
+++ b/people/nox.toml
@@ -1,4 +1,0 @@
-name = "Anthony Ramine"
-github = "nox"
-github-id = 123095
-email = "n.oxyde@gmail.com"

--- a/people/sanxiyn.toml
+++ b/people/sanxiyn.toml
@@ -1,3 +1,0 @@
-name = "Seo Sanghyeon"
-github = "sanxiyn"
-github-id = 45249

--- a/people/sanxiyn.toml
+++ b/people/sanxiyn.toml
@@ -1,6 +1,3 @@
 name = "Seo Sanghyeon"
 github = "sanxiyn"
 github-id = 45249
-
-[permissions]
-bors.rust.review = true

--- a/people/tromey.toml
+++ b/people/tromey.toml
@@ -1,6 +1,3 @@
 name = "Tom Tromey"
 github = "tromey"
 github-id = 1557670
-
-[permissions]
-bors.rust.review = true


### PR DESCRIPTION
We should not grant bors permissions to individuals anymore. It seems that everyone from the list is not active in reviewing anymore, and most of them are no longer active in contributing either.

- apasel422 - Last PR [2018](https://github.com/rust-lang/rust/pulls?q=is%3Apr+apasel422+is%3Aclosed)
- arielb1 - Last PR [2022](https://github.com/rust-lang/rust/pulls?q=is%3Apr+arielb1+is%3Aclosed+)
- bluss - Last PR [2020](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Abluss+is%3Aclosed+)
- fitzgen - Last PR [2024](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Afitzgen+is%3Aclosed+), most 2019 and older
- japaic - Last assigned PR [2020](https://github.com/rust-lang/rust/pulls?q=is%3Apr+assignee%3Ajaparic+is%3Aclosed+)
- ljedrz - Last PR [2020](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Aljedrz+is%3Aclosed+)
- nox - Last PR [2020](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Anox+is%3Aclosed+)
- synxiyn - Last PR [2023](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Asanxiyn+is%3Aclosed+)
- tromey - Last PR [2023](https://github.com/rust-lang/rust/pulls?q=is%3Apr+author%3Atromey+is%3Aclosed+)

Some of the users had no remaining allegiance, so I removed them from team to make CI green.