### PR TITLE
Backport rust-lang-nursery repos (batch 2)

### DIFF
--- a/repos/archive/rust-lang-nursery/portability-wg.toml
+++ b/repos/archive/rust-lang-nursery/portability-wg.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-nursery"
+name = "portability-wg"
+description = "Coordination repository of the portability Working Group (WG)"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-lang-nursery/rustc-seme-regions.toml
+++ b/repos/archive/rust-lang-nursery/rustc-seme-regions.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-nursery"
+name = "rustc-seme-regions"
+description = "Single Entry Multiple Exit Regions -- A stepping stone for full NLL"
+bots = []
+
+[access.teams]

--- a/repos/archive/rust-lang-nursery/wg-verification.toml
+++ b/repos/archive/rust-lang-nursery/wg-verification.toml
@@ -1,0 +1,6 @@
+org = "rust-lang-nursery"
+name = "wg-verification"
+description = "Verification working group"
+bots = []
+
+[access.teams]

--- a/repos/rust-lang-nursery/lazy-static.rs.toml
+++ b/repos/rust-lang-nursery/lazy-static.rs.toml
@@ -1,0 +1,7 @@
+org = "rust-lang-nursery"
+name = "lazy-static.rs"
+description = "A small macro for defining lazy evaluated static variables in Rust."
+bots = []
+
+[access.teams]
+libs = "write"


### PR DESCRIPTION
Backporting the following repos:


- [lazy-static.rs](https://github.com/rust-lang-nursery/lazy-static.rs)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-nursery"
    name = "lazy-static.rs"
    description = "A small macro for defining lazy evaluated static variables in Rust."
    bots = []

    [access.teams]
    libs = "admin"

    [access.individuals]
    aidanhs = "admin"
    kennytm = "admin"
    sfackler = "admin"
    huonw = "admin"
    marcoieni = "admin"
    jdno = "admin"
    Amanieu = "admin"
    Mark-Simulacrum = "admin"
    nikomatsakis = "admin"
    aturon = "admin"
    joshtriplett = "admin"
    carols10cents = "admin"
    thomcc = "admin"
    dtolnay = "admin"
    pietroalbini = "admin"
    KodrAus = "admin"
    rust-lang-owner = "admin"
    nikomatsakis-admin = "admin"
    steveklabnik = "admin"
    nrc = "admin"
    m-ou-se = "admin"
    alexcrichton = "admin"
    the8472 = "admin"
    cuviper = "admin"
    erickt = "admin"
    ```

    </details>

- [portability-wg](https://github.com/rust-lang-nursery/portability-wg)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-nursery"
    name = "portability-wg"
    description = "Coordination repository of the portability Working Group (WG)"
    bots = []

    [access.teams]

    [access.individuals]
    nrc = "admin"
    le-jzr = "write"
    nikomatsakis-admin = "admin"
    pierzchalski = "write"
    steveklabnik = "admin"
    bossmc = "write"
    KodrAus = "admin"
    thejpster = "write"
    nikomatsakis = "admin"
    pietroalbini = "admin"
    Mark-Simulacrum = "admin"
    vcfxb = "write"
    erickt = "admin"
    Tom-Phinney = "write"
    huonw = "admin"
    jdno = "admin"
    alexcrichton = "admin"
    aidanhs = "admin"
    marcoieni = "admin"
    Ericson2314 = "write"
    aturon = "admin"
    acfoltzer = "write"
    rust-lang-owner = "admin"
    kennytm = "admin"
    carols10cents = "admin"
    jethrogb = "admin"
    dtolnay = "admin"
    retep998 = "write"
    sfackler = "admin"
    ```

    </details>

- [rustc-seme-regions](https://github.com/rust-lang-nursery/rustc-seme-regions)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-nursery"
    name = "rustc-seme-regions"
    description = "Single Entry Multiple Exit Regions -- A stepping stone for full NLL"
    bots = []

    [access.teams]

    [access.individuals]
    aturon = "admin"
    erickt = "admin"
    rust-lang-owner = "admin"
    steveklabnik = "admin"
    kennytm = "admin"
    Mark-Simulacrum = "admin"
    nrc = "admin"
    pietroalbini = "admin"
    huonw = "admin"
    KodrAus = "admin"
    alexcrichton = "admin"
    sfackler = "admin"
    nikomatsakis-admin = "admin"
    nikomatsakis = "admin"
    jdno = "admin"
    marcoieni = "admin"
    carols10cents = "admin"
    dtolnay = "admin"
    aidanhs = "admin"
    ```

    </details>

- [wg-verification](https://github.com/rust-lang-nursery/wg-verification)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-nursery"
    name = "wg-verification"
    description = "Verification working group"
    bots = []

    [access.teams]

    [access.individuals]
    erickt = "admin"
    nrc = "admin"
    nikomatsakis-admin = "admin"
    sfackler = "admin"
    kennytm = "admin"
    nikomatsakis = "admin"
    aturon = "admin"
    huonw = "admin"
    rust-lang-owner = "admin"
    asajeffrey = "admin"
    jdno = "admin"
    steveklabnik = "admin"
    Mark-Simulacrum = "admin"
    avadacatavra = "admin"
    aidanhs = "admin"
    KodrAus = "admin"
    marcoieni = "admin"
    carols10cents = "admin"
    dtolnay = "admin"
    alexcrichton = "admin"
    pietroalbini = "admin"
    ```

    </details>

Archived everything except for `lazy-static.rs`.