### PR TITLE
Update crates.io on-call team

### DIFF
--- a/people/Xylakant.toml
+++ b/people/Xylakant.toml
@@ -1,4 +1,0 @@
-name = 'Felix Gilcher'
-github = 'Xylakant'
-github-id = 337823
-zulip-id = 534379

--- a/people/justahero.toml
+++ b/people/justahero.toml
@@ -1,4 +1,0 @@
-name = 'Sebastian Ziebell'
-github = 'justahero'
-github-id = 1305185
-zulip-id = 529812

--- a/people/listochkin.toml
+++ b/people/listochkin.toml
@@ -1,4 +1,0 @@
-name = 'Андрей Листочкин (Andrei Listochkin)'
-github = 'listochkin'
-github-id = 405222
-zulip-id = 499958

--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -1,18 +1,18 @@
 name = "crates-io-on-call"
-# Note: This team is composed of contractors and thus not part of the Rust project.
+# Note: This team is composed of employees of the Rust Foundation.
 # Therefore, we label this as a marker team and not a subteam of crates.io
 kind = "marker-team"
 
 [people]
 leads = []
 members = [
-    "skade",
-    "Xylakant",
-    "justahero",
-    "pietroalbini",
-    "listochkin",
-    "tshepang",
-    "Veykril",
+    "baumanj",
+    "jdno",
+    "JoelMarcey",
+    "LawnGnome",
+    "marcoieni",
+    "Turbo87",
+    "walterhpearce",
 ]
 
 [[github]]


### PR DESCRIPTION
The Rust Foundation has taken over the on-call support for crates.io and the marker team has been updated to give its engineers access to the relevant GitHub resources.