### PR TITLE
Fix name of binary in dry-run CI workflow

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -142,7 +142,7 @@ jobs:
           # Perform build and execution separately to avoid any potential output from
           # cargo leaking into the output file.
           cargo build --release
-          ./target/release/team sync print-plan \
+          ./target/release/rust-team sync print-plan \
             --services github \
             --team-json team-api 2>&1 | tee -a output.txt
 


### PR DESCRIPTION
The name of the binary is `rust-team`, not `team` :facepalm: