### PR TITLE
Actually run crates-io sync in dry run workflow

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -76,7 +76,7 @@ jobs:
           # cargo leaking into the output file.
           cargo build --release
           ./target/release/rust-team sync print-plan \
-            --services github \
+            --services crates-io,github \
             --src team-api 2>&1 | tee -a output.txt
 
       - name: Prepare comment


### PR DESCRIPTION
Sigh.
