### PR TITLE
Add `josh-sync` repository

### DIFF
--- a/repos/rust-lang/josh-sync.toml
+++ b/repos/rust-lang/josh-sync.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "josh-sync"
+description = "Utilities for synchronizing Josh subtrees to the Rust compiler repo"
+bots = []
+
+[access.teams]
+compiler = "write"
+infra = "write"
+
+[[branch-protections]]
+pattern = "main"
+required-approvals = 0


### PR DESCRIPTION
This repository will host Rust code and GitHub Actions workflows for synchronizing Josh subtrees from/into rust-lang/rust.