### PR TITLE
Change @jdno's email address

### DIFF
--- a/people/jdno.toml
+++ b/people/jdno.toml
@@ -1,6 +1,6 @@
 name = 'Jan David Nose'
 github = 'jdno'
 github-id = 865550
-email = 'jandavidnose@rustfoundation.org'
+email = 'jdno@jdno.dev'
 discord-id = 953562944472510494
 zulip-id = 534108


### PR DESCRIPTION
I no longer work at the Rust Foundation, so I need to change this to a personal email address that I can still access.