### PR TITLE
rustc-dev-guide.toml: reduce name varieties of the team

### DIFF
--- a/teams/rustc-dev-guide.toml
+++ b/teams/rustc-dev-guide.toml
@@ -34,8 +34,8 @@ bors.rust.review = true
 orgs = ["rust-lang"]
 
 [website]
-name = "Rustc Dev Guide working area"
-description = "Making the compiler easier to learn by maintaining and improving the Rustc Dev Guide"
+name = "rustc-dev-guide working area"
+description = "Making the compiler easier to learn by maintaining and improving the Rust Compiler Development Guide"
 repo = "https://forge.rust-lang.org/compiler/working-areas.html"
 zulip-stream = "t-compiler/rustc-dev-guide"
 


### PR DESCRIPTION
Either use the repo name or the full name, but not also the third form. Also, it being capitalized made it seem like a formal name, which it's not.

cc @BoxyUwU 