### PR TITLE
Add tmandry to content team

### DIFF
--- a/teams/content.toml
+++ b/teams/content.toml
@@ -13,6 +13,7 @@ members = [
     "MerrimanInd",
     "cldershem",
     "LoriLorusso",
+    "tmandry",
 ]
 alumni = []
 


### PR DESCRIPTION
We're pleased to welcome tmandry to the Rust Content Team and are thrilled that he's volunteering his efforts and considerable talents to push forward this important work.

cc @tmandry @PLeVasseur @rust-lang/content
