### PR TITLE
Update readme links related to bors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ If you need to add or remove a person from a team, send a PR to this
 repository. After it's merged, their account will be added/removed
 from all the supported services.
 
-[bors]: https://buildbot2.rust-lang.org/homu
+[bors]: https://bors.rust-lang.org
 
-[bors-src]: https://github.com/rust-lang/homu/blob/master/homu/auth.py
+[bors-src]: https://github.com/rust-lang/bors/blob/main/src/permissions.rs
 
 [www]: https://www.rust-lang.org/governance
 


### PR DESCRIPTION
A quick win out of a code review I did yesterday when studying this repo. 

I found more references to our [old homu](https://github.com/search?q=repo%3Arust-lang%2Fteam%20homu&type=code) in the Rust code itself, but not sure whether we want/can get rid of them.
