### PR TITLE
Create `smol-str` marker team for `rust-analyzer/smol_str`

### DIFF
--- a/repos/rust-analyzer/smol_str.toml
+++ b/repos/rust-analyzer/smol_str.toml
@@ -5,3 +5,4 @@ bots = []
 
 [access.teams]
 rust-analyzer = "write"
+smol-str = "write"

--- a/teams/smol-str.toml
+++ b/teams/smol-str.toml
@@ -1,0 +1,12 @@
+name = "smol-str"
+kind = "marker-team"
+
+[people]
+leads = ["alexheretic"]
+members = [
+    "alexheretic",
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-analyzer"]


### PR DESCRIPTION
The https://github.com/rust-analyzer/smol_str repo permissions are also managed through the `team` repo, so manually granted write access will be lost on a permission sync (see https://github.com/rust-lang/team/pull/2030#issuecomment-3432332417).

This PR creates a new marker team `smol-str` mimicking `expect-test`'s approach[^subteam] https://github.com/rust-lang/team/blob/d6a865c5c52f17264cdce520bc2500f7c4a24b3f/teams/expect-test.toml#L1 to restore write access to @alexheretic (who I believe was invited to collaborate on`smol_str` but was added not through `team` repo).

Discussion: [#t-infra > rust-analyer/smol_str permissions](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/rust-analyer.2Fsmol_str.20permissions/with/546875651)

This needs a co-lead approval from the parent team (rust-analyzer) so cc @Veykril. Please let me know if this is the intended permission setup.


[^subteam]: Note that `expect-test` is not a proper `rust-analyzer` subteam but a marker team, not sure if that's intended or not. I chose to follow the existing approach to restore the lost write access.