### PR TITLE
Work around missing permissions for rust-lang/rust branch protections

### DIFF
--- a/sync-team/src/github/api/mod.rs
+++ b/sync-team/src/github/api/mod.rs
@@ -47,6 +47,10 @@ impl HttpClient {
         })
     }
 
+    pub fn uses_pat(&self) -> bool {
+        matches!(self.github_tokens, GitHubTokens::Pat(_))
+    }
+
     fn auth_header(&self, org: &str) -> anyhow::Result<HeaderValue> {
         let token = self.github_tokens.get_token(org)?;
         let mut auth = HeaderValue::from_str(&format!("token {}", token.expose_secret()))?;

--- a/sync-team/src/github/api/read.rs
+++ b/sync-team/src/github/api/read.rs
@@ -7,6 +7,8 @@ use reqwest::Method;
 use std::collections::{HashMap, HashSet};
 
 pub(crate) trait GithubRead {
+    fn uses_pat(&self) -> bool;
+
     /// Get user names by user ids
     fn usernames(&self, ids: &[u64]) -> anyhow::Result<HashMap<u64, String>>;
 
@@ -58,6 +60,10 @@ impl GitHubApiRead {
 }
 
 impl GithubRead for GitHubApiRead {
+    fn uses_pat(&self) -> bool {
+        self.client.uses_pat()
+    }
+
     fn usernames(&self, ids: &[u64]) -> anyhow::Result<HashMap<u64, String>> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]

--- a/sync-team/src/github/mod.rs
+++ b/sync-team/src/github/mod.rs
@@ -315,6 +315,13 @@ impl SyncGitHub {
         actual_repo: &api::Repo,
         expected_repo: &rust_team_data::v1::Repo,
     ) -> anyhow::Result<Vec<BranchProtectionDiff>> {
+        // The rust-lang/rust repository uses GitHub apps push allowance actors for its branch
+        // protections, which cannot be read without a PAT.
+        // To avoid errors, we simply return an empty diff here.
+        if !self.github.uses_pat() && actual_repo.org == "rust-lang" && actual_repo.name == "rust" {
+            return Ok(vec![]);
+        }
+
         let mut branch_protection_diffs = Vec::new();
         let mut actual_protections = self
             .github

--- a/sync-team/src/github/tests/test_utils.rs
+++ b/sync-team/src/github/tests/test_utils.rs
@@ -438,6 +438,10 @@ impl GithubMock {
 }
 
 impl GithubRead for GithubMock {
+    fn uses_pat(&self) -> bool {
+        true
+    }
+
     fn usernames(&self, ids: &[UserId]) -> anyhow::Result<HashMap<UserId, String>> {
         Ok(self
             .users


### PR DESCRIPTION
Dry-run for the rust-lang/rust repo currently [fails](https://github.com/rust-lang/team/pull/1463), because the read-only GitHub App tokens used for dry-runs cannot read branch protections of this repository, because they use GitHub App push allowances.

This PR adds a hacky workaround to ignore that error. The `uses_pat` function isn't super nice, but alternatives seemed worse:
- If we just ignored all errors returned from the `branch_protections` function for `rust-lang/rust` in the `diff_branch_protections` function, we could miss actual errors when a PAT is used. That would be bad.
- If we wanted to examine the specific error returned by `branch_protections` without asking if the API uses a PAT, we'd either need to examine its string contents, or create some new enum error variant only for this function, which seemed like overkill. But actuallyit's not trivial to even detect that this specific error has been returned from the GraphQL call.