### PR TITLE
remove davidtwco from some groups

### DIFF
--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -7,13 +7,13 @@ leads = ["BoxyUwU", "lcnr"]
 members = [
     "lcnr",
     "nikomatsakis",
-    "davidtwco",
     "oli-obk",
     "BoxyUwU",
     "camelid",
     "compiler-errors",
 ]
 alumni = [
+    "davidtwco",
     "varkor",
     "withoutboats",
 ]

--- a/teams/wg-mir-opt.toml
+++ b/teams/wg-mir-opt.toml
@@ -4,8 +4,8 @@ kind = "working-group"
 
 [people]
 leads = ["oli-obk"]
-members = ["oli-obk", "eddyb", "davidtwco", "wesleywiser", "vertexclique", "JakobDegen", "dianqk"]
-alumni = ["spastorino"]
+members = ["oli-obk", "eddyb", "wesleywiser", "vertexclique", "JakobDegen", "dianqk"]
+alumni = ["davidtwco", "spastorino"]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
I'm not active in mir-opts or const generics and don't often have much to add to issues that these groups are pinged on, I can still be pinged individually when that's not the case, but this will cut down on my notification load.