### PR TITLE
Fix sync-team link in README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@ people/**/*.toml
 repos/**/*.toml
 teams/**/*.toml
 
+# Do not require admin approvals for Markdown file modifications.
+*.md
+
 # Modifying these files requires admin approval.
 /repos/rust-lang/team.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /repos/rust-lang/sync-team.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ from all the supported services.
 
 [rfcbot-src]: https://github.com/anp/rfcbot-rs/blob/master/src/teams.rs
 
-[sync-team-src]: https://github.com/rust-lang/sync-team
+[sync-team-src]: sync-team
 
 [crates-io-admin-src]: https://github.com/rust-lang/crates.io/blob/main/src/worker/jobs/sync_admins.rs
 

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -119,6 +119,9 @@ fn generate_codeowners_content(data: Data) -> String {
 people/**/*.toml
 repos/**/*.toml
 teams/**/*.toml
+
+# Do not require admin approvals for Markdown file modifications.
+*.md
 "#
     )
     .unwrap();


### PR DESCRIPTION
I wonder if we should allow `*.md` in `CODEOWNERS` to not require infra admin approval for Markdown changes :)

Allowed that in this PR.