### PR TITLE
Fix script for finding publishable package

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -446,4 +446,4 @@ environment = "deploy"
 
 > [!TIP]
 > To list the public crates of a workspace, run:
-> `cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.publish == null or .publish != false) | .name'`
+> `cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.publish == null or .publish == true) | .name'`


### PR DESCRIPTION
When a crate sets `publish = false`, `cargo metadata` seems to represent it with `[]`, rather than `false`.
