### PR TITLE
Document that updating dependencies is security sensitive

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -36,6 +36,7 @@ To give a few more specific examples, here is a non-exhaustive list of scenarios
 - Changing the code of `sync-team` or `team` to give themselves special permissions.
 - Changing the code of CI workflows.
 - Adding or modifying a file that affects what gets executed on CI. For example `.cargo/config.toml` (affects Cargo) or `rust-toolchain.toml` file (affects Rustup).
+- Upgrading dependencies in `Cargo.lock` to a compromised version.
 
 ### Content attacks
 The second category is "content attacks", which can be done without changing code, only by modifying the TOML data files. This kind of attack could be performed by a maintainer, unless we explicitly protect against it.


### PR DESCRIPTION
I've been thinking a lot about sandboxing build scripts and proc-macros lately, and it occurred to me that if I were to attack this repo, I'd go the route of adding a `ctor` to some deeply nested dependency that sends the `GITHUB_TOKEN` somewhere if it detects it's inside this repo, and then just wait for Dependabot to update the dependency here.

CC @Kobzol, opening this to ensure that this is something you / t-infra is aware of.