### PR TITLE
Remove self as active from rustup

### DIFF
--- a/teams/rustup.toml
+++ b/teams/rustup.toml
@@ -3,11 +3,9 @@ subteam-of = "devtools"
 
 [people]
 leads = [
-    "rbtcollins",
     "rami3l",
 ]
 members = [
-    "rbtcollins",
     "djc",
     "rami3l",
     "ChrisDenton",
@@ -18,6 +16,7 @@ alumni = [
     "kinnison",
     "0xPoe",
     "dwijnand",
+    "rbtcollins",
 ]
 
 [website]


### PR DESCRIPTION
We've been bringing djc/rami3l/chrisdenton up to speed, and that seems well established now. With the shutdown of the discord, I can no longer meaningfully participate even at the low rate I was managing, so it is best to step down.