### PR TITLE
Add crates.io trusted publishing back to `ar_archive_writer`

### DIFF
--- a/repos/rust-lang/ar_archive_writer.toml
+++ b/repos/rust-lang/ar_archive_writer.toml
@@ -9,3 +9,7 @@ compiler = "write"
 [[environments]]
 name = "publish"
 
+[[crates-io-publishing]]
+crates = ["ar_archive_writer"]
+workflow-filename = "publish.yml"
+environment = "publish"


### PR DESCRIPTION
It was removed in https://github.com/rust-lang/team/pull/2160.