### PR TITLE
Enable rustbot in `rustc_codegen_cranelift`&`rustc_codegen_gcc`

### DIFF
--- a/repos/rust-lang/rustc_codegen_cranelift.toml
+++ b/repos/rust-lang/rustc_codegen_cranelift.toml
@@ -1,7 +1,7 @@
 org = 'rust-lang'
 name = 'rustc_codegen_cranelift'
 description = 'Cranelift based backend for rustc'
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 compiler = 'maintain'

--- a/repos/rust-lang/rustc_codegen_gcc.toml
+++ b/repos/rust-lang/rustc_codegen_gcc.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "rustc_codegen_gcc"
 description = "libgccjit AOT codegen for rustc"
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 compiler = "write"


### PR DESCRIPTION
This is going to be useful for enabling [`[no-mentions]`](https://forge.rust-lang.org/triagebot/no-mentions.html) and [`[issue-links]`](https://forge.rust-lang.org/triagebot/issue-links.html) in both repository.

Which we should anyway to before enabling them in rust-lang/rust as otherwise subtree sync risk being flagged with warnings.

cc @bjorn3 @GuillaumeGomez @antoyo 