### PR TITLE
Remove carol and justin as extra help@crates.io email receivers

### DIFF
--- a/teams/crates-io.toml
+++ b/teams/crates-io.toml
@@ -54,10 +54,6 @@ include-team-members = false
 extra-emails = [
     "crates.io@rust-lang.zendesk.com",
 ]
-extra-people = [
-    "carols10cents",
-    "jtgeibel",
-]
 
 [[zulip-groups]]
 name = "T-crates-io"


### PR DESCRIPTION
Just Zendesk is fine for now. help@ is getting a bunch of spam lately and @jtgeibel  and I have been getting it to our personal addresses as well because of this configuration, but without the benefit of Zendesk's spam filters.

I think when we started using Zendesk, this was a good idea to make sure we weren't missing anything, but I'm confident with Zendesk now so this is no longer needed.