### PR TITLE
Add @NobodyXu and @madsmtm to crate-maintainers team

### DIFF
--- a/repos/rust-lang/cc-rs.toml
+++ b/repos/rust-lang/cc-rs.toml
@@ -7,10 +7,6 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[access.individuals]
-NobodyXu = 'write'
-madsmtm = 'write'
-
 [[branch-protections]]
 pattern = 'main'
 required-approvals = 0

--- a/teams/crate-maintainers.toml
+++ b/teams/crate-maintainers.toml
@@ -16,7 +16,9 @@ members = [
     "lcnr",
     "tgross35",
     "jongiddy",
-    "Kobzol"
+    "Kobzol",
+    "NobodyXu",
+    "madsmtm",
 ]
 alumni = []
 


### PR DESCRIPTION
Motivation: To make Jiahao show up on the website.

This also removes the `[access.individuals]` key for `cc-rs` as part of https://github.com/rust-lang/team/issues/1476.

CC @rust-lang/crate-maintainers, this would add @NobodyXu and myself to your team. I would limit my use of these rights to contributions to `cc-rs` (which admittedly has been very limited lately), I suspect @NobodyXu would do the same.

An alternative would be to create a separate team `@rust-lang/cc`, I'd be fine with either.