### PR TITLE
chore: Rename annotate-snippets-rs's default branch to main

### DIFF
--- a/repos/rust-lang/annotate-snippets-rs.toml
+++ b/repos/rust-lang/annotate-snippets-rs.toml
@@ -8,6 +8,6 @@ cargo = "write"
 wg-diagnostics = "write"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 ci-checks = ["CI"]
 required-approvals = 0


### PR DESCRIPTION

[#t-infra > moving annotate-snippets under t-compiler @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/moving.20annotate-snippets.20under.20t-compiler/near/556717906)

rust-lang/annotate-snippets-rs#348