### PR TITLE
add tomassedovic to vision doc team

### DIFF
--- a/teams/project-vision-doc-2025.toml
+++ b/teams/project-vision-doc-2025.toml
@@ -13,6 +13,7 @@ members = [
     "joshtriplett",
     "workingjubilee",
     "timClicks",
+    "tomassedovic",
     "traviscross",
     "PLeVasseur",
 ]


### PR DESCRIPTION
Give @tomassedovic access to the vision doc group so he can help with project tasks. Proposed by @traviscross.

cc @jackh726, project co-lead