### PR TITLE
team access refers to team name of toml instead of github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,8 +24,11 @@
 /teams/team-repo-admins.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/Mark-Simulacrum.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/Nadrieril.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/Noratrieb.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/apiraino.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/jackh726.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/jdno.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
+/people/jieyouxu.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/marcoieni.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/oli-obk.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/pietroalbini.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -329,6 +329,10 @@ See [GitHub's documentation][github-roles] for information on what each role is 
 # - "write"
 # - "maintain"
 # - "admin"
+#
+# Instead of showing the team name, the API contains the names of all the GitHub teams
+# in the `[[github]]` list of the team TOML file.
+# In other words, the teams are "expanded" to their corresponding GitHub teams.
 [access.teams]
 compiler = "write"
 
@@ -365,8 +369,8 @@ pattern = "master"
 # Which CI checks to are required for merging (optional)
 # Cannot be set if `pr-required` is `false`.
 ci-checks = ["CI"]
-# Whether new commits after a reviewer's approval of a PR 
-# merging into this branch require another review. 
+# Whether new commits after a reviewer's approval of a PR
+# merging into this branch require another review.
 # (optional - default `false`)
 dismiss-stale-review = false
 # Is a PR required when making changes to this branch?

--- a/repos/rust-lang/async-crashdump-debugging-initiative.toml
+++ b/repos/rust-lang/async-crashdump-debugging-initiative.toml
@@ -4,4 +4,4 @@ description = ""
 bots = []
 
 [access.teams]
-initiative-async-crashdump-debugging = "write"
+project-async-crashdump-debugging = "write"

--- a/repos/rust-lang/discord-mods-bot.toml
+++ b/repos/rust-lang/discord-mods-bot.toml
@@ -4,4 +4,4 @@ description = "discord moderation bot"
 bots = []
 
 [access.teams]
-mods = "maintain"
+mods-venue = "maintain"

--- a/repos/rust-lang/dyn-upcasting-coercion-initiative.toml
+++ b/repos/rust-lang/dyn-upcasting-coercion-initiative.toml
@@ -4,4 +4,4 @@ description = "Initiative to support upcasting dyn Trait values to supertraits"
 bots = []
 
 [access.teams]
-initiative-dyn-upcasting = "write"
+project-dyn-upcasting = "write"

--- a/repos/rust-lang/generic-associated-types-initiative.toml
+++ b/repos/rust-lang/generic-associated-types-initiative.toml
@@ -5,4 +5,4 @@ homepage = "https://rust-lang.github.io/generic-associated-types-initiative/"
 bots = []
 
 [access.teams]
-initiative-generic-associated-types = "write"
+project-generic-associated-types = "write"

--- a/repos/rust-lang/impl-trait-initiative.toml
+++ b/repos/rust-lang/impl-trait-initiative.toml
@@ -5,4 +5,4 @@ homepage = "https://rust-lang.github.io/impl-trait-initiative/"
 bots = []
 
 [access.teams]
-initiative-impl-trait = "maintain"
+project-impl-trait = "maintain"

--- a/repos/rust-lang/keyword-generics-initiative.toml
+++ b/repos/rust-lang/keyword-generics-initiative.toml
@@ -5,4 +5,4 @@ homepage = "https://rust-lang.github.io/keyword-generics-initiative/"
 bots = []
 
 [access.teams]
-initiative-keyword-generics = "write"
+project-keyword-generics = "write"

--- a/repos/rust-lang/moderation-team.toml
+++ b/repos/rust-lang/moderation-team.toml
@@ -4,4 +4,4 @@ description = "Home of the Rust Moderation team."
 bots = []
 
 [access.teams]
-mods = "write"
+mods-venue = "write"

--- a/repos/rust-lang/negative-impls-initiative.toml
+++ b/repos/rust-lang/negative-impls-initiative.toml
@@ -4,4 +4,4 @@ description = "Lang team negative impls initiative"
 bots = []
 
 [access.teams]
-initiative-negative-impls = "write"
+project-negative-impls = "write"

--- a/repos/rust-lang/rust-dbg-ext.toml
+++ b/repos/rust-lang/rust-dbg-ext.toml
@@ -4,4 +4,4 @@ description = ""
 bots = []
 
 [access.teams]
-initiative-async-crashdump-debugging = "maintain"
+project-async-crashdump-debugging = "maintain"

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -4,7 +4,7 @@ description = "Rust teams structure"
 bots = []
 
 [access.teams]
-mods = "write"
+mods-venue = "write"
 team-repo-admins = "write"
 infra = "triage"
 

--- a/repos/rust-lang/trait-system-refactor-initiative.toml
+++ b/repos/rust-lang/trait-system-refactor-initiative.toml
@@ -4,4 +4,4 @@ description = "The Rustc Trait System Refactor Initiative"
 bots = []
 
 [access.teams]
-initiative-trait-system-refactor = "maintain"
+project-trait-system-refactor = "maintain"

--- a/repos/rust-lang/wg-security-response.toml
+++ b/repos/rust-lang/wg-security-response.toml
@@ -4,4 +4,4 @@ description = "Documentation for the Rust Security Response WG"
 bots = []
 
 [access.teams]
-security = "write"
+wg-security-response = "write"

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -38,6 +38,10 @@
         {
           "name": "foo",
           "permission": "maintain"
+        },
+        {
+          "name": "renamed-team",
+          "permission": "maintain"
         }
       ],
       "members": [],

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -8,6 +8,10 @@
     {
       "name": "foo",
       "permission": "maintain"
+    },
+    {
+      "name": "renamed-team",
+      "permission": "maintain"
     }
   ],
   "members": [],


### PR DESCRIPTION
We discussed with the infra team that it's confusing to use the github name as the LHS of the `[access.teams]`, so we want to use the team name (i.e. the `name` field of the team) instead.