### PR TITLE
add leads to private project-leads channel

### DIFF
--- a/teams/leads.toml
+++ b/teams/leads.toml
@@ -12,3 +12,10 @@ orgs = ["rust-lang"]
 [[lists]]
 address = "leads@rust-lang.org"
 extra-teams = ["wg-leads", "leadership-council"]
+
+[[zulip-streams]]
+name = "project leads (private)"
+extra-teams = [
+    "leadership-council",
+    "foundation-board-project-directors"
+]


### PR DESCRIPTION
This channel exists but hasn't been used in many years and isn't fit for purpose, having a wildly out-of-date membership. There's a public project leads channel too which should be used preferentially, but this might as well be maintained just in case it is useful.