### PR TITLE
Make validation error messages more verbose

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1131,7 +1131,7 @@ where
 {
     for item in iter {
         if let Err(err) = func(item, errors) {
-            errors.push(err.to_string());
+            errors.push(format!("{err:?}"));
         }
     }
 }


### PR DESCRIPTION
The inner context is not actually printed by sync-team, so it was swallowed. Found in https://github.com/rust-lang/team/actions/runs/19570968459/job/56044145703?pr=2101.
