### PR TITLE
zulip api: unsubscribe doesn't take an object

### DIFF
--- a/sync-team/src/zulip/api.rs
+++ b/sync-team/src/zulip/api.rs
@@ -241,9 +241,7 @@ impl ZulipApi {
         }
 
         if !remove_ids.is_empty() {
-            let subscriptions = serde_json::to_string(&serde_json::json!([{
-                "name": stream_name,
-            }]))?;
+            let subscriptions = serde_json::to_string(&serde_json::json!([stream_name]))?;
             let remove_ids = serialize_as_array(remove_ids);
             submit(reqwest::Method::DELETE, subscriptions, remove_ids)?;
         }


### PR DESCRIPTION
#2066 didn't have the intended effect. `users/me/subscriptions` subscriptions takes [a object for subscribing](https://zulip.com/api/subscribe#parameter-subscriptions) and [a string for unsubscribing](https://zulip.com/api/unsubscribe#parameter-subscriptions).