### PR TITLE
Add `rfcbot` to the bots used in the reference repo

### DIFF
--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "reference"
 description = "The Rust Reference"
 homepage = "https://doc.rust-lang.org/nightly/reference/"
-bots = ["rustbot"]
+bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 lang = "write"


### PR DESCRIPTION
cf. https://github.com/rust-lang/reference/pull/1792#issuecomment-2824692734 where the bot wasn't able to add the label because it doesn't have the rights to do so.