### PR TITLE
Backfill all crates.io crates

### DIFF
--- a/repos/rust-analyzer/rowan.toml
+++ b/repos/rust-analyzer/rowan.toml
@@ -5,3 +5,7 @@ bots = []
 
 [access.teams]
 rust-analyzer = "write"
+
+[[crates-io-publishing]]
+crates = ["rowan"]
+teams = ["review"]

--- a/repos/rust-lang/ar_archive_writer.toml
+++ b/repos/rust-lang/ar_archive_writer.toml
@@ -9,3 +9,7 @@ compiler = "write"
 [[environments]]
 name = "publish"
 
+
+[[crates-io-publishing]]
+crates = ["ar_archive_writer"]
+teams = []

--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -13,3 +13,7 @@ pattern = 'master'
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["backtrace"]
+teams = []

--- a/repos/rust-lang/cargo-bisect-rustc.toml
+++ b/repos/rust-lang/cargo-bisect-rustc.toml
@@ -17,3 +17,7 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["cargo-bisect-rustc"]
+teams = []

--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -21,3 +21,11 @@ name = "github-pages"
 [[environments]]
 name = "release"
 
+
+[[crates-io-publishing]]
+crates = ["cargo-credential-gnome-secret", "home"]
+teams = []
+
+[[crates-io-publishing]]
+crates = ["build-rs", "cargo", "cargo-credential", "cargo-credential-1password", "cargo-credential-libsecret", "cargo-credential-macos-keychain", "cargo-credential-wincred", "cargo-platform", "cargo-test-macro", "cargo-test-support", "cargo-util", "cargo-util-schemas", "crates-io", "rustfix"]
+teams = ["release-publishers"]

--- a/repos/rust-lang/cfg-if.toml
+++ b/repos/rust-lang/cfg-if.toml
@@ -9,3 +9,7 @@ crate-maintainers = 'maintain'
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["cfg-if"]
+teams = ["libs"]

--- a/repos/rust-lang/chalk.toml
+++ b/repos/rust-lang/chalk.toml
@@ -10,3 +10,7 @@ types = "write"
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["chalk-derive", "chalk-engine", "chalk-ir", "chalk-recursive", "chalk-solve"]
+teams = []

--- a/repos/rust-lang/cmake-rs.toml
+++ b/repos/rust-lang/cmake-rs.toml
@@ -15,3 +15,7 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["cmake"]
+teams = ["libs"]

--- a/repos/rust-lang/compiler-builtins.toml
+++ b/repos/rust-lang/compiler-builtins.toml
@@ -10,3 +10,7 @@ crate-maintainers = "maintain"
 pattern = "main"
 ci-checks = ["success"]
 required-approvals = 0
+
+[[crates-io-publishing]]
+crates = ["compiler_builtins", "libm"]
+teams = ["libs"]

--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -13,3 +13,7 @@ name = "crates-io"
 [[environments]]
 name = "staging-crates-io"
 
+
+[[crates-io-publishing]]
+crates = ["cargo-registry", "cargo-registry-s3"]
+teams = ["core", "crates-io-pushers", "crates-io"]

--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -15,3 +15,7 @@ pr-required = false
 [[environments]]
 name = "release"
 
+
+[[crates-io-publishing]]
+crates = ["crates_io_og_image"]
+teams = []

--- a/repos/rust-lang/docs.rs.toml
+++ b/repos/rust-lang/docs.rs.toml
@@ -11,3 +11,7 @@ docs-rs-reviewers = 'write'
 [[branch-protections]]
 pattern = 'main'
 required-approvals = 0
+
+[[crates-io-publishing]]
+crates = ["badge"]
+teams = []

--- a/repos/rust-lang/ferris-says.toml
+++ b/repos/rust-lang/ferris-says.toml
@@ -6,3 +6,7 @@ bots = []
 
 [access.teams]
 crate-maintainers = "maintain"
+
+[[crates-io-publishing]]
+crates = ["ferris-says"]
+teams = ["website", "crate-maintainers"]

--- a/repos/rust-lang/flate2-rs.toml
+++ b/repos/rust-lang/flate2-rs.toml
@@ -13,3 +13,7 @@ pattern = 'main'
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["flate2"]
+teams = []

--- a/repos/rust-lang/gccjit.rs.toml
+++ b/repos/rust-lang/gccjit.rs.toml
@@ -5,3 +5,7 @@ bots = []
 
 [access.teams]
 wg-gcc-backend = "maintain"
+
+[[crates-io-publishing]]
+crates = ["gccjit"]
+teams = []

--- a/repos/rust-lang/getopts.toml
+++ b/repos/rust-lang/getopts.toml
@@ -10,3 +10,7 @@ crate-maintainers = 'maintain'
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["getopts"]
+teams = ["libs"]

--- a/repos/rust-lang/git2-rs.toml
+++ b/repos/rust-lang/git2-rs.toml
@@ -15,3 +15,7 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["git2", "git2-curl", "libgit2-sys"]
+teams = []

--- a/repos/rust-lang/glob.toml
+++ b/repos/rust-lang/glob.toml
@@ -15,3 +15,7 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["glob"]
+teams = ["libs"]

--- a/repos/rust-lang/hashbrown.toml
+++ b/repos/rust-lang/hashbrown.toml
@@ -16,3 +16,7 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["hashbrown"]
+teams = []

--- a/repos/rust-lang/impl-trait-utils.toml
+++ b/repos/rust-lang/impl-trait-utils.toml
@@ -8,3 +8,7 @@ wg-async = "maintain"
 
 [[branch-protections]]
 pattern = "main"
