### PR TITLE
Add sayantn and folkertdev as maintainers for stdarch

### DIFF
--- a/people/folkertdev.toml
+++ b/people/folkertdev.toml
@@ -2,3 +2,4 @@ name = "Folkert de Vries"
 github = "folkertdev"
 github-id = 7949978
 zulip-id = 416089
+email = "folkert@folkertdev.nl"

--- a/people/sayantn.toml
+++ b/people/sayantn.toml
@@ -1,0 +1,5 @@
+name = "Sayantan Chakraborty"
+github = "sayantn"
+github-id = 142906350
+zulip-id = 727337
+email = "sayantn05@gmail.com"

--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -6,6 +6,8 @@ bots = ["rustbot"]
 
 [access.teams]
 libs = "write"
+libs-api = "write"
+libs-contributors = "write"
 
 [[branch-protections]]
 pattern = "master"

--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -21,6 +21,8 @@ members = [
     "calebzulawski", # std::simd
     "tgross35",
     "ibraheemdev",
+    "folkertdev",
+    "sayantn",
 ]
 alumni = [
     "shepmaster",


### PR DESCRIPTION
This also adds gives libs-contributors merge permissions for stdarch since it is essentially a part of the standard library.