### PR TITLE
Move jsha to alumnis for other groups/teams as well

### DIFF
--- a/teams/docs-rs.toml
+++ b/teams/docs-rs.toml
@@ -6,7 +6,6 @@ leads = ["syphar"]
 members = [
     "GuillaumeGomez",
     "syphar",
-    "jsha",
 ]
 alumni = [
     "Nemo157",
@@ -16,6 +15,7 @@ alumni = [
     "pietroalbini",
     "jyn514",
     "QuietMisdreavus",
+    "jsha",
 ]
 
 [permissions]

--- a/teams/rustdoc-frontend.toml
+++ b/teams/rustdoc-frontend.toml
@@ -6,11 +6,12 @@ leads = []
 members = [
     "notriddle",
     "GuillaumeGomez",
-    "jsha",
     "camelid",
     "lolbinarycat",
 ]
-alumni = []
+alumni = [
+    "jsha",
+]
 
 [permissions]
 bors.rust.review = true


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/team/pull/2083.

They forgot to remove themselves from rustdoc front-end ping group and from docs.rs.