### PR TITLE
add dev desktop access to docs.rs team members

### DIFF
--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -18,6 +18,10 @@ alumni = [
     "QuietMisdreavus",
 ]
 
+[permissions]
+dev-desktop = true
+
+
 [[github]]
 orgs = ["rust-lang", "rust-lang-nursery"]
 


### PR DESCRIPTION
I hope podman is enough, 

this would make development much faster when testing the docs.rs build process, 
and also rustwide tests / changes. 

