### PR TITLE
Lock down permissions on `promote-release`

### DIFF
--- a/repos/rust-lang/promote-release.toml
+++ b/repos/rust-lang/promote-release.toml
@@ -4,7 +4,8 @@ description = "Tooling to publish Rust releases."
 bots = []
 
 [access.teams]
-infra = "write"
+infra = "triage"
+infra-admins = "write"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
It is a sensitive repository, because the code is used to make Rust releases, so the whole of t-infra likely shouldn't have write access.
