### PR TITLE
Backport archived rust-lang-deprecated repos (batch 2)

### DIFF
--- a/repos/archive/rust-lang-deprecated/rust-buildbot.toml
+++ b/repos/archive/rust-lang-deprecated/rust-buildbot.toml
@@ -1,0 +1,10 @@
+org = "rust-lang-deprecated"
+name = "rust-buildbot"
+description = "Buildbot configs for the Rust project"
+bots = []
+[[branch-protections]]
+pattern = "master"
+required-approvals = 0
+pr-required = false
+
+[access.teams]

--- a/repos/archive/rust-lang-deprecated/rust-packaging.toml
+++ b/repos/archive/rust-lang-deprecated/rust-packaging.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-deprecated"
+name = "rust-packaging"
+description = "Packaging for Rust + Cargo in multiple formats"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-lang-deprecated/rustc-benchmarks.toml
+++ b/repos/archive/rust-lang-deprecated/rustc-benchmarks.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-deprecated"
+name = "rustc-benchmarks"
+description = "Some benchmarks for testing rustc performance"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-lang-deprecated/rustc-serialize.toml
+++ b/repos/archive/rust-lang-deprecated/rustc-serialize.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-deprecated"
+name = "rustc-serialize"
+description = "Deprecated serialization/deserialization for Rust"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-lang-deprecated/rustup.sh.toml
+++ b/repos/archive/rust-lang-deprecated/rustup.sh.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-deprecated"
+name = "rustup.sh"
+description = "The rustup.sh script for installing Rust from release channels"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-lang-deprecated/tempdir.toml
+++ b/repos/archive/rust-lang-deprecated/tempdir.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-deprecated"
+name = "tempdir"
+description = "Temporary directory management for Rust"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-lang-deprecated/url.toml
+++ b/repos/archive/rust-lang-deprecated/url.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-deprecated"
+name = "url"
+description = "Deprecated url crate (use rust-url instead)"
+bots = []
+
+[access.teams]


### PR DESCRIPTION
Backporting the following repos:


- [rust-buildbot](https://github.com/rust-lang-deprecated/rust-buildbot)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-deprecated"
    name = "rust-buildbot"
    description = "Buildbot configs for the Rust project"
    bots = []

    [access.teams]

    [access.individuals]
    rust-lang-owner = "admin"
    jdno = "admin"
    Mark-Simulacrum = "admin"
    marcoieni = "admin"
    pietroalbini = "admin"

    [[branch-protections]]
    pattern = "master"
    required-approvals = 0
    pr-required = false
    ```

    </details>

- [rust-packaging](https://github.com/rust-lang-deprecated/rust-packaging)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-deprecated"
    name = "rust-packaging"
    description = "Packaging for Rust + Cargo in multiple formats"
    bots = []

    [access.teams]

    [access.individuals]
    pietroalbini = "admin"
    jdno = "admin"
    rust-lang-owner = "admin"
    marcoieni = "admin"
    Mark-Simulacrum = "admin"
    ```

    </details>

- [rustc-benchmarks](https://github.com/rust-lang-deprecated/rustc-benchmarks)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-deprecated"
    name = "rustc-benchmarks"
    description = "Some benchmarks for testing rustc performance"
    bots = []

    [access.teams]

    [access.individuals]
    jdno = "admin"
    Mark-Simulacrum = "admin"
    marcoieni = "admin"
    pietroalbini = "admin"
    rust-lang-owner = "admin"
    ```

    </details>

- [rustc-serialize](https://github.com/rust-lang-deprecated/rustc-serialize)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-deprecated"
    name = "rustc-serialize"
    description = "Deprecated serialization/deserialization for Rust"
    bots = []

    [access.teams]

    [access.individuals]
    rust-lang-owner = "admin"
    jdno = "admin"
    pietroalbini = "admin"
    Mark-Simulacrum = "admin"
    marcoieni = "admin"
    ```

    </details>

- [rustup.sh](https://github.com/rust-lang-deprecated/rustup.sh)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-deprecated"
    name = "rustup.sh"
    description = "The rustup.sh script for installing Rust from release channels"
    bots = []

    [access.teams]

    [access.individuals]
    jdno = "admin"
    marcoieni = "admin"
    rust-lang-owner = "admin"
    Mark-Simulacrum = "admin"
    pietroalbini = "admin"
    ```

    </details>

- [tempdir](https://github.com/rust-lang-deprecated/tempdir)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-deprecated"
    name = "tempdir"
    description = "Temporary directory management for Rust"
    bots = []

    [access.teams]

    [access.individuals]
    pietroalbini = "admin"
    Mark-Simulacrum = "admin"
    marcoieni = "admin"
    jdno = "admin"
    rust-lang-owner = "admin"
    ```

    </details>

- [url](https://github.com/rust-lang-deprecated/url)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-deprecated"
    name = "url"
    description = "Deprecated url crate (use rust-url instead)"
    bots = []

    [access.teams]
    Owners = "admin"

    [access.individuals]
    rust-lang-owner = "admin"
    jdno = "admin"
    Mark-Simulacrum = "admin"
    pietroalbini = "admin"
    marcoieni = "admin"
    ```

    </details>
