### PR TITLE
Forbid admin permissions

### DIFF
--- a/repos/rust-lang/crates.io-index-archive.toml
+++ b/repos/rust-lang/crates.io-index-archive.toml
@@ -4,7 +4,7 @@ description = "Archive of the crates.io-index commit history after squashes"
 bots = []
 
 [access.teams]
-crates-io = "admin"
+crates-io = "maintain"
 
 [[branch-protections]]
 pattern = "snapshot-*"

--- a/repos/rust-lang/sync-team.toml
+++ b/repos/rust-lang/sync-team.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 infra = "write"
-infra-admins = "admin"
+infra-admins = "maintain"
 
 [[branch-protections]]
 pattern = "master"

--- a/repos/rust-lang/www.rust-lang.org.toml
+++ b/repos/rust-lang/www.rust-lang.org.toml
@@ -5,8 +5,8 @@ homepage = "https://www.rust-lang.org"
 bots = ["rustbot"]
 
 [access.teams]
-# Admin is needed for integrating with external services, e.g. Pontoon
-website = "admin"
+# Maintain is needed for integrating with external services, e.g. Pontoon
+website = "maintain"
 
 [[branch-protections]]
 pattern = "master"

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -9,7 +9,7 @@
       "teams": [
         {
           "name": "foo",
-          "permission": "admin"
+          "permission": "maintain"
         }
       ],
       "members": [],
@@ -42,7 +42,7 @@
       "teams": [
         {
           "name": "foo",
-          "permission": "admin"
+          "permission": "maintain"
         }
       ],
       "members": [],

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -7,7 +7,7 @@
   "teams": [
     {
       "name": "foo",
-      "permission": "admin"
+      "permission": "maintain"
     }
   ],
   "members": [],

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -7,7 +7,7 @@
   "teams": [
     {
       "name": "foo",
-      "permission": "admin"
+      "permission": "maintain"
     }
   ],
   "members": [],

--- a/tests/static-api/repos/archive/test-org/archived_repo.toml
+++ b/tests/static-api/repos/archive/test-org/archived_repo.toml
@@ -4,7 +4,7 @@ description = "An archived repo!"
 bots = []
 
 [access.teams]
-foo = "admin"
+foo = "maintain"
 
 [[branch-protections]]
 pattern = "master"

--- a/tests/static-api/repos/test-org/some_repo.toml
+++ b/tests/static-api/repos/test-org/some_repo.toml
@@ -4,7 +4,7 @@ description = "A repo!"
 bots = []
 
 [access.teams]
-foo = "admin"
+foo = "maintain"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
This PR removes all remaining `admin` permissions and adds a validation check that they are not used anywhere. I didn't remove them fully from the codebase yet, as I'd like to first see for some time if there is really no use-case for it.

In the future, we could in theory allow admin permissions, but require admin approval for PRs that assign them.