### PR TITLE
Add content team

### DIFF
--- a/people/LoriLorusso.toml
+++ b/people/LoriLorusso.toml
@@ -1,0 +1,5 @@
+name = "Lori Lorusso"
+github = "LoriLorusso"
+github-id = 66495765
+zulip-id = 944316
+email = "lorilorusso@rustfoundation.org"

--- a/people/MerrimanInd.toml
+++ b/people/MerrimanInd.toml
@@ -1,0 +1,5 @@
+name = "Xander Cesari"
+github = "MerrimanInd"
+github-id = 38871383
+zulip-id = 880880
+email = "xander@merriman.industries"

--- a/people/cldershem.toml
+++ b/people/cldershem.toml
@@ -1,0 +1,5 @@
+name = "Cameron Dershem"
+github = "cldershem"
+github-id = 201608
+zulip-id = 220131
+email = "cameron@pinkhatbeard.com"

--- a/repos/rust-lang/content-team.toml
+++ b/repos/rust-lang/content-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "content-team"
+description = "Home of the Rust Content Team"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+content = "maintain"

--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -7,6 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 community = "maintain"
 compiler = "maintain"
+content = "maintain"
 crates-io = "maintain"
 docs-rs = "maintain"
 infra = "maintain"

--- a/teams/content.toml
+++ b/teams/content.toml
@@ -1,0 +1,34 @@
+name = "content"
+subteam-of = "launching-pad"
+
+[people]
+leads = [
+    "PLeVasseur",
+    "traviscross",
+]
+members = [
+    "traviscross",
+    "PLeVasseur",
+    "tomassedovic",
+    "MerrimanInd",
+    "cldershem",
+    "LoriLorusso",
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]
+
+[rfcbot]
+label = "T-content"
+name = "Content"
+ping = "rust-lang/content"
+
+[website]
+name = "Content team"
+description = "Produces publishable content"
+zulip-stream = "t-content"
+repo = "https://github.com/rust-lang/content-team"
+
+[[zulip-groups]]
+name = "T-content"


### PR DESCRIPTION
The council chartered the Rust Content Team via an FCP that completed 2025-08-18.  Let's add the team.

- https://github.com/rust-lang/leadership-council/issues/206

cc @PLeVasseur @tomassedovic @MerrimanInd @cldershem @LoriLorusso
