### PR TITLE
t-compiler permissions on stdarch

### DIFF
--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -5,6 +5,7 @@ homepage = "https://doc.rust-lang.org/stable/core/arch/"
 bots = ["rustbot", "rfcbot"]
 
 [access.teams]
+compiler = "write"
 lang = "write"
 lang-ops = "write"
 libs = "write"


### PR DESCRIPTION
stdarch is the responsibility of t-libs but I often find myself wanting to edit an issue title/description, close an issue, re-run the CI, etc and have no permissions to do so.