### PR TITLE
Rotate dev guide leadership

### DIFF
--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -3,7 +3,7 @@ subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["JohnTitor", "spastorino"]
+leads = ["BoxyUwU", "jieyouxu"]
 members = [
     "JohnTitor",
     "camelid",


### PR DESCRIPTION
As discussed in https://rust-lang.zulipchat.com/#narrow/channel/196385-t-compiler.2Frustc-dev-guide/topic/Future.20of.20this.20wg/with/520076018 we are rotating leadership as first step.
We are evaluating what to do mid/long term with this working group.