### PR TITLE
stdarch: rename default branch to main

### DIFF
--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -12,6 +12,6 @@ libs-api = "write"
 libs-contributors = "write"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 ci-checks = ["conclusion"]
 required-approvals = 0


### PR DESCRIPTION
See https://github.com/rust-lang/stdarch/pull/1957