### PR TITLE
Recognize TWIR reviewers alumni

### DIFF
--- a/people/bennyvasquez.toml
+++ b/people/bennyvasquez.toml
@@ -1,0 +1,4 @@
+name = 'benny Vasquez'
+github = 'bennyvasquez'
+github-id = 13630986
+email = 'bennycrampton@gmail.com'

--- a/teams/twir-reviewers.toml
+++ b/teams/twir-reviewers.toml
@@ -13,7 +13,11 @@ members = [
     "bnchi",
     "KannanPalani57"
 ]
-alumni = []
+alumni = [
+    "andrewpollack",
+    "bennyvasquez",
+    "cdmistman",
+]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
Follow-up to #1932 which only removed members to instead move to alumni, as suggested in https://github.com/rust-lang/team/pull/1932#issuecomment-3166296450.