### PR TITLE
Add triagebot to rust-lang/rustdoc-types.

### DIFF
--- a/repos/rust-lang/rustdoc-types.toml
+++ b/repos/rust-lang/rustdoc-types.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "rustdoc-types"
 description = "Rustdoc's JSON output interface"
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 rustdoc = "write"


### PR DESCRIPTION
We want to have him to post reminders that most PR's to this repo should be filed to rust-lang/rust instead.

[Zulip Discussion](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/Triagebot.20for.20rust-lang.2Frustdoc-types/with/522207551)