### PR TITLE
Remove unused bors repos from permission allowlist

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,25 +18,7 @@ allowed-github-orgs = [
 
 permissions-bors-repos = [
     "bors-kindergarten",
-    "cargo",
-    "chalk",
-    "clippy",
-    "compiler-builtins",
-    "crater",
-    "hashbrown",
-    "measureme",
-    "miri",
-    "libc",
-    "regex",
-    "rls",
     "rust",
-    "rust-analyzer",
-    "rustlings",
-    "rustup-rs",
-    "semverver",
-    "stdarch",
-    "team",
-    "vscode-rust",
 ]
 
 permissions-bools = [


### PR DESCRIPTION
These repos no longer use bors (neither the old one nor the new one). Homu no longer loads any other repo than `rust`, so removing the (empty) JSON bors permission files from the rendered output should hopefully be fine.