### PR TITLE
Add back two removed homepages

### DIFF
--- a/repos/archive/rust-lang-nursery/cli-wg.toml
+++ b/repos/archive/rust-lang-nursery/cli-wg.toml
@@ -1,6 +1,7 @@
 org = "rust-lang-nursery"
 name = "cli-wg"
 description = "The only purpose of this is to redirect old links to"
+homepage = "https://rust-cli.github.io/book/index.html"
 bots = []
 
 [access.teams]

--- a/repos/archive/rust-lang-nursery/futures-api-docs.toml
+++ b/repos/archive/rust-lang-nursery/futures-api-docs.toml
@@ -1,6 +1,7 @@
 org = "rust-lang-nursery"
 name = "futures-api-docs"
 description = "API docs for futures-rs"
+homepage = "https://rust-lang-nursery.github.io/futures-api-docs"
 bots = []
 
 [access.teams]


### PR DESCRIPTION
I noticed in the dry-run results of https://github.com/rust-lang/team/pull/1797 that two homepages were removed, I missed that. I think that my backporting scripts skipped some homepages. It didn't seem to happen in the other recently merged PRs, only here.