### PR TITLE
Add `jieyouxu` to `team-repo-admins`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 /people/Nadrieril.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/jackh726.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/jdno.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/jieyouxu.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/marcoieni.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/oli-obk.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/pietroalbini.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni

--- a/teams/team-repo-admins.toml
+++ b/teams/team-repo-admins.toml
@@ -7,6 +7,7 @@ members = [
     "Mark-Simulacrum",
     "rylev",
     "jackh726",
+    "jieyouxu",
 ]
 alumni = []
 


### PR DESCRIPTION
As discussed in [#council > team repo review bandwidth](https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/team.20repo.20review.20bandwidth/with/530571296), I'd like to help with the team-repo-admins side's review bandwidth (at least with the more "obvious" changes under <https://forge.rust-lang.org/infra/team-maintenance.html> to hopefully make those changes take less time to be reviewed).

**This will need a FCP by Council (and/or existing `team-repo-admins`)?**

I ran `cargo run ci generate-codeowners` locally for `CODEOWNERS` change.

cc @ehuss (as you suggested [here](https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/team.20repo.20review.20bandwidth/near/530568050))
cc @rust-lang/team-repo-admins 