### PR TITLE
Create ci-mirrors repo

### DIFF
--- a/people/PartiallyUntyped.toml
+++ b/people/PartiallyUntyped.toml
@@ -1,5 +1,5 @@
 name = "Quinn Sinclair"
-github = "m-rph"
+github = "PartiallyUntyped"
 github-id = 52372765
 zulip-id = 666012
 email = "me@m-rph.dev"

--- a/repos/rust-lang/ci-mirrors.toml
+++ b/repos/rust-lang/ci-mirrors.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "ci-mirrors"
+description = "Upload files to Rust's CI mirrors"
+homepage = "https://ci-mirrors.rust-lang.org"
+bots = []
+
+[access.teams]
+infra = "write"

--- a/teams/clippy-contributors.toml
+++ b/teams/clippy-contributors.toml
@@ -9,7 +9,7 @@ members = [
     "pitaj",
 ]
 alumni = [
-    "m-rph",
+    "PartiallyUntyped",
 ]
 
 [[github]]


### PR DESCRIPTION
The repo will host some tooling to automatically manage https://ci-mirrors.rust-lang.org