### PR TITLE
Configure a `T-website` zulip group for the website team

### DIFF
--- a/teams/website.toml
+++ b/teams/website.toml
@@ -21,3 +21,6 @@ name = "Website team"
 description = "Manages the www.rust-lang.org website"
 repo = "https://github.com/rust-lang/www.rust-lang.org/"
 zulip-stream = "t-website"
+
+[[zulip-groups]]
+name = "T-website"


### PR DESCRIPTION
This was discussed in [#t-infra > Zulip stream for t-website @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Zulip.20stream.20for.20t-website/near/553759673), was reminded again in [#council > Index of "fundable" Rust contributors on the Rust website @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/Index.20of.20.22fundable.22.20Rust.20contributors.20on.20the.20Rust.20website/near/554860648).

This will allow other people to ping the website team on zulip via `T-website`.

FYI @senekor @Manishearth
