### PR TITLE
Add reference expansion repo

### DIFF
--- a/repos/rust-lang/project-goal-reference-expansion.toml
+++ b/repos/rust-lang/project-goal-reference-expansion.toml
@@ -1,0 +1,8 @@
+org = "rust-lang"
+name = "project-goal-reference-expansion"
+description = "Project Goal coordination repository for expansion of the Rust Reference"
+homepage = "https://github.com/rust-lang/rust-project-goals/blob/main/src/2025h2/reference-expansion.md"
+bots = []
+
+[access.teams]
+reference = "write"


### PR DESCRIPTION
This repository should be moved under the `rust-lang` org from https://github.com/joshtriplett/project-goal-reference-expansion, with the help of an infra admin (https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Moving.20a.20repo.20into.20our.20org/with/536853377).