### PR TITLE
let anyone in the org approve PRs to Forge

### DIFF
--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -5,19 +5,7 @@ homepage = "https://forge.rust-lang.org/"
 bots = ["rustbot"]
 
 [access.teams]
-community = "maintain"
-compiler = "maintain"
-crates-io = "maintain"
-docs-rs = "maintain"
-infra = "maintain"
-lang = "maintain"
-lang-ops = "maintain"
-leadership-council = "maintain"
-libs = "maintain"
-libs-api = "maintain"
-edition = "maintain"
-release = "maintain"
-triagebot = "maintain"
+all = "maintain"
 
 [[branch-protections]]
 pattern = "master"

--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -5,7 +5,8 @@ homepage = "https://forge.rust-lang.org/"
 bots = ["rustbot"]
 
 [access.teams]
-all = "maintain"
+all = "write"
+infra = "maintain"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
forge is for everyone, so don't restrict it. in any case, there is very little downside to "eagerly" merging documentation prs, since it's easy to fix them in followups and they can't cause nightly breakage.

cc [#council > who maintains cross-team documentation?](https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/who.20maintains.20cross-team.20documentation.3F/with/519391178), [#t-infra > default writable repos @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/default.20writable.20repos/near/518914499)