### PR TITLE
crates_io_og_image: Remove PR requirement

### DIFF
--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -9,6 +9,5 @@ crates-io = "write"
 
 [[branch-protections]]
 pattern = "main"
-ci-checks = ["CI"]
 required-approvals = 0
 pr-required = false

--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -11,3 +11,4 @@ crates-io = "write"
 pattern = "main"
 ci-checks = ["CI"]
 required-approvals = 0
+pr-required = false


### PR DESCRIPTION
This allows us to push release commits directly to `main` without having to go through pull requests for no real reason.