### PR TITLE
feat: add deployment branch support

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -433,16 +433,25 @@ merge-bots = ["homu"]
 
 ### Repository environments
 
-GitHub environments are used to configure deployment protection rules and secrets for GitHub Actions workflows. This repository can manage environment names for repositories.
+GitHub environments are used to configure deployment protection rules and secrets for GitHub Actions workflows. This repository can manage environment names and deployment branch and tag policies for repositories.
 
 ```toml
 # The environments in this repository (optional)
-[[environments]]
-# The name of the environment (required)
-name = "production"
+# Use table-of-tables syntax where the key is the environment name
+[environments.production]
+# List of branch patterns that can deploy to this environment (optional)
+# If empty or omitted, any branch can deploy
+branches = ["main", "release/*"]
+# List of tag patterns that can deploy to this environment (optional)
+tags = ["v*", "release-*"]
 
-[[environments]]
-name = "staging"
+[environments.staging]
+# Only specific branches can deploy to staging
+branches = ["develop", "staging"]
+# No tag patterns specified - no tags can deploy
+
+[environments.development]
+# No branch or tag patterns specified - any branch or tag can deploy
 ```
 
 ### Crates.io crate management

--- a/repos/rust-analyzer/metrics.toml
+++ b/repos/rust-analyzer/metrics.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 rust-analyzer = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-analyzer/rust-analyzer.github.io.toml
+++ b/repos/rust-analyzer/rust-analyzer.github.io.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 rust-analyzer = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang-nursery/lazy-static.rs.toml
+++ b/repos/rust-lang-nursery/lazy-static.rs.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 libs = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang-nursery/rust-cookbook.toml
+++ b/repos/rust-lang-nursery/rust-cookbook.toml
@@ -7,6 +7,6 @@ bots = []
 cookbook = "write"
 lang-docs = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["gh-pages"]
 

--- a/repos/rust-lang-nursery/rust-lang-nursery.github.io.toml
+++ b/repos/rust-lang-nursery/rust-lang-nursery.github.io.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang-nursery/rust-toolstate.toml
+++ b/repos/rust-lang-nursery/rust-toolstate.toml
@@ -11,6 +11,5 @@ infra = "write"
 pattern = "master"
 pr-required = false
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/a-mir-formality.toml
+++ b/repos/rust-lang/a-mir-formality.toml
@@ -9,6 +9,6 @@ lang-ops = "maintain"
 lang-docs = "maintain"
 types = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 

--- a/repos/rust-lang/annotate-snippets-rs.toml
+++ b/repos/rust-lang/annotate-snippets-rs.toml
@@ -17,5 +17,4 @@ crates = ["annotate-snippets"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
 
-[[environments]]
-name = "publish"
+[environments.publish]

--- a/repos/rust-lang/api-guidelines.toml
+++ b/repos/rust-lang/api-guidelines.toml
@@ -8,6 +8,5 @@ bots = []
 libs-api = "write"
 libs = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/ar_archive_writer.toml
+++ b/repos/rust-lang/ar_archive_writer.toml
@@ -6,8 +6,9 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[environments]]
-name = "publish"
+[environments.publish]
+branches = ["master"]
+tags = ["*"]
 
 [[crates-io]]
 crates = ["ar_archive_writer"]

--- a/repos/rust-lang/areweasyncyet.rs.toml
+++ b/repos/rust-lang/areweasyncyet.rs.toml
@@ -10,6 +10,6 @@ wg-async = "write"
 [access.individuals]
 upsuper = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/arewewebyet.toml
+++ b/repos/rust-lang/arewewebyet.toml
@@ -10,6 +10,5 @@ arewewebyet = "maintain"
 [[branch-protections]]
 pattern = 'master'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/async-book.toml
+++ b/repos/rust-lang/async-book.toml
@@ -7,6 +7,6 @@ bots = []
 [access.teams]
 wg-async = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/async-crashdump-debugging-initiative.toml
