### PR TITLE
Add Darksonn to wg-triage.toml

### DIFF
--- a/people/Darksonn.toml
+++ b/people/Darksonn.toml
@@ -1,4 +1,5 @@
 name = 'Alice Ryhl'
 github = 'Darksonn'
 github-id = 928074
+zulip-id = 218683
 email = 'alice@ryhl.io'

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -26,7 +26,8 @@ members = [
     "lolbinarycat",
     "alex-semenyuk",
     "LFS6502",
-    "gstjepan2"
+    "gstjepan2",
+    "Darksonn"
 ]
 alumni = []
 


### PR DESCRIPTION
This is so that I have the ability to modify tracking issues and add new links or tags to them. Using wg-triage for this was suggested to me by @jyn514.