### PR TITLE
validate: Fix `pr-required = false` validation for `required-approvals = 0`

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -949,12 +949,14 @@ but that team is not mentioned in [access.teams]"#,
                         protection.pattern,
                     );
                 }
-                if protection.required_approvals.is_some() {
-                    bail!(
-                        r#"repo '{}' uses a branch protection for {} that does not require a PR, but sets the `required-approvals` attribute"#,
-                        repo.name,
-                        protection.pattern,
-                    );
+                if let Some(required_approvals) = protection.required_approvals {
+                    if required_approvals > 0 {
+                        bail!(
+                            r#"repo '{}' uses a branch protection for {} that does not require a PR, but `required-approvals` is greater than 0"#,
+                            repo.name,
+                            protection.pattern,
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
Using `required-approvals = 0` should not prevent us from using `pr-required = false`.