### PR TITLE
Add panstromek and James Barford into the compiler performance working area

### DIFF
--- a/people/Jamesbarford.toml
+++ b/people/Jamesbarford.toml
@@ -1,0 +1,4 @@
+name = "James"
+github = "Jamesbarford"
+github-id = 29375815
+zulip-id = 867413

--- a/people/panstromek.toml
+++ b/people/panstromek.toml
@@ -1,0 +1,4 @@
+name = "Matyáš Racek"
+github = "panstromek"
+github-id = 25121817
+zulip-id = 208862

--- a/teams/wg-compiler-performance.toml
+++ b/teams/wg-compiler-performance.toml
@@ -12,6 +12,8 @@ members = [
     "lqd",
     "nnethercote",
     "Zoxc",
+    "panstromek",
+    "Jamesbarford"
 ]
 alumni = [
     "michaelwoerister",


### PR DESCRIPTION
We would like to invite @panstromek and @jamesbarford to the compiler performance working area. I asked both privately and they agreed to join.

panstromek has been doing great work with the performance triage, and James is now working on the [multiple-machine benchmarking](https://rust-lang.github.io/rust-project-goals/2025h1/perf-improvements.html) Rust Project Goal, which should make the latency of getting perf. results much shorter, and enable us to benchmark more things (including ARM machines).

Welcome! :tada:

CC @rust-lang/wg-compiler-performance