### PR TITLE
Add `crates_io_og_image` repository

### DIFF
--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -1,0 +1,13 @@
+org = "rust-lang"
+name = "crates_io_og_image"
+description = "OpenGraph image generation for crates.io packages"
+homepage = "https://crates.io/crates/crates_io_og_image"
+bots = ["renovate", "rustbot"]
+
+[access.teams]
+crates-io = "write"
+
+[[branch-protections]]
+pattern = "main"
+ci-checks = ["CI"]
+required-approvals = 0


### PR DESCRIPTION
We want to extract https://github.com/rust-lang/crates.io/tree/main/crates/crates_io_og_image into a dedicated repo so that it can be versioned and published independently for usage in docs.rs too.

r? @rust-lang/team-repo-admins @rust-lang/infra @rust-lang/crates-io @rust-lang/docs-rs 