### PR TITLE
Add a few website descriptions to archived teams

### DIFF
--- a/teams/archive/community-ctcft.toml
+++ b/teams/archive/community-ctcft.toml
@@ -16,3 +16,7 @@ orgs = ["rust-lang"]
 
 [[lists]]
 address = "ctcft@rust-lang.org"
+
+[website]
+name = "Cross-Team Collaboration Fun Times"
+description = "Fostering cross-team collaboration in the Rust project"

--- a/teams/archive/core.toml
+++ b/teams/archive/core.toml
@@ -44,3 +44,7 @@ address = "user-logos@rust-lang.org"
 
 [[lists]]
 address = "legal@crates.io"
+
+[website]
+name = "Core team"
+description = "A former governing body of Rust. It was replaced by the Leadership Council with RFC 3392."

--- a/teams/archive/ecosystem.toml
+++ b/teams/archive/ecosystem.toml
@@ -12,3 +12,7 @@ alumni = [
 
 [[lists]]
 address = "ecosystem@rust-lang.org"
+
+[website]
+name = "Ecosystem team"
+description = ""

--- a/teams/archive/interim-leadership-chat.toml
+++ b/teams/archive/interim-leadership-chat.toml
@@ -33,3 +33,7 @@ orgs = ["rust-lang"]
 label = "T-interim-leadership-chat"
 name = "Interim Leadership Chat"
 ping = "rust-lang/interim-leadership-chat"
+
+[website]
+name = "Interim Leadership Chat"
+description = "A temporary governing body used to ratify RFC 3392"


### PR DESCRIPTION
Companion to https://github.com/rust-lang/www.rust-lang.org/pull/2202, to provide a proper name and description to a few archived teams.