### PR TITLE
Give libs and libs-contributors write access to wg-allocators

### DIFF
--- a/repos/rust-lang/wg-allocators.toml
+++ b/repos/rust-lang/wg-allocators.toml
@@ -5,4 +5,7 @@ homepage = "http://bit.ly/hello-wg-allocators"
 bots = []
 
 [access.teams]
+libs = "write"
+libs-api = "write"
+libs-contributors = "write"
 wg-allocators = "maintain"


### PR DESCRIPTION
The allocator API overlaps with libs quite a bit, so allow these teams access for issue triage.

r? @Amanieu 