### PR TITLE
Make it possible to run sync-team against local data

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -143,7 +143,7 @@ jobs:
           cargo build --release
           ./target/release/rust-team sync print-plan \
             --services github \
-            --team-json team-api 2>&1 | tee -a output.txt
+            --src team-api 2>&1 | tee -a output.txt
 
       - name: Prepare comment
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
           ZULIP_API_TOKEN: ${{ secrets.ZULIP_API_TOKEN }}
           ZULIP_USERNAME: ${{ secrets.ZULIP_USERNAME }}
         run: |
-          RUST_LOG="sync_team=debug" cargo run sync apply --team-json build
+          RUST_LOG="sync_team=debug" cargo run sync apply --src build
 
       - name: Disable Jekyll
         run: touch build/.nojekyll

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,6 +1558,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sync-team",
+ "tempfile",
  "toml",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 serde-untagged = "0.1"
+tempfile = "3.19.1"
 toml = "0.8"
 
 sync-team = { path = "sync-team" }

--- a/README.md
+++ b/README.md
@@ -158,12 +158,11 @@ cargo run -- sync --services github,mailgun
 cargo run -- sync --services github,mailgun apply
 ```
 
-By default, the synchronization will be based on data from the live `team` endpoint.
-When making changes to the tool it might be useful to test
-with dummy data though. You can do that by passing the `--team-repo` flag to the CLI:
+By default, the synchronization will be based on data from the current `team` repository checkout.
+You can also perform the sync based on the live `team` endpoint using `--src=production`, or on an existing directory on disk that contains the prebuilt JSON files using `--src=<path>`.
 
 ```
-cargo run -- sync --team-json <directory>
+cargo run -- sync --src=<directory>
 ```
 
 The `<directory>` with JSON data can be generated using `cargo run static-api`.


### PR DESCRIPTION
Before, `sync-team` performed sync against the live service. Now it runs against the local `team` checkout by default. This PR also makes it easier to run `sync-team` on the local checkout data (as that is probably a common use-case, if you use it locally), without having to prebuild the JSON data directory first.