### PR TITLE
Remove Noratrieb from compiler-fcp

### DIFF
--- a/teams/compiler-fcp.toml
+++ b/teams/compiler-fcp.toml
@@ -11,7 +11,6 @@ members = [
     "Mark-Simulacrum",
     "matthewjasper",
     "nagisa",
-    "Noratrieb",
     "oli-obk",
     "petrochenkov",
     "SparrowLii",
@@ -20,6 +19,7 @@ members = [
 ]
 alumni = [
     "compiler-errors",
+    "Noratrieb",
 ]
 
 [rfcbot]
@@ -32,3 +32,4 @@ name = "Compiler FCP team"
 description = "Compiler team members with responsibility for signing off on major compiler changes"
 repo = "http://github.com/rust-lang/compiler-team"
 zulip-stream = "t-compiler"
+


### PR DESCRIPTION
I've not been very active in the Rust Project recently, so I don't think it makes sense for me to continue being on FCP rotation.
I also wanted to remove myself from compiler-maintainers but it looks like I was mistakenly never assigned the role :3.