### PR TITLE
Add github sponsors and discord ID for BurntSushi

### DIFF
--- a/people/BurntSushi.toml
+++ b/people/BurntSushi.toml
@@ -4,3 +4,7 @@ github-id = 456674
 irc = "burntsushi"
 email = "jamslam@gmail.com"
 zulip-id = 222471
+discord-id = 433395793635049472
+
+[funding]
+github-sponsors = true


### PR DESCRIPTION
I noticed some other PRs adding this, so I figured I'd add my own. And
while here, I noticed that my Discord id wasn't captured. So I added
that as well.
