### PR TITLE
Sync organization members

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,12 @@ allowed-github-orgs = [
     "rust-analyzer",
 ]
 
+# GitHub organizations where member management is independent
+# and should not be automatically synchronized
+independent-github-orgs = [
+    "rust-embedded",
+]
+
 permissions-bors-repos = [
     "bors-kindergarten",
     "rust",
@@ -26,4 +32,26 @@ permissions-bools = [
     "crates-io-admin",
     "dev-desktop",
     "sync-team-confirmation",
+]
+
+# GitHub accounts that are allowed to stay in the GitHub organizations,
+# even if they may not be members of any team.
+# Note: Infra admins are automatically included from the infra-admins team.
+special-org-members = [
+    # Bots.
+    "bors",
+    "craterbot",
+    "rust-embedded-bot",
+    "rust-highfive",
+    "rust-lang-core-team-agenda-bot",
+    "rust-lang-glacier-bot",
+    "rust-lang-owner",
+    "rust-log-analyzer",
+    "rust-timer",
+    "rustbot",
+
+    # Ferrous systems employees who manage the github sponsors
+    # for rust-analyzer.
+    "MissHolmes",
+    "skade",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -590,5 +590,11 @@ fn perform_sync(opts: SyncOpts, data: Data) -> anyhow::Result<()> {
     let subcmd = opts.command.unwrap_or(SyncCommand::DryRun);
     let only_print_plan = matches!(subcmd, SyncCommand::PrintPlan);
     let dry_run = only_print_plan || matches!(subcmd, SyncCommand::DryRun);
-    run_sync_team(team_api, &services, dry_run, only_print_plan)
+    run_sync_team(
+        team_api,
+        &services,
+        dry_run,
+        only_print_plan,
+        data.get_sync_team_config()?,
+    )
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,15 +3,18 @@ pub(crate) use crate::permissions::Permissions;
 use anyhow::{bail, format_err, Error};
 use serde::de::{Deserialize, Deserializer};
 use serde_untagged::UntaggedEnumVisitor;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Config {
     allowed_mailing_lists_domains: HashSet<String>,
     allowed_github_orgs: HashSet<String>,
+    independent_github_orgs: BTreeSet<String>,
     permissions_bors_repos: HashSet<String>,
     permissions_bools: HashSet<String>,
+    // Use a BTreeSet for consistent ordering in tests
+    special_org_members: BTreeSet<String>,
 }
 
 impl Config {
@@ -29,6 +32,14 @@ impl Config {
 
     pub(crate) fn permissions_bools(&self) -> &HashSet<String> {
         &self.permissions_bools
+    }
+
+    pub(crate) fn independent_github_orgs(&self) -> &BTreeSet<String> {
+        &self.independent_github_orgs
+    }
+
+    pub(crate) fn special_org_members(&self) -> &BTreeSet<String> {
+        &self.special_org_members
     }
 }
 

--- a/sync-team/src/github/api/write.rs
+++ b/sync-team/src/github/api/write.rs
@@ -344,6 +344,18 @@ impl GitHubWrite {
         Ok(())
     }
 
+    /// Remove a member from an org
+    pub(crate) fn remove_gh_member_from_org(&self, org: &str, user: &str) -> anyhow::Result<()> {
+        debug!("Removing user {user} from org {org}");
+        if !self.dry_run {
+            let method = Method::DELETE;
+            let url = GitHubUrl::orgs(org, &format!("members/{user}"))?;
+            let resp = self.client.req(method.clone(), &url)?.send()?;
+            allow_not_found(resp, method, url.url())?;
+        }
+        Ok(())
+    }
+
     /// Remove a collaborator from a repo
     pub(crate) fn remove_collaborator_from_repo(
         &self,

--- a/sync-team/src/github/mod.rs
+++ b/sync-team/src/github/mod.rs
@@ -6,7 +6,7 @@ use self::api::{BranchProtectionOp, TeamPrivacy, TeamRole};
 use crate::github::api::{GithubRead, Login, PushAllowanceActor, RepoPermission, RepoSettings};
 use log::debug;
 use rust_team_data::v1::{Bot, BranchProtectionMode, MergeBot};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Write;
 
 pub(crate) use self::api::{GitHubApiRead, GitHubWrite, HttpClient};
@@ -31,6 +31,7 @@ struct SyncGitHub {
     repos: Vec<rust_team_data::v1::Repo>,
     usernames_cache: HashMap<u64, String>,
     org_owners: HashMap<OrgName, HashSet<u64>>,
+    org_members: HashMap<OrgName, HashMap<u64, String>>,
 }
 
 impl SyncGitHub {
@@ -60,9 +61,11 @@ impl SyncGitHub {
             .collect::<HashSet<_>>();
 
         let mut org_owners = HashMap::new();
+        let mut org_members = HashMap::new();
 
         for org in &orgs {
             org_owners.insert((*org).to_string(), github.org_owners(org)?);
+            org_members.insert((*org).to_string(), github.org_members(org)?);
         }
 
         Ok(SyncGitHub {
@@ -71,17 +74,72 @@ impl SyncGitHub {
             repos,
             usernames_cache,
             org_owners,
+            org_members,
         })
     }
 
     pub(crate) fn diff_all(&self) -> anyhow::Result<Diff> {
         let team_diffs = self.diff_teams()?;
         let repo_diffs = self.diff_repos()?;
+        let org_membership_diffs = self.diff_org_memberships()?;
 
         Ok(Diff {
             team_diffs,
             repo_diffs,
+            org_membership_diffs,
         })
+    }
+
+    // Collect all org members from the respective teams
+    fn get_org_members_from_teams(&self) -> HashMap<OrgName, HashSet<u64>> {
+        let mut org_team_members: HashMap<OrgName, HashSet<u64>> = HashMap::new();
+
+        for team in &self.teams {
+            if let Some(gh) = &team.github {
+                for toml_gh_team in &gh.teams {
+                    org_team_members
+                        .entry(toml_gh_team.org.clone())
+                        .or_default()
+                        .extend(toml_gh_team.members.iter().copied());
+                }
+            }
+        }
+        org_team_members
+    }
+
+    // Diff organization memberships between TOML teams and GitHub
+    fn diff_org_memberships(&self) -> anyhow::Result<Vec<OrgMembershipDiff>> {
+        let toml_org_team_members = self.get_org_members_from_teams();
+
+        let mut org_diffs: BTreeMap<String, OrgMembershipDiff> = BTreeMap::new();
+
+        for (org, toml_members) in toml_org_team_members {
+            let Some(gh_org_members) = self.org_members.get(&org) else {
+                panic!("GitHub organization {org} not found");
+            };
+
+            // Remove all members that are in TOML teams
+            let mut members_to_remove = gh_org_members.clone();
+            for member in toml_members {
+                members_to_remove.remove(&member);
+            }
+
+            // The rest are members that should be removed
+            if !members_to_remove.is_empty() {
+                let mut members_to_remove: Vec<String> = members_to_remove.into_values().collect();
+                members_to_remove.sort();
+
+                org_diffs.insert(
+                    org.clone(),
+                    OrgMembershipDiff {
+                        org,
+                        members_to_remove,
+                    },
+                );
+            }
+        }
+
+        Ok(org_diffs.into_values().collect())
     }
 
     fn diff_teams(&self) -> anyhow::Result<Vec<TeamDiff>> {
@@ -604,6 +662,7 @@ const BOTS_TEAMS: &[&str] = &["bors", "highfive", "rfcbot", "bots"];
 pub(crate) struct Diff {
     team_diffs: Vec<TeamDiff>,
     repo_diffs: Vec<RepoDiff>,
+    org_membership_diffs: Vec<OrgMembershipDiff>,
 }
 
 impl Diff {
@@ -615,12 +674,17 @@ impl Diff {
         for repo_diff in self.repo_diffs {
             repo_diff.apply(sync)?;
         }
+        for org_diff in self.org_membership_diffs {
+            org_diff.apply(sync)?;
+        }
 
         Ok(())
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.team_diffs.is_empty() && self.repo_diffs.is_empty()
+        self.team_diffs.is_empty()
+            && self.repo_diffs.is_empty()
+            && self.org_membership_diffs.is_empty()
     }
 }
 
@@ -637,6 +701,13 @@ impl std::fmt::Display for Diff {
             writeln!(f, "💻 Repo Diffs:")?;
             for repo_diff in &self.repo_diffs {
                 write!(f, "{repo_diff}")?;
+            }
+        }
+
+        if !&self.org_membership_diffs.is_empty() {
+            writeln!(f, "💻 Org membership Diffs:")?;
+            for org_diff in &self.org_membership_diffs {
+                write!(f, "{org_diff}")?;
             }
         }
 
@@ -672,6 +743,34 @@ impl std::fmt::Display for RepoDiff {
             Self::Create(c) => write!(f, "{c}"),
             Self::Update(u) => write!(f, "{u}"),
         }
+    }
+}
+
+#[derive(Debug)]
+struct OrgMembershipDiff {
+    org: OrgName,
+    members_to_remove: Vec<String>,
+}
+
+impl OrgMembershipDiff {
+    fn apply(self, sync: &GitHubWrite) -> anyhow::Result<()> {
+        for member in &self.members_to_remove {
+            sync.remove_gh_member_from_org(&self.org, &member)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for OrgMembershipDiff {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.members_to_remove.is_empty() {
+            writeln!(f, "❌ Removing the following members from `{}`:", self.org)?;
+            for member in &self.members_to_remove {
+                writeln!(f, "  - {member}",)?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/sync-team/src/github/tests/mod.rs
+++ b/sync-team/src/github/tests/mod.rs
@@ -98,6 +98,28 @@ fn team_dont_add_member_if_invitation_is_pending() {
 }
 
 #[test]
+fn remove_org_members() {
+    let mut model = DataModel::default();
+    let user = model.create_user("sakura");
+    model.create_team(TeamData::new("team-1").gh_team("rust-lang", "members-gh", &[user]));
+    let mut gh = model.gh_model();
+    gh.add_member("rust-lang", "martin");
+
+    let gh_org_diff = model.diff_org_membership(gh);
+
+    insta::assert_debug_snapshot!(gh_org_diff, @r#"
+    [
+        OrgMembershipDiff {
+            org: "rust-lang",
+            members_to_remove: [
+                "martin",
+            ],
+        },
+    ]
+    "#);
+}
+
+#[test]
 fn team_remove_member() {
     let mut model = DataModel::default();
     let user = model.create_user("mark");

--- a/sync-team/src/github/tests/test_utils.rs
+++ b/sync-team/src/github/tests/test_utils.rs
@@ -10,7 +10,8 @@ use crate::github::api::{
     BranchProtection, GithubRead, Repo, RepoTeam, RepoUser, Team, TeamMember, TeamPrivacy, TeamRole,
 };
 use crate::github::{
-    RepoDiff, SyncGitHub, TeamDiff, api, construct_branch_protection, convert_permission,
+    OrgMembershipDiff, RepoDiff, SyncGitHub, TeamDiff, api, construct_branch_protection,
+    convert_permission,
 };
 
 pub const DEFAULT_ORG: &str = "rust-lang";
@@ -105,7 +106,13 @@ impl DataModel {
                     slug: gh_team.name.clone(),
                 });
 
-                org.members.extend(gh_team.members.iter().copied());
+                org.members.extend(
+                    gh_team
+                        .members
+                        .iter()
+                        .copied()
+                        .map(|user_id| (user_id, users[&user_id].clone())),
+                );
             }
         }
 
@@ -166,6 +173,12 @@ impl DataModel {
         }
 
         GithubMock { users, orgs }
+    }
+
+    pub fn diff_org_membership(&self, github: GithubMock) -> Vec<OrgMembershipDiff> {
+        self.create_sync(github)
+            .diff_org_memberships()
+            .expect("Cannot diff org membership")
     }
 
     pub fn diff_teams(&self, github: GithubMock) -> Vec<TeamDiff> {
@@ -418,6 +431,16 @@ pub struct GithubMock {
 }
 
 impl GithubMock {
+    pub fn add_member(&mut self, org: &str, username: &str) {
+        let user_id = self.users.len() as UserId;
+        self.users.insert(user_id, username.to_string());
+        self.orgs
+            .get_mut(org)
+            .unwrap()
+            .members
+            .insert((user_id, username.to_string()));
+    }
+
     pub fn add_invitation(&mut self, org: &str, repo: &str, user: &str) {
         self.get_org_mut(org)
             .team_invitations
@@ -455,6 +478,10 @@ impl GithubRead for GithubMock {
 
     fn org_owners(&self, org: &str) -> anyhow::Result<HashSet<UserId>> {
         Ok(self.get_org(org).owners.iter().copied().collect())
+    }
+
+    fn org_members(&self, org: &str) -> anyhow::Result<HashMap<u64, String>> {
+        Ok(self.get_org(org).members.iter().cloned().collect())
     }
 
     fn org_teams(&self, org: &str) -> anyhow::Result<Vec<(String, String)>> {
@@ -549,7 +576,7 @@ impl GithubRead for GithubMock {
 
 #[derive(Default)]
 struct GithubOrg {
-    members: BTreeSet<UserId>,
+    members: BTreeSet<(UserId, String)>,
     owners: BTreeSet<UserId>,
     teams: Vec<Team>,
     // Team name -> list of invited users

--- a/tests/static-api/_expected/v1/people.json
+++ b/tests/static-api/_expected/v1/people.json
@@ -1,5 +1,10 @@
 {
   "people": {
+    "test-admin": {
+      "name": "Test Admin",
+      "email": "test-admin@example.com",
+      "github_id": 7
+    },
     "user-0": {
       "name": "Zeroth user",
       "email": "user0@example.com",

--- a/tests/static-api/_expected/v1/teams.json
+++ b/tests/static-api/_expected/v1/teams.json
@@ -75,6 +75,24 @@
     "roles": [],
     "discord": []
   },
+  "infra-admins": {
+    "name": "infra-admins",
+    "kind": "marker_team",
+    "subteam_of": null,
+    "members": [
+      {
+        "name": "Test Admin",
+        "github": "test-admin",
+        "github_id": 7,
+        "is_lead": false
+      }
+    ],
+    "alumni": [],
+    "github": null,
+    "website_data": null,
+    "roles": [],
+    "discord": []
+  },
   "leaderless": {
     "name": "leaderless",
     "kind": "team",

--- a/tests/static-api/_expected/v1/teams/infra-admins.json
+++ b/tests/static-api/_expected/v1/teams/infra-admins.json
@@ -1,0 +1,18 @@
+{
+  "name": "infra-admins",
+  "kind": "marker_team",
+  "subteam_of": null,
+  "members": [
+    {
+      "name": "Test Admin",
+      "github": "test-admin",
+      "github_id": 7,
+      "is_lead": false
+    }
+  ],
+  "alumni": [],
+  "github": null,
+  "website_data": null,
+  "roles": [],
+  "discord": []
+}

--- a/tests/static-api/config.toml
+++ b/tests/static-api/config.toml
@@ -6,6 +6,10 @@ allowed-github-orgs = [
     "test-org",
 ]
 
+independent-github-orgs = [
+    "org-independent",
+]
+
 permissions-bors-repos = [
     "crates-io",
     "crater",
@@ -13,4 +17,8 @@ permissions-bors-repos = [
 
 permissions-bools = [
     "crater",
+]
+
+special-org-members = [
+    "test-bot",
 ]

--- a/tests/static-api/people/test-admin.toml
+++ b/tests/static-api/people/test-admin.toml
@@ -1,0 +1,4 @@
+name = 'Test Admin'
+github = 'test-admin'
+github-id = 7
+email = 'test-admin@example.com'

--- a/tests/static-api/teams/infra-admins.toml
+++ b/tests/static-api/teams/infra-admins.toml
@@ -1,0 +1,9 @@
+name = "infra-admins"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "test-admin",
+]
+alumni = []


### PR DESCRIPTION
Re-submitting #1866 *again* as requested:

> This PR finishes the work from https://github.com/rust-lang/sync-team/pull/91 (I used @me-diru's code, adapted it to the modified codebase and marked them as an author).
>
> I guess that it would be good to repost this PR by an infra-admin, so that we could get a dry-run for it.
>
> Fixes: https://github.com/rust-lang/team/issues/1731

cc @Kobzol 

- [x] Reach out to people that we are removing to thank them for their work and explain why we are removing them

Discussed in [#t-infra > removing inactive members from the org](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/removing.20inactive.20members.20from.20the.20org/with/528798074).