### PR TITLE
blog repo: change branch protection pattern from 'master' to 'main'

### DIFF
--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -11,7 +11,7 @@ website = "maintain"
 release = "write"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 ci-checks = [
     "lint",
     "build",


### PR DESCRIPTION
Related to https://github.com/rust-lang/blog.rust-lang.org/issues/1687