### PR TITLE
Remove rust-lang/libtest-next

### DIFF
--- a/repos/rust-lang/libtest-next.toml
+++ b/repos/rust-lang/libtest-next.toml
@@ -1,8 +1,0 @@
-org = "rust-lang"
-name = "libtest-next"
-description = "T-testing-devex experiments for new testing tools for Rust developers"
-homepage = "https://docs.rs/pytest-rs"
-bots = ["rustbot", "rfcbot"]
-
-[access.teams]
-testing-devex = "write"


### PR DESCRIPTION
This was moved under rust-lang before T-testing-devex was aware of the crate ownership policy.
This is an experiment that we see being viable for long term support but we are unsure if we'd want to do that within the project or not. Considering the burden to Expatriate a package once published, we are moving the repo out of rust-lang so we can publish them and have the flexibility of having it maintained outside the project or later inside the project without having to abandon the name.

See
[zulip](https://rust-lang.zulipchat.com/#narrow/channel/404371-t-testing-devex/topic/crate.20ownership/near/513724212) for the discussion and decision.