### PR TITLE
Archive `rust-lang/generate-manifest-list`

### DIFF
--- a/repos/archive/rust-lang/generate-manifest-list.toml
+++ b/repos/archive/rust-lang/generate-manifest-list.toml
@@ -5,4 +5,3 @@ homepage = "https://static.rust-lang.org/manifests.txt"
 bots = []
 
 [access.teams]
-infra = "write"


### PR DESCRIPTION
The tool and the GitHub Actions cron running on it is not needed anymore, as `manifests.txt` is now updated by the release process.