### PR TITLE
Require tests to pass on `josh-sync`

### DIFF
--- a/repos/rust-lang/josh-sync.toml
+++ b/repos/rust-lang/josh-sync.toml
@@ -9,4 +9,5 @@ infra = "write"
 
 [[branch-protections]]
 pattern = "main"
+ci-checks = ["Test"]
 required-approvals = 0


### PR DESCRIPTION
CC @marcoieni :innocent:

https://github.com/rust-lang/josh-sync/blob/main/.github/workflows/test.yml#L7