### PR TITLE
Add your_name_here to the LoongArch team

### DIFF
--- a/teams/loongarch.toml
+++ b/teams/loongarch.toml
@@ -8,4 +8,5 @@ members = [
     "xiangzhai",
     "xen0n",
     "xry111",
+    "your_name_here", # Don't forget to run `cargo run add-person` if you're new!
 ]


### PR DESCRIPTION
This is an example PR to show how to add yourself to the LoongArch notification group. It will not be merged.

Once you add your name to the list, you also want to run `cargo run add-person your_name_here`, unless you're already in the team repository.