### PR TITLE
Avoid need for closing and then re-opening PRs for checking a PR's CI again for an updated master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, auto_merge_enabled]
   merge_group:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
As commented here https://github.com/rust-lang/team/pull/1881#issuecomment-2994500350

> I'm wondering: would adding a CI trigger for `auto_merge_enabled` type of the [`pull_request`](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request) event, besides the [implicit default](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request) list of [`opened`, `synchronize` and `reopened`], avoid the need for such re-opening?

Potential downsides: Runs CI more often (presumably also doing it again on/before merges where checks *had* already passed).[^1]

[^1]: *(A possible alternative against this could be to go for `auto_merge_disabled` instead...)*

Potential (additional) upside: The Dry-run check results comment gets updated another time, making the documented diffs in the comment thread more accurate.