### PR TITLE
Grant `rust-analyzer` team perf/crater permissions

### DIFF
--- a/teams/rust-analyzer.toml
+++ b/teams/rust-analyzer.toml
@@ -27,6 +27,8 @@ repo = "https://github.com/rust-lang/rust-analyzer"
 
 [permissions]
 bors.rust.review = true
+perf = true
+crater = true
 
 [[github]]
 orgs = ["rust-lang", "rust-analyzer"]


### PR DESCRIPTION
rust-analyzer team already has bors r+ permissions, it makes sense to grant r-a perf and crater permissions for perf experiments and such as well.

Discussed in [#t-infra > r-a team has bors.rust.review = true but no other perms?](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/r-a.20team.20has.20bors.2Erust.2Ereview.20.3D.20true.20but.20no.20other.20perms.3F/with/541134128).

FYI @rust-lang/rust-analyzer 