### PR TITLE
Change branch protection for `rust-lang/rust`

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -28,7 +28,7 @@ types = "write"
 wg-triage = "write"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 merge-bots = ["homu"]
 
 [[branch-protections]]


### PR DESCRIPTION
In preparation for https://blog.rust-lang.org/inside-rust/2025/10/16/renaming-the-default-branch-of-rust-lang-rust/.
