### PR TITLE
Run dry-run with code from PR if it is not from a fork

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -31,12 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Always checkout the master branch to avoid checking out
-          # code of untrusted PRs.
-          # This might break the dry-run if code or schema modifications
-          # are performed, we can selectively allow that in the future
-          # e.g. if the author of the PR is trusted.
-          ref: 'master'
+          # If the PR is from this repository, checkout the PR sha,
+          # so that we can also test code changes.
+          # If it is from a fork, then always checkout the 'master' branch,
+          # to avoid checking out code of untrusted PRs.
+          ref: ${{ github.event.workflow_run.head_repository.full_name != 'rust-lang/team' && 'master' || github.event.workflow_run.head_sha }}
           persist-credentials: false
 
       - name: Install Rust Stable


### PR DESCRIPTION
This should make it easier to test code changes using the dry-run functionality. Only `mods`, `team-repo-admins` and `infra-admins` have `write+` permissions, so only they are able to create branches on this repository.

Even if someone figured out a way to get through it, dry-run runs only with a read-only token, so the possible damage would be limited.