### PR TITLE
repos/crates.io: Disable PR requirement

### DIFF
--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -17,3 +17,4 @@ ci-checks = [
     "Backend / dependencies",
 ]
 required-approvals = 0
+pr-required = false


### PR DESCRIPTION
This will allow https://github.com/rust-lang/crates.io/pull/12225 to work as intended. All team members with write permissions are aware anyway that we are supposed to use the PR workflow.