### PR TITLE
Clarify what the ci-checks name means

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -364,6 +364,10 @@ Admins cannot override these branch protections. If an admin needs to do that, t
 pattern = "master"
 # Which CI checks to are required for merging (optional)
 # Cannot be set if `pr-required` is `false`.
+#
+# For regular GitHub Actions, this is the name of the *job* that is required,
+# not the name of the workflow or the workflow filename. The name of the job
+# defaults to its YAML key name, or can be overridden with the `name` field.
 ci-checks = ["CI"]
 # Whether new commits after a reviewer's approval of a PR 
 # merging into this branch require another review. 


### PR DESCRIPTION
This can be a little confusing, since there are quite a few different "names" involved, and "ci checks" is a generic system (and thus uses different terminology) whereby GitHub Actions is just one participant.