### PR TITLE
Add support for `rust-timer` merge bot and `try-perf`/`perf-tmp` branch protections

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -39,14 +39,6 @@ pattern = "beta"
 merge-bots = ["homu"]
 
 [[branch-protections]]
-pattern = "try"
-merge-bots = ["homu"]
-
-[[branch-protections]]
-pattern = "auto"
-merge-bots = ["homu"]
-
-[[branch-protections]]
 pattern = "*"
 merge-bots = ["homu"]
 
@@ -65,3 +57,27 @@ pr-required = false
 [[branch-protections]]
 pattern = "automation/bors/try"
 pr-required = false
+
+# Required for running try builds created by homu.
+# Must support force-pushes.
+[[branch-protections]]
+pattern = "try"
+merge-bots = ["homu"]
+
+# Required for running auto (merge) builds created by homu.
+# Must support force-pushes.
+[[branch-protections]]
+pattern = "auto"
+merge-bots = ["homu"]
+
+# Required for unrolled PR builds created by perfbot.
+# Must support force-pushes.
+[[branch-protections]]
+pattern = "try-perf"
+merge-bots = ["rust-timer"]
+
+# Required for unrolled PR builds created by perfbot.
+# Must support force-pushes.
+[[branch-protections]]
+pattern = "perf-tmp"
+merge-bots = ["rust-timer"]

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -246,6 +246,7 @@ pub enum BranchProtectionMode {
 #[serde(rename_all = "snake_case")]
 pub enum MergeBot {
     Homu,
+    RustTimer,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -870,6 +870,7 @@ pub(crate) enum RepoPermission {
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum MergeBot {
     Homu,
+    RustTimer,
 }
 
 #[derive(serde_derive::Deserialize, Debug)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -66,6 +66,7 @@ impl<'a> Generator<'a> {
                         .iter()
                         .map(|bot| match bot {
                             MergeBot::Homu => v1::MergeBot::Homu,
+                            MergeBot::RustTimer => v1::MergeBot::RustTimer,
                         })
                         .collect(),
                 })


### PR DESCRIPTION
Required for https://github.com/rust-lang/infra-team/issues/188.

Note that `MergeBot` means "it merges stuff into branches", which is also done by `rust-timer`.