### PR TITLE
Remove Kivooeo cloud-compute

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -17,7 +17,6 @@ members = [
     "hkBst",
     "tiif",
     "purplesyringa",
-    "Kivooeo",
     "nia-e",
 ]
 


### PR DESCRIPTION
Redundant since https://github.com/rust-lang/team/pull/2059

I'm very grateful for the early access to the dev desktops. It was a great help and enabled me to contribute much more effectively