### PR TITLE
Add `gsoc-contributors` as a subteam of `launching-pad`

### DIFF
--- a/teams/gsoc-contributors.toml
+++ b/teams/gsoc-contributors.toml
@@ -1,4 +1,5 @@
 name = "gsoc-contributors"
+subteam-of = "launching-pad"
 kind = "marker-team"
 
 [people]


### PR DESCRIPTION
I realized that we need to do this in order for the contributors to actually appear on the website. It's a bit of a hack, but I guess that currently any team that doesn't have a parent is in fact a child of the launching pad anyway.