### PR TITLE
Create a private channel that contains all team members

### DIFF
--- a/teams/all.toml
+++ b/teams/all.toml
@@ -45,7 +45,9 @@ excluded-people = [
 
 # Private channel with all team members, so that we can have an easy way of reaching them.
 [[zulip-streams]]
-name = "rust project"
+name = "all/private"
+# Exclude the following people from the Zulip stream for grandfathering purposes,
+# where previously we didn't require all project team members to have Zulip IDs.
 excluded-people = [
     "U007D",
     "andrewpollack",


### PR DESCRIPTION
So that we can communicate with them all at once. This should be a more reliable alternative to the `all@rlo.org` mailing list.
