### PR TITLE
give mods permissions in the cargo repo

### DIFF
--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -6,6 +6,7 @@ bots = ["rustbot", "rfcbot", "renovate"]
 
 [access.teams]
 cargo = "write"
+mods = "write"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
Otherwise we can't unhide comments (hiding works amusingly), lock issues, or ban people directly from comments they leave on that repo

cc @rust-lang/mods 