### PR TITLE
Add bots needed for rust-lang/rust

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -205,6 +205,9 @@ pub enum Bot {
     Rustbot,
     RustTimer,
     Rfcbot,
+    Craterbot,
+    Glacierbot,
+    LogAnalyzer,
     Renovate,
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -843,6 +843,9 @@ pub(crate) enum Bot {
     Rustbot,
     RustTimer,
     Rfcbot,
+    Craterbot,
+    Glacierbot,
+    LogAnalyzer,
     Renovate,
 }
 

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -86,6 +86,9 @@ impl<'a> Generator<'a> {
                         Bot::RustTimer => v1::Bot::RustTimer,
                         Bot::Rustbot => v1::Bot::Rustbot,
                         Bot::Rfcbot => v1::Bot::Rfcbot,
+                        Bot::Craterbot => v1::Bot::Craterbot,
+                        Bot::Glacierbot => v1::Bot::Glacierbot,
+                        Bot::LogAnalyzer => v1::Bot::LogAnalyzer,
                         Bot::Renovate => v1::Bot::Renovate,
                     })
                     .collect(),

--- a/sync-team/src/github/mod.rs
+++ b/sync-team/src/github/mod.rs
@@ -484,6 +484,9 @@ fn bot_user_name(bot: &Bot) -> Option<&str> {
         Bot::RustTimer => Some("rust-timer"),
         Bot::Rustbot => Some("rustbot"),
         Bot::Rfcbot => Some("rfcbot"),
+        Bot::Craterbot => Some("craterbot"),
+        Bot::Glacierbot => Some("rust-lang-glacier-bot"),
+        Bot::LogAnalyzer => Some("rust-log-analyzer"),
         Bot::Renovate => None,
     }
 }


### PR DESCRIPTION
The [dry-run](https://github.com/rust-lang/team/actions/runs/14170134329/job/39691899954) on https://github.com/rust-lang/team/pull/1463 showed that we will need to include these bots.

(It's so great to have the option to modify both team and sync-team in the same PR :heart:)