### PR TITLE
Remove mentions of rust-lang-ci

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -69,14 +69,6 @@ jobs:
           # Set the owner, so the token can be used in all repositories
           owner: rust-lang
 
-      - name: Generate GitHub token (rust-lang-ci)
-        uses: actions/create-github-app-token@v1
-        id: rust-lang-ci-token
-        with:
-          app-id: ${{ secrets.SYNC_TEAM_GH_APP_ID }}
-          private-key: ${{ secrets.SYNC_TEAM_GH_APP_PRIVATE_KEY }}
-          owner: rust-lang-ci
-
       - name: Generate GitHub token (rust-lang-deprecated)
         uses: actions/create-github-app-token@v1
         id: rust-lang-deprecated-token
@@ -128,7 +120,6 @@ jobs:
       - name: Run sync-team dry-run check
         env:
           GITHUB_TOKEN_RUST_LANG: ${{ steps.rust-lang-token.outputs.token }}
-          GITHUB_TOKEN_RUST_LANG_CI: ${{ steps.rust-lang-ci-token.outputs.token }}
           GITHUB_TOKEN_RUST_LANG_DEPRECATED: ${{ steps.rust-lang-deprecated-token.outputs.token }}
           GITHUB_TOKEN_RUST_LANG_NURSERY: ${{ steps.rust-lang-nursery-token.outputs.token }}
           GITHUB_TOKEN_BORS_RS: ${{ steps.bors-rs-token.outputs.token }}

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,6 @@ allowed-mailing-lists-domains = [
 
 allowed-github-orgs = [
     "rust-lang",
-    "rust-lang-ci",
     "rust-lang-nursery",
     "rust-lang-deprecated",
     "rust-dev-tools",

--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -31,7 +31,7 @@ alumni = [
 ]
 
 [[github]]
-orgs = ["rust-lang", "rust-lang-ci", "rust-lang-nursery"]
+orgs = ["rust-lang", "rust-lang-nursery"]
 
 [permissions]
 perf = true


### PR DESCRIPTION
Shouldn't be needed anymore after https://github.com/rust-lang/infra-team/issues/188 (let's wait a few days before merging though).