### PR TITLE
Change branch protection of rustc-dev-guide to `main`

### DIFF
--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -19,7 +19,7 @@ rustdoc-frontend = "write"
 wg-rustc-dev-guide = "maintain"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 ci-checks = ["ci"]
 required-approvals = 0
 


### PR DESCRIPTION
In coordination with https://github.com/rust-lang/rustc-dev-guide/pull/2570.
