### PR TITLE
Configure a `T-internal-sites` zulip group

### DIFF
--- a/teams/internal-sites.toml
+++ b/teams/internal-sites.toml
@@ -17,3 +17,6 @@ orgs = ["rust-lang"]
 [website]
 name = "Internal sites team"
 description = "Supports the Forge and RFC internal websites"
+
+[[zulip-groups]]
+name = "T-internal-sites"


### PR DESCRIPTION
I would like to create a dedicated Zulip channel for the Internal Sites team (something like `#t-internal-sites`, and have an easy way to cc the internal sites team) mostly for maintenance discussions / logging purposes.

cc @rust-lang/internal-sites (for vibes, this will also need a co-lead approval)