### PR TITLE
create the crates-io-infra-admins marker team

### DIFF
--- a/teams/crates-io-infra-admins.toml
+++ b/teams/crates-io-infra-admins.toml
@@ -1,0 +1,17 @@
+# This team defines which members of the crates-io team have administrative access to the
+# crates.io infrastructure, such as the database.
+
+name = "crates-io-infra-admins"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "carols10cents",
+    "jtgeibel",
+    "Turbo87",
+    "LawnGnome",
+]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
This team contains people with elevated crates-io priviledges.
In a follow-up PR, I would like to give these people write access to https://github.com/rust-lang/crates-io-auth-action/ to solve https://github.com/rust-lang/crates-io-auth-action/issues/13
