### PR TITLE
Update homepage URL for effects-initiative

### DIFF
--- a/repos/rust-lang/effects-initiative.toml
+++ b/repos/rust-lang/effects-initiative.toml
@@ -1,11 +1,10 @@
 org = "rust-lang"
 name = "effects-initiative"
 description = "Public repository for the Rust effects initiative"
-homepage = "https://rust-lang.github.io/keyword-generics-initiative/"
+homepage = "https://rust-lang.github.io/effects-initiative/"
 bots = []
 
 [access.teams]
 project-keyword-generics = "write"
 
 [environments.github-pages]
-


### PR DESCRIPTION
Old website gives 404 because we renamed the repo.