### PR TITLE
README: update link to rfcbot repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ from all the supported services.
 
 [rfcbot]: https://rfcbot.rs
 
-[rfcbot-src]: https://github.com/anp/rfcbot-rs/blob/master/src/teams.rs
+[rfcbot-src]: https://github.com/rust-lang/rfcbot-rs/blob/master/src/teams.rs
 
 [sync-team-src]: sync-team
 


### PR DESCRIPTION
Was moved into the rust-lang organization, c.f. rust-lang/infra-team#22