### PR TITLE
improve repo validation error message

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -210,6 +210,13 @@ impl Data {
         }
         result
     }
+
+    pub(crate) fn is_team_archived(&self, team_name: &str, org: &str) -> bool {
+        self.archived_teams()
+            .filter_map(|team| team.github_teams(self).ok())
+            .flatten()
+            .any(|github_team| github_team.name == team_name && github_team.org == org)
+    }
 }
 
 fn load_file<T: DeserializeOwned>(path: &Path) -> Result<T, Error> {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -868,20 +868,25 @@ fn validate_repos(data: &Data, errors: &mut Vec<String>) {
         }
         for team_name in repo.access.teams.keys() {
             if !github_teams.contains(&(repo.org.clone(), team_name.clone())) {
+                let error_reason = if data.is_team_archived(team_name, &repo.org) {
+                    "is archived. Please remove the team access from the `[access.teams]` section of the repo"
+                } else {
+                    "is not present in the `/teams/` folder"
+                };
+
                 bail!(
-                        "access for {}/{} is invalid: '{}' is not configured as a GitHub team for the '{}' org",
-                        repo.org,
-                        repo.name,
-                        team_name,
-                        repo.org
-                    )
+                    "Access for the repo {}/{} is invalid: the team '{}/{team_name}' {error_reason}.",
+                    repo.org,
+                    repo.name,
+                    repo.org,
+                );
             }
         }
 
         for name in repo.access.individuals.keys() {
             if data.person(name).is_none() {
                 bail!(
-                    "access for {}/{} is invalid: '{}' is not the name of a person in the team repo",
+                    "Access for the repo {}/{} is invalid: '{}' is not the name of a person in the team repo",
                     repo.org,
                     repo.name,
                     name


### PR DESCRIPTION
A user complained in https://github.com/rust-lang/team/pull/1763#issuecomment-2778295890 that this error was confusing. 

tested against that PR:

```
$ GITHUB_TOKEN=$(gh auth token) rust-team check                                                                  
[WARN  rust_team::validate] couldn't perform checks relying on the Zulip API, some errors will not be detected
[WARN  rust_team::validate] cause: missing ZULIP_USER and/or ZULIP_TOKEN environment variables
[ERROR rust_team::validate] validation error: Access for the repo rust-lang/wg-debugging is invalid: the team 'rust-lang/wg-debugging' is archived. Please remove it from the repo.
[ERROR rust_team] 1 validation errors found
```