### PR TITLE
Rotate WG-rustc-dev-guide co-lead

### DIFF
--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -3,7 +3,7 @@ subteam-of = "compiler"
 kind = "working-group"
 
 [people]
-leads = ["BoxyUwU", "jieyouxu"]
+leads = ["BoxyUwU", "tshepang"]
 members = [
     "JohnTitor",
     "camelid",


### PR DESCRIPTION
I won't have the bandwidth to meaningfully help with figuring out the future of this WG, so rotate co-lead role to another WG member with more bandwidth. Thanks @tshepang for volunteering ❤️! Discussed in [#t-compiler/rustc-dev-guide > Future of this wg @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/196385-t-compiler.2Frustc-dev-guide/topic/Future.20of.20this.20wg/near/533443765).

(I have bandwidth to review and help with sync, just not also co-lead.)

r? @BoxyUwU 