### PR TITLE
Add branch protection to rust-log-analyzer

### DIFF
--- a/repos/rust-lang/rust-log-analyzer.toml
+++ b/repos/rust-lang/rust-log-analyzer.toml
@@ -5,3 +5,8 @@ bots = []
 
 [access.teams]
 infra = "write"
+
+[[branch-protections]]
+pattern = "master"
+ci-checks = ["CI"]
+required-approvals = 0


### PR DESCRIPTION
Also added a required CI check while we're at it, but didn't require approvals.