### PR TITLE
Leave `project-vision-doc-2025` team

### DIFF
--- a/teams/project-vision-doc-2025.toml
+++ b/teams/project-vision-doc-2025.toml
@@ -13,11 +13,11 @@ members = [
     "joshtriplett",
     "workingjubilee",
     "timClicks",
-    "traviscross",
     "PLeVasseur",
 ]
 alumni = [
     "spastorino",
+    "traviscross",
 ]
 
 [[github]]


### PR DESCRIPTION
I joined the project-vision-doc-2025 team explicitly in the capacity of keeping context on the PM-related activities of the Project, as these activities are a focus of certain council priorities on which I've been leading the charge.

With the team spun up and operating actively, and having now brought @tomassedovic on board the Project (and with the recent [decision](https://github.com/rust-lang/team/pull/1920) that his efforts won't at this time be needed as part of the vision doc work), I don't need to be on the team any longer, and so it's time for me to leave it in its many capable hands.

cc @nikomatsakis
