### PR TITLE
Enable syncing for Zulip `#t-docs-rs/private`

### DIFF
--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -44,3 +44,12 @@ address = "help@docs.rs"
 
 [[zulip-groups]]
 name = "T-docs-rs"
+
+[[zulip-streams]]
+name = "t-docs-rs/private"
+extra-teams = [
+    "infra",
+]
+extra-people = [
+    "walterhpearce",
+]


### PR DESCRIPTION
So based on https://github.com/rust-lang/team/pull/2075, we need to invite rust-lang-owner to the stream first.

Since we also want to have the infra team to have access to this channel, I added them as well.

cc @syphar 