### PR TITLE
don't run dry-run periodically

### DIFF
--- a/sync-team/.github/workflows/dry-run.yml
+++ b/sync-team/.github/workflows/dry-run.yml
@@ -3,9 +3,6 @@ name: Dry Run
 on:
   push:
   workflow_dispatch:
-  schedule:
-    # Run the dry run every 4 hours
-    - cron: "0 */4 * * *"
 
 jobs:
   dry-run:


### PR DESCRIPTION
now that the sync runs every 4 hours, there's no reason to also perform the dry run at the same time.

but maybe I'm missing something.

also, for some reason, the `CI` event is not running in actions: https://github.com/rust-lang/sync-team/actions?query=event%3Aschedule
I fill try to fix this separately