### PR TITLE
Track the FLS repo

### DIFF
--- a/repos/rust-lang/fls.toml
+++ b/repos/rust-lang/fls.toml
@@ -1,0 +1,15 @@
+org = "rust-lang"
+name = "fls"
+description = "The FLS"
+homepage = "https://rust-lang.github.io/fls"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+lang = "write"
+lang-docs = "write"
+spec = "write"
+spec-contributors = "write"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = ["CI finished"]


### PR DESCRIPTION
Transferred the FLS repo from `ferrocene/specification` to `rust-lang/fls`. This will have the same permissions and access levels as the reference. cc @rust-lang/spec 