### PR TITLE
Add more blocking CI checks to rustc-perf

### DIFF
--- a/repos/rust-lang/rustc-perf.toml
+++ b/repos/rust-lang/rustc-perf.toml
@@ -12,5 +12,7 @@ pattern = "master"
 ci-checks = [
     "Test and deploy",
     "Test on Windows",
+    "Test benchmarks",
+    "Test runtime benchmarks",
     "Database Check",
 ]


### PR DESCRIPTION
The CI didn't block on compile benchmarks failing, which is annoying (https://github.com/rust-lang/rustc-perf/pull/2176).