### PR TITLE
Add rfcbot to `style-team` repo

### DIFF
--- a/repos/rust-lang/style-team.toml
+++ b/repos/rust-lang/style-team.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "style-team"
 description = "Home of the Rust style team"
-bots = ["rustbot"]
+bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 style = "maintain"


### PR DESCRIPTION
On the style team, we often do FCPs on issues in the `style-team` repo.  For this to work correctly, we need to list "rfcbot" among the allowed bots.  Let's do that.

cc @rust-lang/style
