### PR TITLE
Fix rustc-perf CI checks

### DIFF
--- a/repos/rust-lang/rustc-perf.toml
+++ b/repos/rust-lang/rustc-perf.toml
@@ -12,7 +12,10 @@ pattern = "master"
 ci-checks = [
     "Test and deploy",
     "Test on Windows",
-    "Test benchmarks",
+    "Test benchmarks (--include cargo-0.87.1,stm32f4-0.15.1, Check,Debug,Doc)",
+    "Test benchmarks (--exclude cargo-0.87.1,stm32f4-0.15.1, Check,Debug,Doc)",
+    "Test benchmarks (--include cargo-0.87.1,stm32f4-0.15.1, Opt)",
+    "Test benchmarks (--exclude cargo-0.87.1,stm32f4-0.15.1, Opt)",
     "Test runtime benchmarks",
     "Database Check",
 ]


### PR DESCRIPTION
Yet again I did this [wrong](https://github.com/rust-lang/rustc-perf/pull/2202). I really wish it was possible to use a `*` asterisk here.. :laughing: