### PR TITLE
Create internal repository for collecting feedback

### DIFF
--- a/repos/rust-lang/github-feedback.toml
+++ b/repos/rust-lang/github-feedback.toml
@@ -1,0 +1,9 @@
+org = "rust-lang"
+name = "github-feedback"
+description = "Feedback and feature requests for GitHub"
+bots = []
+private-non-synced = true
+
+[access.teams]
+infra = "maintain"
+all = "triage"


### PR DESCRIPTION
The infra-team has a regular call with GitHub, which allows us to bring issues or feature requests to their attention. In the past, we've collected this feedback ad-hoc in Zulip, but that process does not scale.

As an experiment, we are creating an internal repository to collect the feedback in GitHub Issues. The repository itself is private to clearly indicate that this is only for feedback from the project and not the general public.