### PR TITLE
Add myself to cloud compute

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -22,6 +22,7 @@ members = [
     "jyn514",
     "samueltardieu",
     "davidlattimore",
+    "reddevilmidzy",
 ]
 
 alumni = [


### PR DESCRIPTION
I am a member of the triage team and the rustc-dev-guide working group.

For rustc-dev-guide documentation work, I need to run rustc in debug mode to
inspect logs and internal behavior. Running debug builds locally is difficult
due to hardware limitations.

Access to a dev desktop would allow me to do this work more effectively.

cc @Kobzol 