### PR TITLE
Remove compiler-errors from FCPs, working groups

### DIFF
--- a/teams/compiler-fcp.toml
+++ b/teams/compiler-fcp.toml
@@ -5,7 +5,6 @@ subteam-of = "compiler"
 leads = []
 members = [
     "cjgillot",
-    "compiler-errors",
     "davidtwco",
     "estebank",
     "jieyouxu",
@@ -19,7 +18,9 @@ members = [
     "spastorino",
     "wesleywiser",
 ]
-alumni = []
+alumni = [
+    "compiler-errors",
+]
 
 [rfcbot]
 label = "T-compiler"

--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -14,7 +14,7 @@ members = [
     { github = "chenyukang", roles = ["compiler-maintainer"] },
     "ChrisDenton",
     { github = "cjgillot",  roles = ["compiler-maintainer"] },
-    { github = "compiler-errors", roles = ["compiler-maintainer"] },
+    "compiler-errors",
     "cuviper",
     { github = "davidtwco", roles = ["compiler-maintainer"] },
     "dianqk",

--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -10,9 +10,9 @@ members = [
     "oli-obk",
     "BoxyUwU",
     "camelid",
-    "compiler-errors",
 ]
 alumni = [
+    "compiler-errors",
     "davidtwco",
     "varkor",
     "withoutboats",

--- a/teams/project-const-traits.toml
+++ b/teams/project-const-traits.toml
@@ -7,12 +7,13 @@ leads = [
     "fee1-dead",
 ]
 members = [
-    "compiler-errors",
     "fee1-dead",
     "fmease",
     "oli-obk",
 ]
-alumni = []
+alumni = [
+    "compiler-errors",
+]
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/project-trait-system-refactor.toml
+++ b/teams/project-trait-system-refactor.toml
@@ -11,11 +11,12 @@ leads = [
 members = [
     "BoxyUwU",
     "cjgillot",
-    "compiler-errors",
     "lcnr",
     "lqd",
 ]
-alumni = []
+alumni = [
+    "compiler-errors",
+]
 
 [website]
 name = "Rustc Trait System Refactor Initiative"

--- a/teams/types-fcp.toml
+++ b/teams/types-fcp.toml
@@ -5,14 +5,15 @@ subteam-of = "types"
 leads = []
 members = [
     "BoxyUwU",
-    "compiler-errors",
     "jackh726",
     "lcnr",
     "nikomatsakis",
     "oli-obk",
     "spastorino",
 ]
-alumni = []
+alumni = [
+    "compiler-errors",
+]
 
 [rfcbot]
 label = "T-types"

--- a/teams/wg-async.toml
+++ b/teams/wg-async.toml
@@ -5,7 +5,6 @@ kind = "working-group"
 [people]
 leads = ["nikomatsakis", "tmandry"]
 members = [
-    "compiler-errors",
     "eholk",
     "estebank",
     "guswynn",
@@ -24,6 +23,7 @@ alumni = [
     "bIgBV",
     "betamos",
     "cramertj",
+    "compiler-errors",
     "csmoe",
     "doc-jones",
     "eminence",

--- a/teams/wg-diagnostics.toml
+++ b/teams/wg-diagnostics.toml
@@ -7,12 +7,13 @@ leads = ["estebank", "oli-obk"]
 members = [
     "JohnTitor",
     "TaKO8Ki",
-    "compiler-errors",
     "davidtwco",
     "estebank",
     "oli-obk",
 ]
-alumni = []
+alumni = [
+    "compiler-errors",
+]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
I'm not planning on contributing to Rust very much in the short-to-medium-term due to changes in my job situation.

I'm removing myself from FCPs from T-compiler and T-types just so I don't end up blocking FCPs, and I'm removing myself from a bunch of random project groups at the same time just to tidy stuff up. I'm remaining on T-compiler and T-types for the time being though.