### PR TITLE
Add T-compiler ops team

### DIFF
--- a/teams/compiler-ops.toml
+++ b/teams/compiler-ops.toml
@@ -1,0 +1,18 @@
+name = "compiler-ops"
+subteam-of = "compiler"
+
+[people]
+leads = ["apiraino"]
+members = [
+    "apiraino",
+]
+alumni = [
+]
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "compiler-ops team"
+description = "Operations for the compiler team: preparing agenda, issue triage and prioritization, scheduling and documenting meetings"
+zulip-stream = "t-compiler/ops"


### PR DESCRIPTION
With this first step I'd like to formalize the existence and work of a T-compiler operation group.

This group will prepare meetings agenda, do issue triaging and prioritization, scheduling and documenting meetings.

It will replace the current Prioritization Working Group inside T-compiler.

r? @davidtwco 