### PR TITLE
rustc-dev-guide team: add Kobzol

### DIFF
--- a/teams/rustc-dev-guide.toml
+++ b/teams/rustc-dev-guide.toml
@@ -12,6 +12,7 @@ members = [
     "tshepang",
     "amanjeev",
     "Noratrieb",
+    "Kobzol",
 ]
 alumni = [
     "LeSeulArtichaut",


### PR DESCRIPTION
A very belated addition, @Kobzol does a lot to help improve things for the team

cc @BoxyUwU 