### PR TITLE
Create the `rust-heroku-deploy-access` bot

### DIFF
--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "crates.io"
 description = "The Rust package registry"
 homepage = "https://crates.io"
-bots = ["renovate", "rustbot"]
+bots = ["renovate", "rustbot", "heroku-deploy-access"]
 
 [access.teams]
 crates-io = "write"

--- a/repos/rust-lang/www.rust-lang.org.toml
+++ b/repos/rust-lang/www.rust-lang.org.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "www.rust-lang.org"
 description = "The home of the Rust website"
 homepage = "https://www.rust-lang.org"
-bots = ["rustbot"]
+bots = ["rustbot", "heroku-deploy-access"]
 
 [access.teams]
 # Maintain is needed for integrating with external services, e.g. Pontoon

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -209,6 +209,7 @@ pub enum Bot {
     Glacierbot,
     LogAnalyzer,
     Renovate,
+    HerokuDeployAccess,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -847,6 +847,7 @@ pub(crate) enum Bot {
     Glacierbot,
     LogAnalyzer,
     Renovate,
+    HerokuDeployAccess,
 }
 
 #[derive(serde_derive::Deserialize, Debug)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -91,6 +91,7 @@ impl<'a> Generator<'a> {
                         Bot::Glacierbot => v1::Bot::Glacierbot,
                         Bot::LogAnalyzer => v1::Bot::LogAnalyzer,
                         Bot::Renovate => v1::Bot::Renovate,
+                        Bot::HerokuDeployAccess => v1::Bot::HerokuDeployAccess,
                     })
                     .collect(),
                 teams: {

--- a/sync-team/src/github/mod.rs
+++ b/sync-team/src/github/mod.rs
@@ -495,6 +495,7 @@ fn bot_user_name(bot: &Bot) -> Option<&str> {
         Bot::Glacierbot => Some("rust-lang-glacier-bot"),
         Bot::LogAnalyzer => Some("rust-log-analyzer"),
         Bot::Renovate => None,
+        Bot::HerokuDeployAccess => Some("rust-heroku-deploy-access"),
     }
 }
 


### PR DESCRIPTION
This bot will have write access to the GitHub repositories we link to Heroku. Adding the bot to a repo will allow linking an Heroku app to the repo via the Heroku Dashboard.

I already created the bot, added it to the org, and created an Heroku account for it. Once this is merged, we will stop linking Heroku and GitHub through my personal account.