### PR TITLE
chore: validate no duplicate team members #1918

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -220,29 +220,30 @@ fn validate_team_leads(data: &Data, errors: &mut Vec<String>) {
     });
 }
 
-/// Ensure team members are people and don't contain duplicates
+/// Ensure team members are real people and not duplicated
 fn validate_team_members(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.teams(), errors, |team, errors| {
-        let mut seen = std::collections::HashSet::new();
+        // Check for duplicate members in explicit_members
+        let mut seen = HashSet::new();
+        for member in team.explicit_members() {
+            if !seen.insert(&member.github) {
+                bail!(
+                    "person `{}` is duplicated in team `{}`",
+                    member.github,
+                    team.name()
+                );
+            }
+        }
+        
+        // Existing validation: ensure members are real people
         wrapper(team.members(data)?.iter(), errors, |member, _| {
-            // Check if member exists
             if data.person(member).is_none() {
                 bail!(
-                    "person {} is member of team {} but doesn't exist",
+                    "person `{}` is member of team `{}` but doesn't exist",
                     member,
                     team.name()
                 );
             }
-
-            // Check for duplicates
-            if !seen.insert(member) {
-                bail!(
-                    "person {} is listed multiple times in team {}",
-                    member,
-                    team.name()
-                );
-            }
-
             Ok(())
         });
         Ok(())


### PR DESCRIPTION
Added HashSet to track members in validate_team_members. Validation now fails if duplicate found in same team like rylev in mods-venue.toml. Fixes #1918