### PR TITLE
Add Eric Huss as a lang advisor

### DIFF
--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -7,6 +7,7 @@ members = [
     "alexcrichton",
     "Amanieu",
     "cramertj",
+    "ehuss",
     "jackh726",
     "JakobDegen",
     "RalfJung",


### PR DESCRIPTION
By unanimous agreement, the lang team is pleased to recognize and welcome Eric Huss as a lang advisor.

---

One of the standards that we've used for deciding on lang advisors is to ask, "if the person were to flag something, how concerned should we be?"

Whenever @ehuss flags something for us, it always gets my attention, and he's, by my accounting, always correct it's something we should review, and fairly often, it's something of significance that we've all missed.

His work on the Reference makes him a key partner for us as we increasingly turn our lang attention toward carefully specifying our language.  He's the lead of the Cargo team, he's a valuable member of the Council, his support was invaluable in making Rust 2024 a success, and I've come to realize that, in a quiet way, he's a critical part of the human infrastructure that makes the Project work.

He's someone I've had the opportunity to spend a considerable amount of time working closely with, and I can say without reservation that he's an individual of consistently high judgment and character.

He'll make a great addition to our distinguished team of lang advisors.

---

cc @rust-lang/lang @rust-lang/lang-advisors @rust-lang/team-repo-admins
