### PR TITLE
Archive rust-lang/libm, update compiler-builtins

### DIFF
--- a/repos/archive/rust-lang/libm.toml
+++ b/repos/archive/rust-lang/libm.toml
@@ -4,7 +4,6 @@ description = "A port of MUSL's libm to Rust."
 bots = []
 
 [access.teams]
-crate-maintainers = 'maintain'
 
 [[branch-protections]]
 pattern = "master"

--- a/repos/rust-lang/compiler-builtins.toml
+++ b/repos/rust-lang/compiler-builtins.toml
@@ -1,11 +1,10 @@
-org = 'rust-lang'
-name = 'compiler-builtins'
-description = 'Porting `compiler-rt` intrinsics to Rust'
-homepage = "https://github.com/rust-lang/rust/issues/35437"
+org = "rust-lang"
+name = "compiler-builtins"
+description = "Rust implementations of compiler-rt and libm"
 bots = []
 
 [access.teams]
-crate-maintainers = 'maintain'
+crate-maintainers = "maintain"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
Since https://github.com/rust-lang/compiler-builtins/pull/822, libm is now part of the compiler-builtins repository. Archive rust-lang/libm and update the description for compiler-builtins here.