### PR TITLE
Unarchive gha-self-hosted

### DIFF
--- a/repos/rust-lang/gha-self-hosted.toml
+++ b/repos/rust-lang/gha-self-hosted.toml
@@ -4,3 +4,7 @@ description = "GitHub Actions self-hosted runners infrastructure"
 bots = []
 
 [access.teams]
+infra = "write"
+
+[[branch-protections]]
+pattern = "main"


### PR DESCRIPTION
As discussed at the All Hands, let's unarchive the gha-self-hosted repo, so that we can bring it to a working state again and do some benchmarks on it. We're not sure yet whether we actually want to start using it again though.