### PR TITLE
Add a cargo-team repo

### DIFF
--- a/repos/rust-lang/cargo-team.toml
+++ b/repos/rust-lang/cargo-team.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "cargo-team"
+description = "Coordination repository for the Cargo team"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+cargo = "write"


### PR DESCRIPTION
The Cargo team would like to have a separate repo for storing things that are more directed towards the team, and not directly related to the cargo tool. Primarily this will start with meeting notes, but we may expand to other things we want to capture.

cc @rust-lang/cargo 