### PR TITLE
readme: add line about how teams are used to manage permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Rust teams structure
 
-This repository contains the structure of the Rust teams. The repository is
-automatically synchronized with:
+This repository contains the structure of the Rust teams,
+and is used to manage permissions such as the ability to merge PRs.
+The repository is automatically synchronized with:
 
 | Service                                                    |  Synchronized every   |                                           |
 |------------------------------------------------------------|:---------------------:|-------------------------------------------|


### PR DESCRIPTION
the fact that team membership is linked to permissions was something that initially confused me as a new contributor coming from nixpkgs, where teams exist mainly as lists of people you can ping about issues.  hopefully this line makes it more clear to new contributors that end up here that team membership has a bit more weight in the rust-lang organization.