### PR TITLE
Add back branch protection for `expect-test`

### DIFF
--- a/repos/rust-analyzer/expect-test.toml
+++ b/repos/rust-analyzer/expect-test.toml
@@ -8,4 +8,4 @@ rust-analyzer = "write"
 
 [[branch-protections]]
 pattern = "master"
-pr-required = false
+ci-checks = ["test"]


### PR DESCRIPTION
The [expect-test](https://github.com/rust-analyzer/expect-test) repo had quite weird branch protections (https://github.com/rust-lang/team/pull/1805): both `pr-required = false` and non-empty `ci-checks`. In https://github.com/rust-lang/team/pull/1805, I removed the CI check, but I think it actually makes more sense to require PRs and the CI check, unless someone asks for the opposite.