+++ b/repos/rust-lang/async-crashdump-debugging-initiative.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 project-async-crashdump-debugging = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/async-fundamentals-initiative.toml
+++ b/repos/rust-lang/async-fundamentals-initiative.toml
@@ -11,6 +11,6 @@ wg-async = "maintain"
 pattern = "master"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -10,6 +10,5 @@ crate-maintainers = 'maintain'
 [[branch-protections]]
 pattern = 'master'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -17,6 +17,6 @@ ci-checks = [
     "build",
 ]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 

--- a/repos/rust-lang/book.toml
+++ b/repos/rust-lang/book.toml
@@ -12,6 +12,6 @@ pattern = "main"
 ci-checks = []
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["gh-pages"]
 

--- a/repos/rust-lang/bors-kindergarten.toml
+++ b/repos/rust-lang/bors-kindergarten.toml
@@ -7,15 +7,11 @@ bots = ["rustbot"]
 infra = "write"
 infra-bors = "write"
 
-[[environments]]
-name = "bors"
+[environments.bors]
 
-[[environments]]
-name = "ci"
+[environments.ci]
 
-[[environments]]
-name = "production"
+[environments.production]
 
-[[environments]]
-name = "staging"
+[environments.staging]
 

--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -14,9 +14,9 @@ pattern = "main"
 ci-checks = ["Test", "Test Docker"]
 required-approvals = 0
 
-[[environments]]
-name = "production"
+[environments.production]
+branches = ["main"]
 
-[[environments]]
-name = "staging"
+[environments.staging]
+branches = ["main"]
 

--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -20,6 +20,6 @@ wg-async = "maintain"
 pattern = "main"
 pr-required = false
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 

--- a/repos/rust-lang/cargo-bisect-rustc.toml
+++ b/repos/rust-lang/cargo-bisect-rustc.toml
@@ -14,6 +14,6 @@ ehuss = "write"
 pattern = "master"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["gh-pages", "master"]
 

