### PR TITLE
Remove branch protections from `crates.io` repository

### DIFF
--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -6,14 +6,3 @@ bots = ["renovate", "rustbot", "heroku-deploy-access"]
 
 [access.teams]
 crates-io = "write"
-
-[[branch-protections]]
-pattern = "main"
-ci-checks = [
-    "Backend / Lint",
-    "Backend / Test",
-    "Frontend / Lint",
-    "Frontend / Test",
-    "Backend / dependencies",
-]
-required-approvals = 0


### PR DESCRIPTION
The `team` repo currently only supports creating "classic" branch protections, not the more modern "rulesets". Unfortunately rulesets are required to allow GitHub Apps to bypass branch protections (e.g. to push to protected branches without PRs). For the crates.io repository, Marco manually created a ruleset based on the current classic branch protection. Once the `team` repo supports rulesets we will bring them back into the repo.

Context: https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/crates.2Eio.20GitHub.20app/with/547767243