### PR TITLE
Allow rustc-dev-guide WG leads to r+ subtree syncs

### DIFF
--- a/teams/wg-rustc-dev-guide.toml
+++ b/teams/wg-rustc-dev-guide.toml
@@ -25,6 +25,10 @@ alumni = [
     "togiberlin",
 ]
 
+[leads-permissions]
+# Intended primarily for subtree syncs.
+bors.rust.review = true
+
 [[github]]
 orgs = ["rust-lang"]
 


### PR DESCRIPTION
This is primarily intended for rustc-dev-guide WG leads to be able to approve subtree syncs.

The r+ permission is currently limited to WG leads only, because it's not determined yet if the WG membership is intended to be more permissive.

cc @BoxyUwU @tshepang 