### PR TITLE
add branch protections for crates-io-auth-action

### DIFF
--- a/repos/rust-lang/crates-io-auth-action.toml
+++ b/repos/rust-lang/crates-io-auth-action.toml
@@ -6,3 +6,8 @@ bots = []
 [access.teams]
 infra-admins = "write"
 infra = "triage"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = ["Conclusion"]
+required-approvals = 0


### PR DESCRIPTION
we should also protect the `v1` branch, but let's do it in another PR.

Close https://github.com/rust-lang/crates-io-auth-action/issues/2