### PR TITLE
Add aws-runners-test repository under automation

### DIFF
--- a/repos/rust-lang/aws-runners-test.toml
+++ b/repos/rust-lang/aws-runners-test.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "aws-runners-test"
+description = ""
+bots = []
+
+[access.teams]
+infra = "write"
+infra-admins = "maintain"


### PR DESCRIPTION
Repository: https://github.com/rust-lang/aws-runners-test

Extracted from GH:
```toml
org = "rust-lang"
name = "aws-runners-test"
description = ""
bots = []

[access.teams]
infra = "write"
infra-admins = "admin"
security = "pull"

[access.individuals]
kennytm = "write"
pietroalbini = "admin"
jdno = "admin"
shepmaster = "write"
Mark-Simulacrum = "admin"
Kobzol = "write"
marcoieni = "admin"
rust-lang-owner = "admin"
```