### PR TITLE
add camelid encrypted email

### DIFF
--- a/people/camelid.toml
+++ b/people/camelid.toml
@@ -2,4 +2,4 @@ name = 'Noah Lev'
 github = 'camelid'
 github-id = 37223377
 zulip-id = 307537
-email = "camelidcamel@gmail.com"
+email = "encrypted+ebe6f3cec2ee373b57408f88ad0f14dc86c1f1bfaf7829aa5628073ae74e78ae52bc02b1b3ae221ed92284b923258b53a2572142cd62de3f92244cb7045d9058@rust-lang.invalid"


### PR DESCRIPTION
To verify the email address is encrypted correctly an infra admin should:

1. go to the legacy profile in aws (region us-west-1) and retrieve the secret "/prod/sync-team/email-encryption-key" as explained in the readme
2. run the following:

```
$ cargo run decrypt-email 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `/Users/marco/.cargo-target/debug/rust-team decrypt-email`
Encrypted address: encrypted+ebe6f3cec2ee373b57408f88ad0f14dc86c1f1bfaf7829aa5628073ae74e78ae52bc02b1b3ae221ed92284b923258b53a2572142cd62de3f92244cb7045d9058@rust-lang.invalid
Secret key: [hidden]
```


👆 I verified that the right email is returned