### PR TITLE
Add crates.io trusted publishing back to `crates_io_og_image`

### DIFF
--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -15,3 +15,7 @@ pr-required = false
 [[environments]]
 name = "release"
 
+[[crates-io-publishing]]
+crates = ["crates_io_og_image"]
+workflow-filename = "release.yml"
+environment = "release"


### PR DESCRIPTION
It was removed in https://github.com/rust-lang/team/pull/2160.