--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -15,9 +15,8 @@ ci-checks = ["conclusion"]
 pattern = "rust-1.*"
 ci-checks = ["conclusion"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 
-[[environments]]
-name = "release"
+[environments.release]
+tags = ["*"]
 

--- a/repos/rust-lang/cc-rs.toml
+++ b/repos/rust-lang/cc-rs.toml
@@ -18,9 +18,8 @@ publish-workflow = "publish.yml"
 publish-environment = "publish"
 teams = ["libs"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 
-[[environments]]
-name = "publish"
+[environments.publish]
+branches = ["main"]
 

--- a/repos/rust-lang/cfg-if.toml
+++ b/repos/rust-lang/cfg-if.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/chalk.toml
+++ b/repos/rust-lang/chalk.toml
@@ -7,6 +7,5 @@ bots = ["rustbot"]
 [access.teams]
 types = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/ci-mirrors.toml
+++ b/repos/rust-lang/ci-mirrors.toml
@@ -12,6 +12,5 @@ pattern = "main"
 ci-checks = ["Build finished"]
 dismiss-stale-review = true
 
-[[environments]]
-name = "upload"
+[environments.upload]
 

--- a/repos/rust-lang/cmake-rs.toml
+++ b/repos/rust-lang/cmake-rs.toml
@@ -12,6 +12,5 @@ pattern = "master"
 ci-checks = ['success']
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/compiler-team.toml
+++ b/repos/rust-lang/compiler-team.toml
@@ -13,6 +13,5 @@ types = "write"
 pattern = "master"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/const-eval.toml
+++ b/repos/rust-lang/const-eval.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 wg-const-eval = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -7,9 +7,7 @@ bots = ["renovate", "rustbot", "heroku-deploy-access"]
 [access.teams]
 crates-io = "write"
 
-[[environments]]
-name = "crates-io"
+[environments.crates-io]
 
-[[environments]]
-name = "staging-crates-io"
+[environments.staging-crates-io]
 

--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -12,8 +12,7 @@ pattern = "main"
 required-approvals = 0
 pr-required = false
 
-[[environments]]
-name = "release"
+[environments.release]
 
 [[crates-io]]
 crates = ["crates_io_og_image"]

--- a/repos/rust-lang/dyn-upcasting-coercion-initiative.toml
+++ b/repos/rust-lang/dyn-upcasting-coercion-initiative.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 project-dyn-upcasting = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/edition-guide.toml
+++ b/repos/rust-lang/edition-guide.toml
@@ -12,6 +12,5 @@ pattern = "master"
 ci-checks = ["Success gate"]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/enzyme.toml
+++ b/repos/rust-lang/enzyme.toml
@@ -21,6 +21,5 @@ pr-required = false
 pattern = "master"
 pr-required = false
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/flate2-rs.toml
+++ b/repos/rust-lang/flate2-rs.toml
@@ -10,6 +10,5 @@ crate-maintainers = 'maintain'
 [[branch-protections]]
 pattern = 'main'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/fls.toml
+++ b/repos/rust-lang/fls.toml
@@ -17,6 +17,6 @@ spec-contributors = "triage"
 pattern = "main"
 ci-checks = ["CI finished"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["gh-readonly-queue/main/*", "main"]
 

--- a/repos/rust-lang/futures-rs.toml
+++ b/repos/rust-lang/futures-rs.toml
@@ -11,6 +11,5 @@ wg-async = "write"
 pattern = "master"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/generic-associated-types-initiative.toml
+++ b/repos/rust-lang/generic-associated-types-initiative.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 project-generic-associated-types = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/getopts.toml
+++ b/repos/rust-lang/getopts.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/gha-self-hosted.toml
+++ b/repos/rust-lang/gha-self-hosted.toml
@@ -10,6 +10,5 @@ infra = "write"
 pattern = "main"
 ci-checks = ["CI finished"]
 
-[[environments]]
-name = "upload"
+[environments.upload]
 

--- a/repos/rust-lang/git2-rs.toml
+++ b/repos/rust-lang/git2-rs.toml
@@ -12,6 +12,5 @@ pattern = "master"
 ci-checks = ["Success gate"]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/glob.toml
+++ b/repos/rust-lang/glob.toml
@@ -12,6 +12,5 @@ pattern = "master"
 ci-checks = ["success"]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/hashbrown.toml
+++ b/repos/rust-lang/hashbrown.toml
@@ -13,6 +13,5 @@ pattern = "master"
 ci-checks = ["conclusion"]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/impl-trait-initiative.toml
+++ b/repos/rust-lang/impl-trait-initiative.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 project-impl-trait = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/initiative-template.toml
+++ b/repos/rust-lang/initiative-template.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 lang = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/jobserver-rs.toml
+++ b/repos/rust-lang/jobserver-rs.toml
@@ -7,6 +7,5 @@ bots = []
 cargo = "write"
 compiler = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/keyword-generics-initiative.toml
+++ b/repos/rust-lang/keyword-generics-initiative.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 project-keyword-generics = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/lang-team.toml
+++ b/repos/rust-lang/lang-team.toml
@@ -11,6 +11,6 @@ lang-docs = "maintain"
 types = "maintain"
 release = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["gh-pages", "master"]
 

--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -19,6 +19,6 @@ pattern = 'libc-0.2'
 ci-checks = ['success']
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["gh-pages", "main", "master"]
 

--- a/repos/rust-lang/libz-sys.toml
+++ b/repos/rust-lang/libz-sys.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/log.toml
+++ b/repos/rust-lang/log.toml
@@ -10,6 +10,5 @@ crate-maintainers = 'maintain'
 [access.individuals]
 Thomasdezeeuw = 'maintain'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -31,9 +31,9 @@ crates = [
 publish-workflow = "deploy.yml"
 publish-environment = "publish"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 
-[[environments]]
-name = "publish"
+[environments.publish]
+branches = ["master"]
+tags = ["*"]
 

--- a/repos/rust-lang/measureme.toml
+++ b/repos/rust-lang/measureme.toml
@@ -19,6 +19,7 @@ crates = ["analyzeme", "decodeme", "measureme"]
 publish-workflow = "publish.yml"
 publish-environment = "publish"
 
-[[environments]]
-name = "publish"
+[environments.publish]
+branches = ["master"]
+tags = ["*"]
 

--- a/repos/rust-lang/negative-impls-initiative.toml
+++ b/repos/rust-lang/negative-impls-initiative.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 project-negative-impls = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/packed_simd.toml
+++ b/repos/rust-lang/packed_simd.toml
@@ -10,6 +10,5 @@ libs-api = "write"
 libs = "write"
 project-portable-simd = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/pkg-config-rs.toml
+++ b/repos/rust-lang/pkg-config-rs.toml
@@ -10,6 +10,5 @@ crate-maintainers = "maintain"
 [access.individuals]
 sdroege = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/polonius.toml
+++ b/repos/rust-lang/polonius.toml
@@ -6,6 +6,6 @@ bots = []
 [access.teams]
 wg-polonius = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/pontoon.toml
+++ b/repos/rust-lang/pontoon.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[environments]]
-name = "rust-pontoon"
+[environments.rust-pontoon]
 

--- a/repos/rust-lang/portable-simd.toml
+++ b/repos/rust-lang/portable-simd.toml
@@ -10,6 +10,5 @@ project-portable-simd = "write"
 pattern = "master"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/project-const-generics.toml
+++ b/repos/rust-lang/project-const-generics.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 project-const-generics = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/project-goal-reference-expansion.toml
+++ b/repos/rust-lang/project-goal-reference-expansion.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 project-goal-reference-expansion = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/project-group-template.toml
+++ b/repos/rust-lang/project-group-template.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 leadership-council = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/project-stable-mir.toml
+++ b/repos/rust-lang/project-stable-mir.toml
@@ -9,6 +9,5 @@ project-stable-mir = "write"
 [[branch-protections]]
 pattern = "main"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/regex.toml
+++ b/repos/rust-lang/regex.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 regex = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rfcbot-rs.toml
+++ b/repos/rust-lang/rfcbot-rs.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[environments]]
-name = "rfcbot-rs"
+[environments.rfcbot-rs]
 

--- a/repos/rust-lang/rfcs.toml
+++ b/repos/rust-lang/rfcs.toml
@@ -11,6 +11,6 @@ all = "write"
 pattern = "master"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -13,6 +13,5 @@ pattern = "master"
 ci-checks = ["conclusion"]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rust-bindgen.toml
+++ b/repos/rust-lang/rust-bindgen.toml
@@ -12,6 +12,5 @@ pattern = "main"
 required-approvals = 0
 ci-checks = ["success"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rust-by-example.toml
+++ b/repos/rust-lang/rust-by-example.toml
@@ -7,6 +7,5 @@ bots = ["rustbot"]
 [access.teams]
 rust-by-example = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -18,6 +18,5 @@ ci-checks = [
 ]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rust-enhanced.toml
+++ b/repos/rust-lang/rust-enhanced.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 devtools = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -27,6 +27,6 @@ rustc-dev-guide = "maintain"
 pattern = "master"
 ci-checks = ["test"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/rust-lang.github.io.toml
+++ b/repos/rust-lang/rust-lang.github.io.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rust-log-analyzer.toml
+++ b/repos/rust-lang/rust-log-analyzer.toml
@@ -11,6 +11,5 @@ pattern = "master"
 ci-checks = ["CI"]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rust-project-goals.toml
+++ b/repos/rust-lang/rust-project-goals.toml
@@ -17,6 +17,6 @@ edition = "maintain"
 goals = "maintain"
 goal-owners = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 

--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -83,6 +83,6 @@ merge-bots = ["rust-timer"]
 pattern = "perf-tmp"
 merge-bots = ["rust-timer"]
 
-[[environments]]
-name = "bors"
+[environments.bors]
+branches = ["auto", "automation/bors/try", "try", "try-perf"]
 

--- a/repos/rust-lang/rustc-demangle.toml
+++ b/repos/rust-lang/rustc-demangle.toml
@@ -17,6 +17,5 @@ ci-checks = [
     "Publish Documentation"
 ]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -29,6 +29,5 @@ required-approvals = 0
 [[branch-protections]]
 pattern = "master-old"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rustc-pr-tracking.toml
+++ b/repos/rust-lang/rustc-pr-tracking.toml
@@ -7,6 +7,5 @@ bots = ["highfive"]
 [access.teams]
 release = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rustc-reading-club.toml
+++ b/repos/rust-lang/rustc-reading-club.toml
@@ -5,6 +5,5 @@ bots = []
 
 [access.teams]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rustfmt.toml
+++ b/repos/rust-lang/rustfmt.toml
@@ -35,6 +35,6 @@ required-approvals = 0
 pattern = "rust-1.*"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 

--- a/repos/rust-lang/rustlings.toml
+++ b/repos/rust-lang/rustlings.toml
@@ -7,6 +7,6 @@ bots = []
 [access.teams]
 rustlings = "maintain"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["gh-pages", "main"]
 

--- a/repos/rust-lang/rustup-components-history.toml
+++ b/repos/rust-lang/rustup-components-history.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -11,6 +11,5 @@ rustup = "maintain"
 pattern = "main"
 ci-checks = ["conclusion"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/socket2.toml
+++ b/repos/rust-lang/socket2.toml
@@ -25,6 +25,5 @@ ci-checks = [
     'Test (windows)',
 ]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/stacker.toml
+++ b/repos/rust-lang/stacker.toml
@@ -6,6 +6,5 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/std-dev-guide.toml
+++ b/repos/rust-lang/std-dev-guide.toml
@@ -14,6 +14,5 @@ rustc-dev-guide = "write"
 pattern = "master"
 ci-checks = ["book-test"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -17,6 +17,5 @@ pattern = "main"
 ci-checks = ["conclusion"]
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -13,9 +13,9 @@ pattern = "main"
 ci-checks = ["CI"]
 dismiss-stale-review = true
 
-[[environments]]
-name = "deploy"
+[environments.deploy]
+branches = ["gh-readonly-queue/main/*", "main"]
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 

--- a/repos/rust-lang/thanks.toml
+++ b/repos/rust-lang/thanks.toml
@@ -8,6 +8,6 @@ bots = []
 website = "write"
 infra = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/thorin.toml
+++ b/repos/rust-lang/thorin.toml
@@ -15,6 +15,6 @@ publish-workflow = "release-plz.yml"
 publish-environment = "publish"
 teams = ["compiler"]
 
-[[environments]]
-name = "publish"
+[environments.publish]
+branches = ["main"]
 

--- a/repos/rust-lang/types-team.toml
+++ b/repos/rust-lang/types-team.toml
@@ -7,6 +7,5 @@ bots = ["rustbot"]
 [access.teams]
 types = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/repos/rust-lang/unsafe-code-guidelines.toml
+++ b/repos/rust-lang/unsafe-code-guidelines.toml
@@ -7,6 +7,6 @@ bots = ["rustbot", "rfcbot"]
 [access.teams]
 opsem = 'maintain'
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/wg-async.toml
+++ b/repos/rust-lang/wg-async.toml
@@ -11,6 +11,6 @@ wg-async = "write"
 pattern = "master"
 required-approvals = 0
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["master"]
 

--- a/repos/rust-lang/wg-macros.toml
+++ b/repos/rust-lang/wg-macros.toml
@@ -9,6 +9,6 @@ wg-macros = "maintain"
 [[branch-protections]]
 pattern = "main"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 

--- a/repos/rust-lang/www.rust-lang.org.toml
+++ b/repos/rust-lang/www.rust-lang.org.toml
@@ -10,15 +10,12 @@ website = "write"
 [[branch-protections]]
 pattern = "main"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
+branches = ["main"]
 
-[[environments]]
-name = "new-rust-www"
+[environments.new-rust-www]
 
-[[environments]]
-name = "rust-www-staging"
+[environments.rust-www-staging]
 
-[[environments]]
-name = "rust-www-try"
+[environments.rust-www-try]
 

--- a/repos/rust-lang/zulip_archive.toml
+++ b/repos/rust-lang/zulip_archive.toml
@@ -7,6 +7,5 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[environments]]
-name = "github-pages"
+[environments.github-pages]
 

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -175,7 +175,7 @@ pub struct Repo {
     pub members: Vec<RepoMember>,
     pub branch_protections: Vec<BranchProtection>,
     pub crates: Vec<Crate>,
-    pub environments: Vec<Environment>,
+    pub environments: IndexMap<String, Environment>,
     pub archived: bool,
     // This attribute is not synced by sync-team.
     pub private: bool,
@@ -269,7 +269,10 @@ pub struct CratesIoPublishing {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Environment {
-    pub name: String,
+    #[serde(default)]
+    pub branches: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,8 +502,20 @@ fn run() -> Result<(), Error> {
                 let repo_name = format!("{}/{}", repo.org, repo.name);
                 if !repo.environments.is_empty() {
                     println!("{repo_name}:");
-                    for env in &repo.environments {
-                        println!("  - {}", env.name);
+                    for (env_name, env) in &repo.environments {
+                        print!("  - {env_name}");
+
+                        // Show branches if present
+                        if !env.branches.is_empty() {
+                            print!(" (branches: {})", env.branches.join(", "));
+                        }
+
+                        // Show tags if present
+                        if !env.tags.is_empty() {
+                            print!(" (tags: {})", env.tags.join(", "));
+                        }
+
+                        println!();
                     }
                 } else {
                     println!("{repo_name}: (no environments)");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,7 +3,7 @@ pub(crate) use crate::permissions::Permissions;
 use anyhow::{bail, format_err, Error};
 use serde::de::{Deserialize, Deserializer};
 use serde_untagged::UntaggedEnumVisitor;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 #[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -814,7 +814,7 @@ pub(crate) struct Repo {
     #[serde(default)]
     pub crates_io: Vec<CratesIoConfiguration>,
     #[serde(default)]
-    pub environments: Vec<Environment>,
+    pub environments: BTreeMap<String, Environment>,
 }
 
 #[derive(serde_derive::Deserialize, Debug, Clone, PartialEq)]
@@ -891,5 +891,10 @@ pub(crate) struct CratesIoConfiguration {
 #[derive(serde_derive::Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Environment {
-    pub name: String,
+    /// Branch patterns that can deploy to this environment
+    #[serde(default)]
+    pub branches: Vec<String>,
+    /// Tag patterns that can deploy to this environment
+    #[serde(default)]
+    pub tags: Vec<String>,
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -182,13 +182,23 @@ impl<'a> Generator<'a> {
                         })
                         .collect::<anyhow::Result<Vec<Crate>>>()?
                 },
-                environments: r
-                    .environments
-                    .iter()
-                    .map(|e| v1::Environment {
-                        name: e.name.clone(),
-                    })
-                    .collect(),
+                environments: {
+                    let mut envs: Vec<_> = r
+                        .environments
+                        .iter()
+                        .map(|(name, env)| {
+                            (
+                                name.clone(),
+                                v1::Environment {
+                                    branches: env.branches.clone(),
+                                    tags: env.tags.clone(),
+                                },
+                            )
+                        })
+                        .collect();
+                    envs.sort_by(|a, b| a.0.cmp(&b.0));
+                    envs.into_iter().collect()
+                },
                 archived,
                 auto_merge_enabled: !managed_by_bors,
             };

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -25,7 +25,7 @@
         }
       ],
       "crates": [],
-      "environments": [],
+      "environments": {},
       "archived": true,
       "private": false,
       "auto_merge_enabled": true
@@ -103,7 +103,7 @@
           ]
         }
       ],
-      "environments": [],
+      "environments": {},
       "archived": false,
       "private": false,
       "auto_merge_enabled": true

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -23,7 +23,7 @@
     }
   ],
   "crates": [],
-  "environments": [],
+  "environments": {},
   "archived": true,
   "private": false,
   "auto_merge_enabled": true

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -71,7 +71,7 @@
       ]
     }
   ],
-  "environments": [],
+  "environments": {},
   "archived": false,
   "private": false,
   "auto_merge_enabled": true


### PR DESCRIPTION
Closes: #2132
Extends environment configuration to support specifying deployment branch restrictions, allowing teams to control which branches can deploy to each environment via a new field in the TOML schema.