### PR TITLE
Remove website entry for the alumni team

### DIFF
--- a/teams/alumni.toml
+++ b/teams/alumni.toml
@@ -10,8 +10,3 @@ kind = "marker-team"
 leads = []
 members = []
 include-all-alumni = true
-
-[website]
-name = "Rust team alumni"
-description = "Enjoying a leisurely retirement"
-weight = -1000


### PR DESCRIPTION
All alumni are now automatically shown in https://rust-lang.org/governance/all-team-members.html and https://rust-lang.org/governance/archived-teams.html.

Marker teams with a website entry should be reserved for teams that we actually want to show on the website in the page of a specific toplevel team.

Unblocks https://github.com/rust-lang/www.rust-lang.org/pull/2213.