### PR TITLE
Add myself to `cloud-compute`

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -23,6 +23,7 @@ members = [
     "samueltardieu",
     "davidlattimore",
     "reddevilmidzy",
+    "ShoyuVanilla",
 ]
 
 alumni = [


### PR DESCRIPTION
I’m currently contributing to rust-analyzer and rustc, mainly focusing on next-solver related work for the latter.

While I usually work from my physical desktop, having access to a dev desktop would be a significant help for several reasons:

- It would allow me to continue working on these projects when I don’t have access to my main machine, for example, while commuting or working from a cafe.
- I frequently compile rustc with different experimental tweaks and compare the results 😅.
  Even when I'm at home, being able to use a dev desktop would let me run builds in parallel and iterate more efficiently.

I'm submitting this request in accordance with the application process described at https://forge.rust-lang.org/infra/docs/dev-desktop.html#how-to-apply-to-the-program.

Please let me know if there are any additional qualifications or approvals required 😄 