### PR TITLE
give crates-io admins write access to the creates-io-auth-action

### DIFF
--- a/repos/rust-lang/crates-io-auth-action.toml
+++ b/repos/rust-lang/crates-io-auth-action.toml
@@ -4,6 +4,7 @@ description = "Get a crates.io temporary access token"
 bots = []
 
 [access.teams]
+crates-io-infra-admins = "write"
 infra-admins = "write"
 infra = "triage"
 


### PR DESCRIPTION
In https://github.com/rust-lang/team/pull/1943 we created this team.
Now let's give them the permission.

Close https://github.com/rust-lang/crates-io-auth-action/issues/13