+
+[[crates-io-publishing]]
+crates = ["trait-variant"]
+teams = []

--- a/repos/rust-lang/jobserver-rs.toml
+++ b/repos/rust-lang/jobserver-rs.toml
@@ -10,3 +10,7 @@ compiler = "write"
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["jobserver"]
+teams = []

--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -22,3 +22,15 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["ctest"]
+teams = []
+
+[[crates-io-publishing]]
+crates = ["libc-test"]
+teams = ["libc"]
+
+[[crates-io-publishing]]
+crates = ["libc"]
+teams = ["libs", "libc"]

--- a/repos/rust-lang/libz-sys.toml
+++ b/repos/rust-lang/libz-sys.toml
@@ -9,3 +9,7 @@ crate-maintainers = 'maintain'
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["libz-ng-sys", "libz-sys"]
+teams = []

--- a/repos/rust-lang/literal-escaper.toml
+++ b/repos/rust-lang/literal-escaper.toml
@@ -5,3 +5,7 @@ bots = []
 
 [access.teams]
 compiler = "write"
+
+[[crates-io-publishing]]
+crates = ["rustc-literal-escaper"]
+teams = ["compiler"]

--- a/repos/rust-lang/log.toml
+++ b/repos/rust-lang/log.toml
@@ -13,3 +13,7 @@ Thomasdezeeuw = 'maintain'
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["log"]
+teams = ["log-owners", "libs"]

--- a/repos/rust-lang/packed_simd.toml
+++ b/repos/rust-lang/packed_simd.toml
@@ -13,3 +13,7 @@ project-portable-simd = "write"
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["packed_simd", "packed_simd_2"]
+teams = []

--- a/repos/rust-lang/pkg-config-rs.toml
+++ b/repos/rust-lang/pkg-config-rs.toml
@@ -13,3 +13,7 @@ sdroege = "write"
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["pkg-config"]
+teams = []

--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -16,3 +16,11 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["ra_ap_edition", "ra_ap_intern", "ra_ap_load-cargo", "ra_ap_macros", "ra_ap_proc-macro-srv-cli", "ra_ap_query-group-macro", "ra_ap_span", "ra_ap_syntax-bridge"]
+teams = []
+
+[[crates-io-publishing]]
+crates = ["ra_ap_base_db", "ra_ap_cfg", "ra_ap_hir", "ra_ap_hir_def", "ra_ap_hir_expand", "ra_ap_hir_ty", "ra_ap_ide", "ra_ap_ide_assists", "ra_ap_ide_completion", "ra_ap_ide_db", "ra_ap_ide_diagnostics", "ra_ap_ide_ssr", "ra_ap_limit", "ra_ap_mbe", "ra_ap_parser", "ra_ap_paths", "ra_ap_proc_macro_api", "ra_ap_proc_macro_srv", "ra_ap_profile", "ra_ap_project_model", "ra_ap_rust-analyzer", "ra_ap_stdx", "ra_ap_syntax", "ra_ap_test_utils", "ra_ap_text_edit", "ra_ap_toolchain", "ra_ap_tt", "ra_ap_vfs", "ra_ap_vfs-notify"]
+teams = ["wg-rls-2"]

--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -21,3 +21,11 @@ required-approvals = 0
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["clippy_config", "clippy_utils"]
+teams = []
+
+[[crates-io-publishing]]
+crates = ["rustc_tools_util"]
+teams = ["clippy"]

--- a/repos/rust-lang/rustc-demangle.toml
+++ b/repos/rust-lang/rustc-demangle.toml
@@ -20,3 +20,7 @@ ci-checks = [
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["rustc-demangle"]
+teams = ["libs", "compiler"]

--- a/repos/rust-lang/rustc-stable-hash.toml
+++ b/repos/rust-lang/rustc-stable-hash.toml
@@ -8,3 +8,7 @@ compiler = "write"
 
 [[branch-protections]]
 pattern = "main"
+
+[[crates-io-publishing]]
+crates = ["rustc-stable-hash"]
+teams = ["compiler"]

--- a/repos/rust-lang/rustc_apfloat.toml
+++ b/repos/rust-lang/rustc_apfloat.toml
@@ -12,3 +12,7 @@ compiler = 'maintain'
 
 # Likewise, eventually we may want a branch protections section, but we will
 # tackle that later.
+
+[[crates-io-publishing]]
+crates = ["rustc_apfloat"]
+teams = []

--- a/repos/rust-lang/rustdoc-types.toml
+++ b/repos/rust-lang/rustdoc-types.toml
@@ -5,3 +5,7 @@ bots = ["rustbot"]
 
 [access.teams]
 rustdoc = "write"
+
+[[crates-io-publishing]]
+crates = ["rustdoc-types"]
+teams = ["rustdoc"]

--- a/repos/rust-lang/rustup-components-history.toml
+++ b/repos/rust-lang/rustup-components-history.toml
@@ -10,3 +10,7 @@ infra = "write"
 [[environments]]
 name = "github-pages"
 
+
+[[crates-io-publishing]]
+crates = ["rustup-available-packages"]
+teams = []

--- a/repos/rust-lang/rustwide.toml
+++ b/repos/rust-lang/rustwide.toml
@@ -6,3 +6,7 @@ bots = []
 [access.teams]
 infra = "write"
 docs-rs = "write"
+
+[[crates-io-publishing]]
+crates = ["rustwide"]
+teams = ["infra"]


### PR DESCRIPTION
This is not supposed to be merged, I just wanted to see which crates are owned by `rust-lang-owner` today, and which repos/teams are associated to them.
