### PR TITLE
Do not panic when a person is not found

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -786,7 +786,9 @@ fn validate_present_zulip_id(data: &Data, errors: &mut Vec<String>) {
         data.active_members().unwrap().iter(),
         errors,
         |person, _| {
-            let person = data.person(person).expect("Person not found");
+            let Some(person) = data.person(person) else {
+                return Err(anyhow::anyhow!("Person {person} not found"));
+            };
             if person.zulip_id().is_none()
                 && !data
                     .config()


### PR DESCRIPTION
When a team contains a missing person, we used to have a nice error, but after the recent Zulip ID requirement change, the code now panics. This PR fixes that.
