### PR TITLE
Add foundation staff marker team and include in all/private

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -78,7 +78,8 @@ members-without-zulip-id = [
     "ryankurte",
     "Stammark",
     "therealprof",
-    "zeenix"
+    "zeenix",
+    "abibroom",
 ]
 
 enable-rulesets-repos = [

--- a/people/abibroom.toml
+++ b/people/abibroom.toml
@@ -1,0 +1,4 @@
+name = "Abi Broom"
+github = "abibroom"
+github-id = 560001
+email = "abibroom@rustfoundation.org"

--- a/people/becrumbul.toml
+++ b/people/becrumbul.toml
@@ -1,0 +1,5 @@
+name = "Rebecca Rumbul"
+github = "becrumbul"
+github-id = 94852900
+zulip-id = 522541
+email = "rebeccarumbul@rustfoundation.org"

--- a/people/walterhpearce.toml
+++ b/people/walterhpearce.toml
@@ -2,3 +2,4 @@ name = "walterhpearce"
 github = "walterhpearce"
 github-id = 123987141
 zulip-id = 584939
+email = "walterpearce@rustfoundation.org"

--- a/teams/all.toml
+++ b/teams/all.toml
@@ -33,5 +33,9 @@ extra-emails = [
 name = "T-all"
 
 # Private channel with all team members, so that we can have an easy way of reaching them.
+# Also includes Rust Foundation staff, for any relevant non-public communication.
 [[zulip-streams]]
 name = "all/private"
+extra-teams = [
+    "foundation-staff",
+]

--- a/teams/foundation-staff.toml
+++ b/teams/foundation-staff.toml
@@ -1,0 +1,20 @@
+name = "foundation-staff"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    "becrumbul",
+    "graciegregory",
+    "JoelMarcey",
+    "LoriLorusso",
+    "abibroom",
+    "baumanj",
+    "walterhpearce",
+    "Turbo87",
+    "LawnGnome",
+    "marcoieni",
+    "ubiratansoares",
+    "ernestkissiedu",
+]
+alumni = []


### PR DESCRIPTION
I wanted to make this a marker team, but I didn't see an obvious way to concat private zulip stream membership.

(This means they will end up in `@all`, but not sure if that's *actually* what we want. It's a fine stopgap for now.)