### PR TITLE
chore: Add ci checks to annotate-snippets-rs

### DIFF
--- a/repos/rust-lang/annotate-snippets-rs.toml
+++ b/repos/rust-lang/annotate-snippets-rs.toml
@@ -9,4 +9,5 @@ wg-diagnostics = "write"
 
 [[branch-protections]]
 pattern = "master"
+ci-checks = ["CI"]
 required-approvals = 0


### PR DESCRIPTION
This PR adds a CI check for [`annotate-snippets` `ci` job](https://github.com/rust-lang/annotate-snippets-rs/blob/974a75be76c36b35f28faba79c289bc3377a8f97/.github/workflows/ci.yml#L22)