### PR TITLE
add trusted publishing action repo

### DIFF
--- a/repos/rust-lang/crates-io-auth-action.toml
+++ b/repos/rust-lang/crates-io-auth-action.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "crates-io-auth-action"
+description = "Get a crates.io temporary access token"
+bots = []
+
+[access.teams]
+infra-admins = "write"
+infra = "triage"


### PR DESCRIPTION
[Trusted publishing](https://rust-lang.github.io/rfcs/3691-trusted-publishing-cratesio.html) is working on crates.io staging.

I worked on an [action](https://github.com/marcoieni/trusted-publishing-action-draft) to allow users to use trusted publishing on GitHub Actions.

In this PR, I create the repo for the action. After the repo has been created, I will push my code in that repo.

After the repo is created, I will edit this file again to add branch protections and maybe give infra team write access, but we need to make sure that only infra admins can push tags to that repo.

After my code is merged, I'm happy to receive PRs to change what you don't like about the action 👍

Regarding the license of the repo, is it enough to copy these files in the repo:
- https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE 
- https://github.com/rust-lang/rust/blob/master/LICENSE-MIT

And in the readme we could write the following:

```
Licensed under either of [./LICENSE-APACHE](Apache License, Version 2.0) or [./LICENSE-MIT](MIT license) at your option.
```

Not sure if we have any guidelines around licenses in the project.