### PR TITLE
Add github team for rust-for-linux

### DIFF
--- a/teams/rust-for-linux.toml
+++ b/teams/rust-for-linux.toml
@@ -21,3 +21,6 @@ members = [
 
 [permissions]
 bors.rust.try = true
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
This makes it possible to give the team repo permissions, like I was attempting to do in #2238. It also makes it easier to @-mention the group.

cc @ojeda 