### PR TITLE
Rename `simbleau` -> `nuzzles`

### DIFF
--- a/people/nuzzles.toml
+++ b/people/nuzzles.toml
@@ -1,5 +1,5 @@
 name = "Spencer C. Imbleau"
-github = "simbleau"
+github = "nuzzles"
 github-id = 48108917
 zulip-id = 701866
 email = "spencer@imbleau.com"

--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -28,7 +28,7 @@ members = [
     "gstjepan2",
     "Darksonn",
     "cyrgani",
-    "simbleau",
+    "nuzzles",
     "shard77",
     "xizheyin",
     "karolzwolak",


### PR DESCRIPTION
Their github username changed.

cf. CI failure: https://github.com/rust-lang/team/actions/runs/19804501700/job/56736593547?pr=2136