### PR TITLE
Add GSoC 2025 mentors to the `mentors` team

### DIFF
--- a/people/cassaundra.toml
+++ b/people/cassaundra.toml
@@ -1,0 +1,4 @@
+name = "cassaundra"
+github = "cassaundra"
+github-id = 21976313
+zulip-id = 459226

--- a/people/tautschnig.toml
+++ b/people/tautschnig.toml
@@ -1,0 +1,4 @@
+name = "Michael Tautschnig"
+github = "tautschnig"
+github-id = 1144736
+zulip-id = 887765

--- a/teams/mentors.toml
+++ b/teams/mentors.toml
@@ -13,7 +13,17 @@ members = [
     "ytmimi",
     "oli-obk",
     "obi1kenobi",
-    "davidlattimore"
+    "davidlattimore",
+    "ZuseZ4",
+    "tautschnig",
+    "antoyo",
+    "onur-ozkan",
+    "SparrowLii",
+    "rami3l",
+    "tgross35",
+    "Veykril",
+    "celinval",
+    "cassaundra"
 ]
 alumni = []
 


### PR DESCRIPTION
I kept the mentors from GSoC 2024 (ytmimi and Jack), but we could also move them to Alumni, I don't think it matters that much.