### PR TITLE
Rename community survey team to survey team

### DIFF
--- a/repos/rust-lang/surveys-private.toml
+++ b/repos/rust-lang/surveys-private.toml
@@ -5,4 +5,4 @@ bots = []
 private-non-synced = true
 
 [access.teams]
-community-survey = "maintain"
+survey = "maintain"

--- a/repos/rust-lang/surveys.toml
+++ b/repos/rust-lang/surveys.toml
@@ -4,4 +4,4 @@ description = "Repo for coordinating the creation, distribution, collection, and
 bots = []
 
 [access.teams]
-community-survey = "write"
+survey = "write"

--- a/teams/community.toml
+++ b/teams/community.toml
@@ -33,7 +33,6 @@ address = "community@rust-lang.org"
 extra-teams = [
     "community-content",
     "community-events",
-    "community-survey",
     "community-localization",
 ]
 
@@ -42,7 +41,6 @@ address = "community-team@rust-lang.org"
 extra-teams = [
     "community-content",
     "community-events",
-    "community-survey",
     "community-localization",
 ]
 

--- a/teams/survey.toml
+++ b/teams/survey.toml
@@ -1,5 +1,5 @@
-name = "community-survey"
-subteam-of = "community"
+name = "survey"
+subteam-of = "launching-pad"
 
 [people]
 leads = ["Kobzol", "apiraino"]
@@ -15,7 +15,7 @@ alumni = [
 
 [website]
 name = "Survey team"
-description = "Running, analysing, and presenting the community survey"
+description = "Running, analysing, and presenting various Rust surveys"
 repo = "https://github.com/rust-lang/surveys"
 
 [[github]]


### PR DESCRIPTION
And make launching-pad its parent.

As per https://github.com/rust-lang/leadership-council/issues/133.
