### PR TITLE
Remove jdno from crates-io-on-call

### DIFF
--- a/teams/crates-io-on-call.toml
+++ b/teams/crates-io-on-call.toml
@@ -7,7 +7,6 @@ kind = "marker-team"
 leads = []
 members = [
     "baumanj",
-    "jdno",
     "JoelMarcey",
     "LawnGnome",
     "marcoieni",


### PR DESCRIPTION
I am no longer part of the on-call rotation.