### PR TITLE
refactor: improve environment diffing using BTreeSet

### DIFF
--- a/sync-team/src/github/tests/mod.rs
+++ b/sync-team/src/github/tests/mod.rs
@@ -990,16 +990,20 @@ fn repo_environment_create() {
                 permission_diffs: [],
                 branch_protection_diffs: [],
                 environment_diffs: [
-                    Create {
-                        name: "production",
-                        branches: [],
-                        tags: [],
-                    },
-                    Create {
-                        name: "staging",
-                        branches: [],
-                        tags: [],
-                    },
+                    Create(
+                        "production",
+                        Environment {
+                            branches: [],
+                            tags: [],
+                        },
+                    ),
+                    Create(
+                        "staging",
+                        Environment {
+                            branches: [],
+                            tags: [],
+                        },
+                    ),
                 ],
             },
         ),
@@ -1044,12 +1048,12 @@ fn repo_environment_delete() {
                 permission_diffs: [],
                 branch_protection_diffs: [],
                 environment_diffs: [
-                    Delete {
-                        name: "production",
-                    },
-                    Delete {
-                        name: "staging",
-                    },
+                    Delete(
+                        "production",
+                    ),
+                    Delete(
+                        "staging",
+                    ),
                 ],
             },
         ),
@@ -1109,14 +1113,16 @@ fn repo_environment_update() {
                 permission_diffs: [],
                 branch_protection_diffs: [],
                 environment_diffs: [
-                    Create {
-                        name: "dev",
-                        branches: [],
-                        tags: [],
-                    },
-                    Delete {
-                        name: "staging",
-                    },
+                    Create(
+                        "dev",
+                        Environment {
+                            branches: [],
+                            tags: [],
+                        },
+                    ),
+                    Delete(
+                        "staging",
+                    ),
                 ],
             },
         ),


### PR DESCRIPTION
**Summary**

- Replace HashSet with BTreeSet for deterministic ordering
- Simplify diff_environments logic using set operations directly
- Simplify EnvironmentDiff enum by using tuple variants
- Remove unused patterns_equal function
- Update test snapshots to match the new enum structure

Separate PR is asked in one of the comments https://github.com/rust-lang/team/pull/2168#discussion_r2622187439, and it makes sense. This is done as part of refactoring existing code; there are no functionality changes. 

cc @marcoieni 