### PR TITLE
Archive `smol_str`, `text-size` and `ungrammar`

### DIFF
--- a/repos/archive/rust-analyzer/smol_str.toml
+++ b/repos/archive/rust-analyzer/smol_str.toml
@@ -4,4 +4,3 @@ description = ""
 bots = []
 
 [access.teams]
-rust-analyzer = "write"

--- a/repos/archive/rust-analyzer/text-size.toml
+++ b/repos/archive/rust-analyzer/text-size.toml
@@ -1,7 +1,6 @@
 org = "rust-analyzer"
-name = "ungrammar"
+name = "text-size"
 description = ""
 bots = []
 
 [access.teams]
-rust-analyzer = "write"

--- a/repos/archive/rust-analyzer/ungrammar.toml
+++ b/repos/archive/rust-analyzer/ungrammar.toml
@@ -1,7 +1,6 @@
 org = "rust-analyzer"
-name = "text-size"
+name = "ungrammar"
 description = ""
 bots = []
 
 [access.teams]
-rust-analyzer = "write"


### PR DESCRIPTION
We have moved these repos into the main rust-analyzer repo