### PR TITLE
Add debug logging of team and repo diffs during actual sync

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
           ZULIP_API_TOKEN: ${{ secrets.ZULIP_API_TOKEN }}
           ZULIP_USERNAME: ${{ secrets.ZULIP_USERNAME }}
         run: |
-          cargo run sync apply --team-json build
+          RUST_LOG="sync_team=debug" cargo run sync apply --team-json build
 
       - name: Disable Jekyll
         run: touch build/.nojekyll

--- a/sync-team/src/github/mod.rs
+++ b/sync-team/src/github/mod.rs
@@ -135,6 +135,8 @@ impl SyncGitHub {
     }
 
     fn diff_team(&self, github_team: &rust_team_data::v1::GitHubTeam) -> anyhow::Result<TeamDiff> {
+        debug!("Diffing team `{}/{}`", github_team.org, github_team.name);
+
         // Ensure the team exists and is consistent
         let team = match self.github.team(&github_team.org, &github_team.name)? {
             Some(team) => team,
@@ -234,6 +236,11 @@ impl SyncGitHub {
     }
 
     fn diff_repo(&self, expected_repo: &rust_team_data::v1::Repo) -> anyhow::Result<RepoDiff> {
+        debug!(
+            "Diffing repo `{}/{}`",
+            expected_repo.org, expected_repo.name
+        );
+
         let actual_repo = match self.github.repo(&expected_repo.org, &expected_repo.name)? {
             Some(r) => r,
             None => {


### PR DESCRIPTION
To help observe the progress better when real synces are being performed. Currently, we are staring at an empty screen for ~3 minutes.