### PR TITLE
rename default branch to main

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -33,9 +33,9 @@ jobs:
         with:
           # If the PR is from this repository, checkout the PR sha,
           # so that we can also test code changes.
-          # If it is from a fork, then always checkout the 'master' branch,
+          # If it is from a fork, then always checkout the 'main' branch,
           # to avoid checking out code of untrusted PRs.
-          ref: ${{ github.event.workflow_run.head_repository.full_name != 'rust-lang/team' && 'master' || github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_repository.full_name != 'rust-lang/team' && 'main' || github.event.workflow_run.head_sha }}
           persist-credentials: false
 
       - name: Install Rust Stable

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -365,7 +365,7 @@ Admins cannot override these branch protections. If an admin needs to do that, t
 # The branch protections (optional)
 [[branch-protections]]
 # The pattern matching the branches to be protected (required)
-pattern = "master"
+pattern = "main"
 # Which CI checks to are required for merging (optional)
 # Cannot be set if `pr-required` is `false`.
 #

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -9,6 +9,6 @@ team-repo-admins = "write"
 infra = "triage"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 ci-checks = ["CI"]
 dismiss-stale-review = true


### PR DESCRIPTION
Is this enough? Or some other repo depends on `master`?

Related to https://github.com/rust-lang/infra-team/issues/227

before merging this:
- [x] change the branch name in the settings
- [x] update the branch name in https://github.com/rust-lang/team/settings/environments