### PR TITLE
people/Enselic.toml: funding.github-sponsors = true

### DIFF
--- a/people/Enselic.toml
+++ b/people/Enselic.toml
@@ -3,3 +3,6 @@ github = "Enselic"
 github-id = 115040
 zulip-id = 477660
 email = "enselic@gmail.com"
+
+[funding]
+github-sponsors = true


### PR DESCRIPTION
See [this](https://rust-lang.zulipchat.com/#narrow/channel/546943-all.2Fprivate/topic/Adding.20GitHub.20Sponsors.20information.20to.20team/with/560210281).