### PR TITLE
Move directors to launching pad, give them blog permissions

### DIFF
--- a/teams/foundation-board-project-directors.toml
+++ b/teams/foundation-board-project-directors.toml
@@ -1,5 +1,5 @@
 name = "foundation-board-project-directors"
-kind = "marker-team"
+subteam-of = "launching-pad"
 
 [people]
 leads = []

--- a/teams/inside-rust-reviewers.toml
+++ b/teams/inside-rust-reviewers.toml
@@ -4,7 +4,7 @@ kind = "marker-team"
 [people]
 leads = []
 members = []
-included-teams = ["leadership-council", "leads", "project-group-leads"]
+included-teams = ["leadership-council", "leads", "project-group-leads", "foundation-board-project-directors"]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
I think we can trust directors to post on the blog, so lets give them permissions to do that so they don't need to bug anyone else to do it.

To accommodate the addition of permissions, this promotes it from a marker team to a team in the launching pad (which we are planning to rebrand as a home for cross-cutting teams). There's no expectation that this would change anything in practice, and the membership is still chosen by the council.

cc @rust-lang/leadership-council @carols10cents @JakobDegen @rylev @scottmcm @spastorino