### PR TITLE
use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -356,7 +356,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -910,7 +910,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1008,12 +1008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,11 +1071,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1116,9 +1109,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -1131,26 +1124,26 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.98",
+ "syn",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1197,7 +1190,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1214,9 +1207,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
@@ -1581,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -1594,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1629,7 +1622,7 @@ checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1731,17 +1724,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -1786,7 +1768,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1840,7 +1822,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1896,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2160,7 +2142,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2194,7 +2176,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2499,7 +2481,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "synstructure",
 ]
 
@@ -2520,7 +2502,7 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2540,7 +2522,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "synstructure",
 ]
 
@@ -2569,5 +2551,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,31 +4,31 @@ edition = '2021'
 license.workspace = true
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-base64 = "0.22"
-clap = { version = "4.5", features = ["derive"] }
-dialoguer = "0.10.1"
-env_logger = { version = "0.9.0", default-features = false }
-indexmap = "2"
-log = "0.4"
-regex = "1.5.5"
-reqwest = { version = "0.12", features = ["json", "blocking"] }
-rust_team_data = { path = "rust_team_data", features = ["email-encryption"] }
-serde = "1"
-serde_derive = "1"
-serde_json = "1"
-serde-untagged = "0.1"
-tempfile = "3.19.1"
-toml = "0.8"
+anyhow = { workspace = true, features = ["backtrace"] }
+base64.workspace = true
+clap = { workspace = true, features = ["derive"] }
+dialoguer.workspace = true
+env_logger = { workspace = true, default-features = false }
+indexmap.workspace = true
+log.workspace = true
+regex.workspace = true
+reqwest = { workspace = true, features = ["json", "blocking"], default-features = true }
+rust_team_data = { workspace = true, features = ["email-encryption"] }
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+serde-untagged.workspace = true
+tempfile.workspace = true
+toml.workspace = true
 
-sync-team = { path = "sync-team" }
+sync-team.workspace = true
 
 [dev-dependencies]
-ansi_term = "0.12.1"
-atty = "0.2.14"
-difference = "2.0.0"
-duct = "0.13.4"
-walkdir = "2.3.1"
+ansi_term.workspace = true
+atty.workspace = true
+difference.workspace = true
+duct.workspace = true
+walkdir.workspace = true
 
 [workspace]
 members = [
@@ -38,3 +38,34 @@ members = [
 
 [workspace.package]
 license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+anyhow = "1.0"
+ansi_term = "0.12.1"
+atty = "0.2.14"
+base64 = "0.22"
+chacha20poly1305 = "0.9.0"
+clap = "4.5"
+derive_builder = "0.20.2"
+dialoguer = "0.10.1"
+difference = "2.0.0"
+duct = "0.13.4"
+env_logger = { version = "0.9.0", default-features = false }
+getrandom = "0.2.1"
+hex = "0.4.2"
+hyper-old-types = "0.11"
+indexmap = "2.6.0"
+insta = "1.40.0"
+log = "0.4"
+regex = "1.5.5"
+reqwest = { version = "0.12.8", default-features = false }
+rust_team_data = { path = "rust_team_data" }
+secrecy = "0.10"
+serde = "1.0.85"
+serde_derive = "1.0"
+serde_json = "1.0"
+serde-untagged = "0.1"
+sync-team = { path = "sync-team" }
+tempfile = "3.19.1"
+toml = "0.8"
+walkdir = "2.3.1"

--- a/rust_team_data/Cargo.toml
+++ b/rust_team_data/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license.workspace = true
 
 [dependencies]
-chacha20poly1305 = { version = "0.9.0", optional = true }
-getrandom = { version = "0.2.1", optional = true }
-hex = { version = "0.4.2", optional = true }
-indexmap = { version = "2", features = ["serde"] }
-serde = { version = "1.0.85", features = ["derive"] }
+chacha20poly1305 = { workspace = true, optional = true }
+getrandom = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+indexmap = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
 
 [features]
 email-encryption = ["chacha20poly1305", "getrandom", "hex"]

--- a/sync-team/Cargo.toml
+++ b/sync-team/Cargo.toml
@@ -5,17 +5,17 @@ authors = ["Pietro Albini <pietro@pietroalbini.org>"]
 edition = "2024"
 
 [dependencies]
-reqwest = { version = "0.12.8", features = ["blocking", "json", "rustls-tls", "charset", "http2", "macos-system-configuration"], default-features = false }
-log = "0.4"
-rust_team_data = { path = "../rust_team_data", features = ["email-encryption"] }
-serde = { version = "1.0", features = ["derive"] }
-anyhow = "1.0"
-base64 = "0.22"
-hyper-old-types = "0.11"
-serde_json = "1.0"
-secrecy = "0.10"
+reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls", "charset", "http2", "macos-system-configuration"], default-features = false }
+log.workspace = true
+rust_team_data = { workspace = true, features = ["email-encryption"] }
+serde = { workspace = true, features = ["derive"] }
+anyhow.workspace = true
+base64.workspace = true
+hyper-old-types.workspace = true
+serde_json.workspace = true
+secrecy.workspace = true
 
 [dev-dependencies]
-indexmap = "2.6.0"
-derive_builder = "0.20.2"
-insta = "1.40.0"
+indexmap.workspace = true
+derive_builder.workspace = true
+insta.workspace = true


### PR DESCRIPTION
This avoids having different dependency versions among crates