### PR TITLE
Add rustdoc team to rust-forge and triagebot maintenance

### DIFF
--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -17,6 +17,7 @@ libs = "maintain"
 libs-api = "maintain"
 edition = "maintain"
 release = "maintain"
+rustdoc = "maintain"
 triagebot = "maintain"
 
 [[branch-protections]]


### PR DESCRIPTION
Suggested by @ehuss in https://github.com/rust-lang/rust-forge/pull/852#issuecomment-2898439546.

Hopefully I correctly understood what they meant.

r? @ehuss 