### PR TITLE
Simplify comment implementation in dry-run

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -166,14 +166,6 @@ jobs:
         run: |
           PR=${PR_NUMBER}
           echo "Pull request ${PR}"
-
-          # --edit-last doesn't work if there is no previous comment, so we have to figure out
-          # if we should create a comment or not
-          if gh issue view ${PR} --repo rust-lang/team --json comments \
-            --jq '.comments.[].author.login' | grep --quiet --fixed-strings "github-actions"; then
-            echo "Editing comment"
-            gh pr comment ${PR} --repo rust-lang/team --body-file comment.txt --edit-last
-          else
-            echo "Creating new comment"
-            gh pr comment ${PR} --repo rust-lang/team --body-file comment.txt
-          fi
+          gh pr comment ${PR} --repo rust-lang/team --body-file comment.txt \
+            --edit-last \
+            --create-if-none


### PR DESCRIPTION
[gh pr comment](https://cli.github.com/manual/gh_pr_comment) now takes `--create-if-none` option, so we can avoid this complicated dance.