### PR TITLE
Backport archived rls-vfs repo

### DIFF
--- a/repos/archive/rust-dev-tools/rls-vfs.toml
+++ b/repos/archive/rust-dev-tools/rls-vfs.toml
@@ -1,0 +1,6 @@
+org = "rust-dev-tools"
+name = "rls-vfs"
+description = "Virtual File System for the RLS"
+bots = []
+
+[access.teams]


### PR DESCRIPTION
Backporting the following repos:


- [rls-vfs](https://github.com/rust-dev-tools/rls-vfs)
    <details markdown="1">
    <summary>Original content</summary>

    ```toml
    org = "rust-dev-tools"
    name = "rls-vfs"
    description = "Virtual File System for the RLS"
    bots = []

    [access.teams]

    [access.individuals]
    marcoieni = "admin"
    killercup = "admin"
    pietroalbini = "admin"
    rust-lang-owner = "admin"
    Manishearth = "admin"
    Xanewok = "admin"
    nrc = "admin"
    ```

    </details>
