### PR TITLE
remove discord-mods-bot repository

### DIFF
--- a/repos/rust-lang/discord-mods-bot.toml
+++ b/repos/rust-lang/discord-mods-bot.toml
@@ -1,7 +1,0 @@
-org = "rust-lang"
-name = "discord-mods-bot"
-description = "discord moderation bot"
-bots = []
-
-[access.teams]
-mods-venue = "maintain"


### PR DESCRIPTION
Removing this repo so that we can transfer it to @technetos as requested.

Removing the repo shouldn't have any effect (for example, the sync mechanism won't delete the repo).

See https://github.com/rust-lang/simpleinfra/issues/756