### PR TITLE
Add @ojeda to goal-owners

### DIFF
--- a/teams/goal-owners.toml
+++ b/teams/goal-owners.toml
@@ -29,6 +29,7 @@ members = [
     "lqd",
     "nikomatsakis",
     "obi1kenobi",
+    "ojeda",
     "oli-obk",
     "petrochenkov",
     "ranger-ross",
@@ -45,4 +46,3 @@ alumni = [
 
 [[github]]
 orgs = ["rust-lang"]
-


### PR DESCRIPTION
Miguel Ojeda is the lead for the Rust for Linux project and while I'm the point of contact, he should be able to write send updates or make corrections.