### PR TITLE
Add triagebot to glob

### DIFF
--- a/repos/rust-lang/glob.toml
+++ b/repos/rust-lang/glob.toml
@@ -1,11 +1,11 @@
-org = 'rust-lang'
-name = 'glob'
-description = 'Support for matching file paths against Unix shell style patterns.'
-homepage = "http://doc.rust-lang.org/glob"
-bots = []
+org = "rust-lang"
+name = "glob"
+description = "Support for matching file paths against Unix shell style patterns."
+homepage = "https://doc.rust-lang.org/glob"
+bots = ["rustbot"]
 
 [access.teams]
-crate-maintainers = 'maintain'
+crate-maintainers = "maintain"
 
 [[branch-protections]]
 pattern = "master"


### PR DESCRIPTION
It is supposed to be used there (https://github.com/rust-lang/glob/blob/master/triagebot.toml).
