### PR TITLE
Backport archived rust-dev-tools repos

### DIFF
--- a/repos/archive/rust-dev-tools/rls-analysis.toml
+++ b/repos/archive/rust-dev-tools/rls-analysis.toml
@@ -1,0 +1,6 @@
+org = "rust-dev-tools"
+name = "rls-analysis"
+description = "Core functionality for handling rustc's save-analysis data"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-dev-tools/rls-blacklist.toml
+++ b/repos/archive/rust-dev-tools/rls-blacklist.toml
@@ -1,0 +1,6 @@
+org = "rust-dev-tools"
+name = "rls-blacklist"
+description = "Blacklist of crates for the RLS to skip"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-dev-tools/rls-data.toml
+++ b/repos/archive/rust-dev-tools/rls-data.toml
@@ -1,0 +1,6 @@
+org = "rust-dev-tools"
+name = "rls-data"
+description = "Data structures used by the RLS and Rust compiler"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-dev-tools/rls-rustc.toml
+++ b/repos/archive/rust-dev-tools/rls-rustc.toml
@@ -1,0 +1,6 @@
+org = "rust-dev-tools"
+name = "rls-rustc"
+description = "A simple shim around rustc to allow using save-analysis with a stable toolchain"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-dev-tools/rls-span.toml
+++ b/repos/archive/rust-dev-tools/rls-span.toml
@@ -1,0 +1,6 @@
+org = "rust-dev-tools"
+name = "rls-span"
+description = "Types for identifying code spans/ranges."
+bots = []
+
+[access.teams]


### PR DESCRIPTION
Backporting the following repos:


- [rls-analysis](https://github.com/rust-dev-tools/rls-analysis)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-dev-tools"
    name = "rls-analysis"
    description = "Core functionality for handling rustc's save-analysis data"
    bots = []

    [access.teams]

    [access.individuals]
    marcoieni = "admin"
    nrc = "admin"
    pietroalbini = "admin"
    Manishearth = "admin"
    killercup = "admin"
    Xanewok = "admin"
    rust-lang-owner = "admin"
    ```

    </details>

- [rls-blacklist](https://github.com/rust-dev-tools/rls-blacklist)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-dev-tools"
    name = "rls-blacklist"
    description = "Blacklist of crates for the RLS to skip"
    bots = []

    [access.teams]

    [access.individuals]
    pietroalbini = "admin"
    Manishearth = "admin"
    killercup = "admin"
    rust-lang-owner = "admin"
    nrc = "admin"
    Xanewok = "admin"
    marcoieni = "admin"
    ```

    </details>

- [rls-data](https://github.com/rust-dev-tools/rls-data)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-dev-tools"
    name = "rls-data"
    description = "Data structures used by the RLS and Rust compiler"
    bots = []

    [access.teams]

    [access.individuals]
    killercup = "admin"
    nrc = "admin"
    Manishearth = "admin"
    Xanewok = "admin"
    pietroalbini = "admin"
    marcoieni = "admin"
    rust-lang-owner = "admin"
    ```

    </details>

- [rls-rustc](https://github.com/rust-dev-tools/rls-rustc)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-dev-tools"
    name = "rls-rustc"
    description = "A simple shim around rustc to allow using save-analysis with a stable toolchain"
    bots = []

    [access.teams]

    [access.individuals]
    rust-lang-owner = "admin"
    nrc = "admin"
    killercup = "admin"
    pietroalbini = "admin"
    Manishearth = "admin"
    marcoieni = "admin"
    Xanewok = "admin"
    ```

    </details>

- [rls-span](https://github.com/rust-dev-tools/rls-span)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-dev-tools"
    name = "rls-span"
    description = "Types for identifying code spans/ranges."
    bots = []

    [access.teams]

    [access.individuals]
    Xanewok = "admin"
    marcoieni = "admin"
    Manishearth = "admin"
    rust-lang-owner = "admin"
    pietroalbini = "admin"
    nrc = "admin"
    killercup = "admin"
    ```

    </details>
