### PR TITLE
add jyn514 back to rustc-dev-guide

### DIFF
--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -12,8 +12,9 @@ members = [
     "tshepang",
     "BoxyUwU",
     "jieyouxu",
+    "jyn514",
 ]
-alumni = ["LeSeulArtichaut", "Nashenas88", "amanjeev", "chrissimpkins", "jyn514", "mark-i-m", "rylev", "togiberlin", "pierwill"]
+alumni = ["LeSeulArtichaut", "Nashenas88", "amanjeev", "chrissimpkins", "mark-i-m", "rylev", "togiberlin", "pierwill"]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
i want to do a bunch of work around stability, the unstable-book, and forge. we don't really have a team for any of that, but rustc-dev-guide seems close enough.

can someone confirm that this will *not* give me r+ for rust-lang/rust? i don't want that access.