### PR TITLE
Add rustbot to the `portable-simd` repository

### DIFF
--- a/repos/rust-lang/portable-simd.toml
+++ b/repos/rust-lang/portable-simd.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "portable-simd"
 description = "The testing ground for the future of portable SIMD in Rust"
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 project-portable-simd = "write"


### PR DESCRIPTION
We need to add `rustbot` to the `portable-simd` repository, otherwise triagebot won't have the necessary permissions for all the enabled features.

Following https://github.com/rust-lang/portable-simd/pull/504

cc @calebzulawski @programmerjake 