### PR TITLE
Rename y86-dev to BennoLossin

### DIFF
--- a/people/BennoLossin.toml
+++ b/people/BennoLossin.toml
@@ -1,3 +1,3 @@
 name = "Benno Lossin"
-github = "y86-dev"
+github = "BennoLossin"
 github-id = 94611769

--- a/teams/goal-owners.toml
+++ b/teams/goal-owners.toml
@@ -6,7 +6,10 @@ kind = "marker-team"
 leads = []
 members = [
     "1c3t3a",
+    "BennoLossin",
     "BoxyUwU",
+    "Eh2406",
+    "JoelMarcey",
     "Muscraft",
     "SparrowLii",
     "ZuseZ4",
@@ -14,12 +17,10 @@ members = [
     "celinval",
     "chorman0773",
     "davidtwco",
-    "Eh2406",
     "epage",
     "folkertdev",
     "jhpratt",
     "jieyouxu",
-    "JoelMarcey",
     "joshtriplett",
     "jswrenn",
     "lcnr",
@@ -32,7 +33,6 @@ members = [
     "tmandry",
     "veluca93",
     "walterhpearce",
-    "y86-dev",
     "yaahc",
 ]
 included-teams = []

--- a/teams/rust-for-linux.toml
+++ b/teams/rust-for-linux.toml
@@ -4,10 +4,11 @@ kind = "marker-team"
 [people]
 leads = []
 members = [
+    "BennoLossin",
+    "Darksonn",
     "alex",
     "bjorn3",
     "dakr",
-    "Darksonn",
     "dingxiangfei2009",
     "fbq",
     "maurer",
@@ -16,7 +17,6 @@ members = [
     "ojeda",
     "tgross35",
     "vincenzopalazzo",
-    "y86-dev",
 ]
 
 [permissions]


### PR DESCRIPTION
A GitHub user just renamed themself, so I am updating our team repository to unblock further patches.

cc: FIY @bennolossin