### PR TITLE
Rename `Osintedx` -> `iownrena`

### DIFF
--- a/people/iownrena.toml
+++ b/people/iownrena.toml
@@ -1,5 +1,5 @@
 name = 'Taylor'
-github = 'Osintedx'
+github = 'iownrena'
 github-id = 88603393
 email = 'taylor@nottaylorswift.com'
 zulip-id = 951106

--- a/teams/wg-triage.toml
+++ b/teams/wg-triage.toml
@@ -33,7 +33,7 @@ members = [
     "shard77",
     "xizheyin",
     "karolzwolak",
-    "Osintedx",
+    "iownrena",
     "theemathas",
     "Hayden602",
 ]


### PR DESCRIPTION
Since their github handle changed, which causes team repo CI checks to fail.