### PR TITLE
Add Karan Janthe to `gsoc-contributors`

### DIFF
--- a/people/KMJ-007.toml
+++ b/people/KMJ-007.toml
@@ -1,0 +1,4 @@
+name = "Karan Janthe"
+github = "KMJ-007"
+github-id = 86996507
+zulip-id = 888623

--- a/teams/gsoc-contributors.toml
+++ b/teams/gsoc-contributors.toml
@@ -22,7 +22,10 @@ members = [
     "DriedYellowPeach",
     "makai410",
     "Pyr0de",
-    "secona"
+    "secona",
+    # KMJ-007 is participating in LLVM GSoC 2025, but they are working on Rust related things
+    # Therefore, we include them here to give them access to the dev desktops
+    { github = "KMJ-007", roles = ["guest"] },
 ]
 alumni = [
     "d-sonuga",
@@ -38,6 +41,10 @@ alumni = [
 dev-desktop = true
 bors.rust.try = true
 perf = true
+
+[[roles]]
+id = "guest"
+description = "External GSoC contributor"
 
 [[zulip-groups]]
 name = "gsoc-contributors"


### PR DESCRIPTION
We were asked by Manuel Drehwald to add Karan Janthe to our GSoC contributors team, so that they can access the dev desktops. They are working on a LLVM GSoC project which is related to Rust.

I created a pseudo `guest` role to mark this distinction.

CC @jackh726 @ZuseZ4