### PR TITLE
Create `T-all` zulip user group

### DIFF
--- a/teams/all.toml
+++ b/teams/all.toml
@@ -31,3 +31,6 @@ extra-emails = [
 
 [[discord-roles]]
 name = "WGs and Teams"
+
+[[zulip-groups]]
+name = "T-all"


### PR DESCRIPTION
This is needed to configure the infra announcement channel so the zulip user group membership is synced automatically with project team membership.

This notably does not include working groups, project groups, or marker teams. The cloud-compute marker team will need its own zulip user group in a follow-up.

See [#t-infra > Communication method for dev desktops @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Communication.20method.20for.20dev.20desktops/near/536886782) for more details.