### PR TITLE
switch docs.rs to "main" as default branch

### DIFF
--- a/repos/rust-lang/docs.rs.toml
+++ b/repos/rust-lang/docs.rs.toml
@@ -9,5 +9,5 @@ docs-rs = 'write'
 docs-rs-reviewers = 'write'
 
 [[branch-protections]]
-pattern = 'master'
+pattern = 'main'
 required-approvals = 0


### PR DESCRIPTION
see [#t-infra > Renaming default branches from master to main @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Renaming.20default.20branches.20from.20master.20to.20main/near/558428956) 

to review / merge for @marcoieni 