### PR TITLE
Allow automatically fetching Zulip ID for newly added users

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ cargo run add-person <github-username>
 
 You can also add additional information, such as someone's Discord or Zulip ID by adding additional fields to their `.toml` file.
 
-To determine someone's Zulip ID, find them in the list of people on the
+You can use the `--fetch-zulip-id` flag to automatically try to find the Zulip ID for the added user based on their GitHub login. This will only work if the user has linked their Zulip and GitHub accounts. You will need to get a [Zulip API key](https://zulip.com/api/api-keys#get-your-api-key) for this to work, and set the following environment variables:
+
+- `ZULIP_USER`: should be set to the e-mail address of your Zulip account
+- `ZULIP_TOKEN`: should be set to your API key
+
+If you need to determine someone's Zulip ID manually, find them in the list of people on the
 right-hand side in Zulip, click the "three dots" menu and then "View profile", and copy the 'User ID'
 into the toml file:
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -676,7 +676,7 @@ fn validate_discord_team_members_have_discord_ids(data: &Data, errors: &mut Vec<
 
 /// Ensure every member of a team that has a Zulip group has a Zulip id
 fn validate_zulip_users(data: &Data, zulip: &ZulipApi, errors: &mut Vec<String>) {
-    let by_id = match zulip.get_users() {
+    let by_id = match zulip.get_users(false) {
         Ok(u) => u.iter().map(|u| u.user_id).collect::<HashSet<_>>(),
         Err(err) => {
             errors.push(format!("couldn't verify Zulip users: {}", err));


### PR DESCRIPTION
I had to add a bunch of users recently (new GSoC contributors), and it was quite painful to lookup their Zulip IDs manually. This PR adds a flag to the `add-person` command to automate this (if possible).