### PR TITLE
Add trusted publishing to mdbook

### DIFF
--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -16,3 +16,17 @@ Dylan-DPC = "write"
 pattern = "master"
 ci-checks = ["Success gate"]
 required-approvals = 0
+
+[[crates-io-publishing]]
+crates = [
+    "mdbook",
+    "mdbook-core",
+    "mdbook-driver",
+    "mdbook-html",
+    "mdbook-markdown",
+    "mdbook-preprocessor",
+    "mdbook-renderer",
+    "mdbook-summary",
+]
+workflow-filename = "deploy.yml"
+environment = "publish"


### PR DESCRIPTION
As per https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Trusted.20publishing.20through.20team/with/559011123.

@ehuss Could you please check if the list of publishable crates looks ok?