### PR TITLE
Add `expect-test` team

### DIFF
--- a/people/quad.toml
+++ b/people/quad.toml
@@ -1,0 +1,4 @@
+name = "Scott Robinson"
+github = "quad"
+github-id = 24025
+zulip-id = 705090

--- a/repos/rust-analyzer/expect-test.toml
+++ b/repos/rust-analyzer/expect-test.toml
@@ -5,6 +5,7 @@ bots = []
 
 [access.teams]
 rust-analyzer = "write"
+expect-test = "write"
 
 [[branch-protections]]
 pattern = "master"

--- a/teams/expect-test.toml
+++ b/teams/expect-test.toml
@@ -1,0 +1,10 @@
+name = "expect-test"
+kind = "marker-team"
+
+[people]
+leads = ["quad"]
+members = ["quad"]
+alumni = []
+
+[[github]]
+orgs = ["rust-analyzer"]


### PR DESCRIPTION
After https://github.com/rust-lang/team/pull/1805, @quad no longer access to maintain the `expect-test` repository. In [#t-compiler/rust-analyzer > Rust-analyzer org repository access and status @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Rust-analyzer.20org.20repository.20access.20and.20status/near/521110084), we have discussed how to resolve this situation, and the outcome was to create a `expect-test` team that would be responsible only for this repository.

We can do this in two ways, I suppose:
- Create a marker team (which is what this PR does)
- Create the team as a subteam of `rust-analyzer` (?), and add a website entry for it

The second approach seemed a bit heavyweight for a tiny team designed to maintain a single small Rust Analyzer dependency, so I went with the first.