### PR TITLE
Add website entry for GSoC contributors

### DIFF
--- a/teams/gsoc-contributors.toml
+++ b/teams/gsoc-contributors.toml
@@ -48,3 +48,7 @@ description = "External GSoC contributor"
 
 [[zulip-groups]]
 name = "gsoc-contributors"
+
+[website]
+name = "Rust Google Summer of Code contributors"
+description = "Contributors that have participated in Rust GSoC projects"


### PR DESCRIPTION
Since https://github.com/rust-lang/www.rust-lang.org/pull/2152, we show even marker teams with a `[website]` entry in the Governance section of the Rust website. This PR adds a website section for GSoC contributors, so that we can acknowledge their participation within the Project.

There's a small weirdness in that we now have the "external" LLVM contributor with the `guest` role, but I think that's fine. We could also rename the "guest" role to something like "LLVM GSoC contributor", so that the label displayed on the website makes a bit more sense.