### PR TITLE
Rename default branch of rustup to `main`

### DIFF
--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -8,5 +8,5 @@ bots = ["rustbot", "renovate"]
 rustup = "maintain"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 ci-checks = ["conclusion"]


### PR DESCRIPTION
Related PR: https://github.com/rust-lang/rustup/pull/4511
