### PR TITLE
Archive "community content" team

### DIFF
--- a/teams/archive/community-content.toml
+++ b/teams/archive/community-content.toml
@@ -3,14 +3,13 @@ subteam-of = "community"
 
 [people]
 leads = []
-members = [
-    "adityac8",
-    "nellshamrell",
-    "wezm",
-]
+members = []
 alumni = [
+    "adityac8",
     "nasa42",
+    "nellshamrell",
     "skade",
+    "wezm",
 ]
 
 [website]


### PR DESCRIPTION
As per https://github.com/rust-lang/leadership-council/issues/129#issuecomment-2576491095, archiving the community-content subteam as part of Launching Pad cleanup.

CC @nellshamrell (sorry for being so late to actually do this!)