### PR TITLE
restrict mods write access to the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,11 +24,8 @@
 /teams/team-repo-admins.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/Mark-Simulacrum.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/Nadrieril.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
-/people/Noratrieb.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
-/people/apiraino.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/jackh726.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/jdno.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
-/people/jieyouxu.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/marcoieni.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/oli-obk.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni
 /people/pietroalbini.toml @Mark-Simulacrum @pietroalbini @jdno @marcoieni

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -4,7 +4,7 @@ description = "Rust teams structure"
 bots = []
 
 [access.teams]
-mods-venue = "write"
+mods = "write"
 team-repo-admins = "write"
 infra = "triage"
 


### PR DESCRIPTION
Before https://github.com/rust-lang/team/pull/1923 the access was `mods = "write"` but no one in the infra team discussion we had realized that `mods` expanded to the [mods](https://github.com/orgs/rust-lang/teams/mods) github team instead of the [moderation](https://github.com/orgs/rust-lang/teams/moderation) one. This was also clear by the bug in the codeowners file we had.

With this PR we want to restrict the write access to [moderation](https://github.com/orgs/rust-lang/teams/moderation) instead of [mods](https://github.com/orgs/rust-lang/teams/mods).