### PR TITLE
Add Josh to T-spec

### DIFF
--- a/teams/spec.toml
+++ b/teams/spec.toml
@@ -8,6 +8,7 @@ members = [
     "ehuss",
     "traviscross",
     "nikomatsakis",
+    "joshtriplett",
 ]
 alumni = [
     "m-ou-se",


### PR DESCRIPTION
The spec team has, by unanimous agreement, invited Josh to join the team, and we're thrilled that he has accepted and will be picking up the mantle of helping to push forward our specification efforts.

cc @rust-lang/spec @rust-lang/lang
