### PR TITLE
Add FLS team

### DIFF
--- a/people/AlexCeleste.toml
+++ b/people/AlexCeleste.toml
@@ -1,0 +1,5 @@
+name = "Alex Eris Celeste née Gilding"
+github = "AlexCeleste"
+github-id = 1959106
+email = false
+zulip-id = 776329

--- a/repos/rust-lang/fls-team.toml
+++ b/repos/rust-lang/fls-team.toml
@@ -1,0 +1,13 @@
+org = "rust-lang"
+name = "fls-team"
+description = "Home of the Rust FLS team"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+fls = "maintain"
+fls-contributors = "triage"
+lang = "maintain"
+lang-docs = "maintain"
+lang-ops = "maintain"
+spec = "maintain"
+spec-contributors = "triage"

--- a/repos/rust-lang/fls.toml
+++ b/repos/rust-lang/fls.toml
@@ -5,10 +5,13 @@ homepage = "https://rust-lang.github.io/fls"
 bots = ["rustbot", "rfcbot"]
 
 [access.teams]
+fls = "write"
+fls-contributors = "triage"
 lang = "write"
 lang-docs = "write"
+lang-ops = "write"
 spec = "write"
-spec-contributors = "write"
+spec-contributors = "triage"
 
 [[branch-protections]]
 pattern = "main"

--- a/teams/fls-contributors.toml
+++ b/teams/fls-contributors.toml
@@ -1,0 +1,19 @@
+name = "fls-contributors"
+subteam-of = "fls"
+
+[people]
+leads = []
+members = [
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "FLS team contributors"
+description = "Regular contributors to the FLS"
+zulip-stream = "t-lang/fls"
+
+[[zulip-groups]]
+name = "T-fls-contributors"

--- a/teams/fls.toml
+++ b/teams/fls.toml
@@ -1,0 +1,29 @@
+name = "fls"
+subteam-of = "spec"
+
+[people]
+leads = ["PLeVasseur"]
+members = [
+    "PLeVasseur",
+    "traviscross",
+    "tshepang",
+    "AlexCeleste",
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]
+
+[rfcbot]
+label = "T-fls"
+name = "FLS"
+ping = "rust-lang/fls"
+
+[website]
+name = "FLS team"
+description = "Maintaining and improving the FLS"
+repo = "http://github.com/rust-lang/fls-team"
+zulip-stream = "t-lang/fls"
+
+[[zulip-groups]]
+name = "T-fls"


### PR DESCRIPTION
Back in May 2025, we [adopted] the FLS into the Project.  It's now time to create a team charged with maintaining and improving this document.  Pete LeVasseur has graciously volunteered to lead this team, and we're all excited to see where he and the team can take it.

The initial charter of the FLS team is:

> The FLS Team maintains and improves the FLS for the benefit of the Project and the safety-critical community.
>
> The FLS Team is responsible for:
>
> - Maintaining and improving the content and tooling of the FLS.
> - Keeping the FLS up to date with new releases of Rust.
> - Setting and documenting guidelines for authorship and contribution to the FLS.
> - Working with the safety-critical community to ensure the FLS continues to serve them, particularly with regard to supporting the qualification of Rust-related tools.
> - Working with other Rust teams to ensure the accuracy of content in the FLS.
> - Working with the maintainers of the Reference to identify areas where each document and team can provide value to the other.
> - Cultivating and curating membership of `fls-contributors` and setting policies for that team.
>
> The FLS Team leads are tasked with ensuring the health of the team.  The team manages its own membership and selects its own leads.

The initial charter of the FLS contributors team is:

> The FLS Contributors Team supports the work of the FLS Team in maintaining and improving the FLS.
>
> The FLS Contributors Team is responsible for:
>
> - Proposing updates and improvements to the FLS, following the guidance of the FLS Team.
> - Working with members of the FLS Team to refine and integrate those changes.
> - Reviewing pull requests and suggesting improvements to them.
> - Identifying changes to the FLS relevant to the Reference and filing Reference issues or submitting Reference PRs.
> - Triaging issues and pull requests.
>
> The FLS Contributors team does not have any leads and its membership is managed by the FLS Team. The team is a subteam of the FLS Team.

The FLS contributors team is starting out with no members, but there are some immediate candidates, and it's expected these will be added soon.

[adopted]: https://blog.rust-lang.org/2025/03/26/adopting-the-fls/

@plevasseur @ehuss @tshepang @nikomatsakis @rust-lang/spec @rust-lang/lang-docs @rust-lang/lang