### PR TITLE
allow team leaders to edit their teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,93 @@
 # on every change to the data files.
 people/**/*.toml
 repos/**/*.toml
+# Useful for teams without leaders.
 teams/**/*.toml
 
 # Do not require admin approvals for Markdown file modifications.
 *.md
+
+# Team leads can approve changes to their own team files.
+/teams/book.toml @team-repo-admins @mods @carols10cents @chriskrycho
+/teams/bootstrap.toml @team-repo-admins @mods @Mark-Simulacrum @onur-ozkan
+/teams/cargo.toml @team-repo-admins @mods @ehuss
+/teams/clippy.toml @team-repo-admins @mods @Manishearth @flip1995
+/teams/community-localization.toml @team-repo-admins @mods @Manishearth @vertexclique
+/teams/community-rustbridge.toml @team-repo-admins @mods @shadows-withal
+/teams/community-survey.toml @team-repo-admins @mods @Kobzol @apiraino
+/teams/compiler.toml @team-repo-admins @mods @davidtwco @wesleywiser
+/teams/crates-io.toml @team-repo-admins @mods @Turbo87 @jtgeibel
+/teams/devtools.toml @team-repo-admins @mods @Manishearth
+/teams/docker.toml @team-repo-admins @mods @Muscraft
+/teams/docs-rs.toml @team-repo-admins @mods @syphar
+/teams/edition.toml @team-repo-admins @mods @ehuss @traviscross
+/teams/goals.toml @team-repo-admins @mods @nikomatsakis
+/teams/infra.toml @team-repo-admins @mods @jdno @shepmaster
+/teams/infra-bors.toml @team-repo-admins @mods @Mark-Simulacrum
+/teams/lang.toml @team-repo-admins @mods @nikomatsakis @tmandry
+/teams/lang-docs.toml @team-repo-admins @mods @JohnTitor @ehuss
+/teams/lang-ops.toml @team-repo-admins @mods @traviscross
+/teams/libs.toml @team-repo-admins @mods @Amanieu @m-ou-se
+/teams/mentorship.toml @team-repo-admins @mods @Kobzol @jackh726
+/teams/miri.toml @team-repo-admins @mods @RalfJung @oli-obk
+/teams/opsem.toml @team-repo-admins @mods @JakobDegen @RalfJung
+/teams/project-async-crashdump-debugging.toml @team-repo-admins @mods @michaelwoerister
+/teams/project-const-generics.toml @team-repo-admins @mods @BoxyUwU @lcnr
+/teams/project-const-traits.toml @team-repo-admins @mods @fee1-dead
+/teams/project-dyn-upcasting.toml @team-repo-admins @mods @crlf0710
+/teams/project-exploit-mitigations.toml @team-repo-admins @mods @rcvalle
+/teams/project-generic-associated-types.toml @team-repo-admins @mods @jackh726
+/teams/project-impl-trait.toml @team-repo-admins @mods @nikomatsakis
+/teams/project-keyword-generics.toml @team-repo-admins @mods @oli-obk @yoshuawuyts
+/teams/project-negative-impls.toml @team-repo-admins @mods @nikomatsakis
+/teams/project-portable-simd.toml @team-repo-admins @mods @calebzulawski @workingjubilee
+/teams/project-stable-mir.toml @team-repo-admins @mods @celinval
+/teams/project-trait-system-refactor.toml @team-repo-admins @mods @lcnr
+/teams/regex.toml @team-repo-admins @mods @BurntSushi
+/teams/release.toml @team-repo-admins @mods @Mark-Simulacrum
+/teams/rust-analyzer.toml @team-repo-admins @mods @Veykril
+/teams/rust-by-example.toml @team-repo-admins @mods @marioidival
+/teams/rustdoc.toml @team-repo-admins @mods @GuillaumeGomez
+/teams/rustfmt.toml @team-repo-admins @mods @calebcartwright
+/teams/rustlings.toml @team-repo-admins @mods @mo8it @shadows-withal
+/teams/rustup.toml @team-repo-admins @mods @rbtcollins
+/teams/social-media.toml @team-repo-admins @mods @m-ou-se
+/teams/spec.toml @team-repo-admins @mods @JoelMarcey
+/teams/style.toml @team-repo-admins @mods @calebcartwright
+/teams/testing-devex.toml @team-repo-admins @mods @calebcartwright
+/teams/triagebot.toml @team-repo-admins @mods @Mark-Simulacrum
+/teams/twir.toml @team-repo-admins @mods @nellshamrell
+/teams/twir-reviewers.toml @team-repo-admins @mods @nellshamrell
+/teams/types.toml @team-repo-admins @mods @jackh726 @lcnr
+/teams/website.toml @team-repo-admins @mods @Manishearth
+/teams/wg-allocators.toml @team-repo-admins @mods @TimDiekmann
+/teams/wg-async.toml @team-repo-admins @mods @nikomatsakis @tmandry
+/teams/wg-binary-size.toml @team-repo-admins @mods @m-ou-se @thomcc
+/teams/wg-bindgen.toml @team-repo-admins @mods @emilio @fitzgen
+/teams/wg-cli.toml @team-repo-admins @mods @epage
+/teams/wg-compiler-performance.toml @team-repo-admins @mods @Mark-Simulacrum
+/teams/wg-const-eval.toml @team-repo-admins @mods @RalfJung @oli-obk
+/teams/wg-debugging.toml @team-repo-admins @mods @wesleywiser
+/teams/wg-diagnostics.toml @team-repo-admins @mods @estebank @oli-obk
+/teams/wg-embedded.toml @team-repo-admins @mods @adamgreig @therealprof
+/teams/wg-ffi-unwind.toml @team-repo-admins @mods @BatmanAoD @acfoltzer @nikomatsakis
+/teams/wg-gamedev.toml @team-repo-admins @mods @AngelOnFira @erlend-sh @kvark @ozkriff
+/teams/wg-gcc-backend.toml @team-repo-admins @mods @antoyo
+/teams/wg-incr-comp.toml @team-repo-admins @mods @wesleywiser
+/teams/wg-inline-asm.toml @team-repo-admins @mods @Amanieu
+/teams/wg-llvm.toml @team-repo-admins @mods @nikic
+/teams/wg-macros.toml @team-repo-admins @mods @eholk @vincenzopalazzo
+/teams/wg-mir-opt.toml @team-repo-admins @mods @oli-obk
+/teams/wg-parallel-rustc.toml @team-repo-admins @mods @cjgillot
+/teams/wg-polonius.toml @team-repo-admins @mods @lqd @nikomatsakis
+/teams/wg-polymorphization.toml @team-repo-admins @mods @davidtwco
+/teams/wg-prioritization.toml @team-repo-admins @mods @apiraino @wesleywiser
+/teams/wg-rustc-dev-guide.toml @team-repo-admins @mods @JohnTitor @spastorino
+/teams/wg-rustc-reading-club.toml @team-repo-admins @mods @doc-jones @nikomatsakis
+/teams/wg-safe-transmute.toml @team-repo-admins @mods @jswrenn
+/teams/wg-secure-code.toml @team-repo-admins @mods @Shnatsel @tarcieri
+/teams/wg-self-profile.toml @team-repo-admins @mods @wesleywiser
+/teams/wg-triage.toml @team-repo-admins @mods @Dylan-DPC
 
 # Modifying these files requires admin approval.
 /repos/rust-lang/team.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -6,6 +6,7 @@ bots = []
 [access.teams]
 mods = "write"
 team-repo-admins = "write"
