### PR TITLE
Update configuration of the website repo

### DIFF
--- a/repos/rust-lang/www.rust-lang.org.toml
+++ b/repos/rust-lang/www.rust-lang.org.toml
@@ -2,17 +2,10 @@ org = "rust-lang"
 name = "www.rust-lang.org"
 description = "The home of the Rust website"
 homepage = "https://www.rust-lang.org"
-bots = ["rustbot", "heroku-deploy-access"]
+bots = ["rustbot"]
 
 [access.teams]
-# Maintain is needed for integrating with external services, e.g. Pontoon
-website = "maintain"
+website = "write"
 
 [[branch-protections]]
 pattern = "main"
-pr-required = false
-
-[[branch-protections]]
-pattern = "deploy"
-pr-required = false
-allowed-merge-teams = ["website"]


### PR DESCRIPTION
After the change of the website to a static web, we:
- Should not need the `deploy` branch protection
- We should require PRs for the `main` branch (IMO), as it is now automatically deployed
- The website team should not need `maintain` permissions anymore, as Pontoon is no longer used
- We don't need the Heroku bot anymore

CC @senekor if this looks good.