### PR TITLE
Set `CRATES_IO_USERNAME` environment variable in dry-run

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -69,6 +69,7 @@ jobs:
           # However, even without a token, we can actually read most of the crates.io state that we
           # need to print a diff.
           CRATES_IO_TOKEN: ""
+          CRATES_IO_USERNAME: "rust-lang-owner"
         # This applies pipefail, so that the tee pipeline below fails when sync-team fails.
         shell: bash
         run: |


### PR DESCRIPTION
So that it is propagated to `main` and we can do a dry-run for https://github.com/rust-lang/team/pull/2160.
