### PR TITLE
Add ubiratan to crates.io oncall rotation

### DIFF
--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -13,6 +13,7 @@ members = [
     "marcoieni",
     "Turbo87",
     "walterhpearce",
+    "ubiratansoares",
 ]
 
 [[github]]


### PR DESCRIPTION
Self-explained. 

Follow-up for #2228 🙂