+leads = "write"
 infra = "triage"
 
 [[branch-protections]]

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -128,13 +128,29 @@ fn generate_codeowners_content(data: Data) -> String {
 # on every change to the data files.
 people/**/*.toml
 repos/**/*.toml
+# Useful for teams without leaders.
 teams/**/*.toml
 
 # Do not require admin approvals for Markdown file modifications.
 *.md
-"#
+
+# Team leads can approve changes to their own team files."#
     )
     .unwrap();
+
+    // Add team leads as reviewers for their team files
+    for (team_name, leads) in data.team_leads() {
+        let leads_list = leads
+            .iter()
+            .map(|lead| format!("@{lead}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        writeln!(
+            codeowners,
+            "/teams/{team_name}.toml @team-repo-admins @mods {leads_list}"
+        )
+        .unwrap();
+    }
 
     // There are several data files that we want to be protected more
     // Notably, the properties of the team and sync-team repositories,
@@ -143,7 +159,7 @@ teams/**/*.toml
 
     writeln!(
         codeowners,
-        "# Modifying these files requires admin approval."
+        "\n# Modifying these files requires admin approval."
     )
     .unwrap();
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,7 @@
 use crate::schema::{Config, List, Person, Repo, Team, ZulipGroup, ZulipStream};
 use anyhow::{bail, Context as _, Error};
 use serde::de::DeserializeOwned;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::path::Path;
 
@@ -156,6 +156,16 @@ impl Data {
 
     pub(crate) fn teams(&self) -> impl Iterator<Item = &Team> {
         self.teams.values()
+    }
+
+    /// Map of team name to list of leaders
+    pub(crate) fn team_leads(&self) -> BTreeMap<&str, BTreeSet<&str>> {
+        self.teams()
+            .filter_map(|team| {
+                let leads = team.leads();
+                (!leads.is_empty()).then_some((team.name(), leads))
+            })
+            .collect()
     }
 
     pub(crate) fn subteams_of<'a>(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,7 +3,7 @@ pub(crate) use crate::permissions::Permissions;
 use anyhow::{bail, format_err, Error};
 use serde::de::{Deserialize, Deserializer};
 use serde_untagged::UntaggedEnumVisitor;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -231,7 +231,7 @@ impl Team {
         false
     }
 
-    pub(crate) fn leads(&self) -> HashSet<&str> {
+    pub(crate) fn leads(&self) -> BTreeSet<&str> {
         self.people.leads.iter().map(|s| s.as_str()).collect()
     }
 


### PR DESCRIPTION


- [ ] If this is approved, merge the `leads = "write"` before this PR, so that team leads have write access

We want to give team leaders permission to approve PRs in this repository, so that they can unblock their teams.

The question is: how much permission can we give them? If you look at the CODEOWNERS file, you can see that anyone
with write access can approve PRs in the `/people` `/repos` and `/teams` directories.
But what if an attacker compromises a team-lead's account? They could then approve their own PRs
to remove branch protection rules, kick out team members, or archive all rust-lang repositories.

To prevent this, we want to limit the permissions of team-leads to only the directories they own,
i.e. their `/teams` and the `/repos` owned by their teams.

With this PR, I start by giving team-leads write access to their own `/teams` directory.