### PR TITLE
Add a `funding` repository

### DIFF
--- a/repos/rust-lang/funding.toml
+++ b/repos/rust-lang/funding.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "funding"
+description = "Discussions about funding Rust maintainers"
+bots = ["rfcbot"]
+
+[access.teams]
+leadership-council = "write"


### PR DESCRIPTION
To discuss funding matters, such as the Rust Foundation Maintainer Fund (RFMF), and operations of the RFMF subcommittee (https://github.com/rust-lang/leadership-council/pull/248).

I didn't create a team for the subcommittee to make this simpler, LC access for merging PRs should be enough for now, everyone will be able to create issues or comment on PRs.
