### PR TITLE
Add Tomas to lang-ops

### DIFF
--- a/teams/lang-ops.toml
+++ b/teams/lang-ops.toml
@@ -5,6 +5,7 @@ subteam-of = "lang"
 leads = ["traviscross"]
 members = [
     "traviscross",
+    "tomassedovic",
 ]
 alumni = [
 ]


### PR DESCRIPTION
Due to his consistent and valuable work in supporting the operations of the lang team, the lang-ops team is pleased to welcome Tomas.

cc @tomassedovic @rust-lang/lang @rust-lang/lang-ops
