### PR TITLE
Backport rust-lang-nursery repos (batch 3)

### DIFF
--- a/repos/rust-lang-nursery/.github.toml
+++ b/repos/rust-lang-nursery/.github.toml
@@ -1,0 +1,7 @@
+org = "rust-lang-nursery"
+name = ".github"
+description = "GitHub metadata for this organization"
+bots = []
+
+[access.teams]
+infra = "write"

--- a/repos/rust-lang-nursery/rust-lang-nursery.github.io.toml
+++ b/repos/rust-lang-nursery/rust-lang-nursery.github.io.toml
@@ -1,0 +1,7 @@
+org = "rust-lang-nursery"
+name = "rust-lang-nursery.github.io"
+description = "GitHub pages redirects"
+bots = []
+
+[access.teams]
+infra = "write"

--- a/repos/rust-lang-nursery/rust-toolstate.toml
+++ b/repos/rust-lang-nursery/rust-toolstate.toml
@@ -1,0 +1,12 @@
+org = "rust-lang-nursery"
+name = "rust-toolstate"
+description = "Records build and test status of external tools bundled with the Rust repository."
+homepage = "https://rust-lang-nursery.github.io/rust-toolstate/"
+bots = ["highfive"]
+
+[access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "master"
+pr-required = false


### PR DESCRIPTION
Backporting the following repos:


- [.github](https://github.com/rust-lang-nursery/.github)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-nursery"
    name = ".github"
    description = "GitHub metadata for this organization"
    bots = []

    [access.teams]

    [access.individuals]
    erickt = "admin"
    KodrAus = "admin"
    nikomatsakis = "admin"
    aidanhs = "admin"
    alexcrichton = "admin"
    kennytm = "admin"
    huonw = "admin"
    pietroalbini = "admin"
    steveklabnik = "admin"
    carols10cents = "admin"
    sfackler = "admin"
    nrc = "admin"
    marcoieni = "admin"
    Mark-Simulacrum = "admin"
    jdno = "admin"
    rust-lang-owner = "admin"
    nikomatsakis-admin = "admin"
    aturon = "admin"
    dtolnay = "admin"
    ```

    </details>

- [rust-lang-nursery.github.io](https://github.com/rust-lang-nursery/rust-lang-nursery.github.io)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-nursery"
    name = "rust-lang-nursery.github.io"
    description = "GitHub pages redirects"
    bots = []

    [access.teams]

    [access.individuals]
    Mark-Simulacrum = "admin"
    carols10cents = "admin"
    steveklabnik = "admin"
    aidanhs = "admin"
    nrc = "admin"
    huonw = "admin"
    pietroalbini = "admin"
    erickt = "admin"
    dtolnay = "admin"
    nikomatsakis = "admin"
    kennytm = "admin"
    aturon = "admin"
    KodrAus = "admin"
    jdno = "admin"
    nikomatsakis-admin = "admin"
    marcoieni = "admin"
    rust-lang-owner = "admin"
    alexcrichton = "admin"
    sfackler = "admin"
    ```

    </details>

- [rust-toolstate](https://github.com/rust-lang-nursery/rust-toolstate)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-lang-nursery"
    name = "rust-toolstate"
    description = "Records build and test status of external tools bundled with the Rust repository."
    bots = []

    [access.teams]
    bots = "write"
    infra = "admin"

    [access.individuals]
    Mark-Simulacrum = "admin"
    alexcrichton = "admin"
    marcoieni = "admin"
    kennytm = "admin"
    aturon = "admin"
    nrc = "admin"
    sfackler = "admin"
    pietroalbini = "admin"
    dtolnay = "admin"
    shepmaster = "admin"
    erickt = "admin"
    jdno = "admin"
    huonw = "admin"
    carols10cents = "admin"
    KodrAus = "admin"
    rust-highfive = "write"
    nikomatsakis-admin = "admin"
    aidanhs = "admin"
    Kobzol = "admin"
    steveklabnik = "admin"
    nikomatsakis = "admin"
    pietroalbini-cat = "write"
    rust-lang-owner = "admin"
    bors = "write"

    [[branch-protections]]
    pattern = "master"
    required-approvals = 0
    pr-required = false
    ```

    </details>

Not completely sure about `rust-toolstate`, I added access to `highfive`, it seems like bors access shouldn't be needed?