### PR TITLE
Revert "Merge pull request #1752 from Kobzol/debug-log"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
           ZULIP_API_TOKEN: ${{ secrets.ZULIP_API_TOKEN }}
           ZULIP_USERNAME: ${{ secrets.ZULIP_USERNAME }}
         run: |
-          RUST_LOG="sync_team=debug" cargo run sync apply --src build
+          cargo run sync apply --src build
 
       - name: Disable Jekyll
         run: touch build/.nojekyll


### PR DESCRIPTION
This reverts commit 4c2bdca7b86cf427e88370a034a53ea9de83eed7 (https://github.com/rust-lang/team/pull/1752), reversing changes made to 1388cc0ef318223dbafdd8f8122de0b729d9c581.

While the debug log is indeed nice for observing progress, it can also leak some information that might not be public (private Zulip stream membership), and it also drowns the actually performed changes. So I think it's not worth it after all.

I only reverted the CI change, because having the debug log of diffing teams/repos can still be useful for observing progress locally.