### PR TITLE
Track `gll` repository

### DIFF
--- a/repos/rust-lang/gll.toml
+++ b/repos/rust-lang/gll.toml
@@ -1,0 +1,9 @@
+org = "rust-lang"
+name = "gll"
+description = "GLL parsing framework."
+bots = []
+
+[access.teams]
+
+[[branch-protections]]
+pattern = "master"


### PR DESCRIPTION
This is the last repository that still isn't tracked by `team`. We wanted to archive it (https://github.com/rust-lang/gll/pull/145), but @eddyb asked us to move it back under the LykenSol organization instead.

We should finally do either of those, to unblock https://github.com/rust-lang/team/pull/2149.
