### PR TITLE
Add another e-mail address for t-survey

### DIFF
--- a/teams/survey.toml
+++ b/teams/survey.toml
@@ -23,3 +23,6 @@ orgs = ["rust-lang"]
 
 [[lists]]
 address = "surveys@rust-lang.org"
+
+[[lists]]
+address = "survey-contributors@rust-lang.org"


### PR DESCRIPTION
We want to add some people the permissions to create and access a limited set of surveys, without necessarily inviting them to t-survey yet.
