### PR TITLE
Give myself permissions on rust-artwork repo.

### DIFF
--- a/repos/rust-lang/rust-artwork.toml
+++ b/repos/rust-lang/rust-artwork.toml
@@ -3,5 +3,7 @@ name = "rust-artwork"
 description = "Official artwork for the Rust project."
 bots = []
 
-# There is no current clear owner of this repository, so the access is left empty for now.
 [access.teams]
+
+[access.individuals]
+m-ou-se = "write"


### PR DESCRIPTION
Nobody currently has access to rust-artwork.

The most relevant thing in this repo is the logo svg, the current version of which I authored five years ago. (https://github.com/rust-lang/rust-artwork/pull/9) I'd like to add the logo in a few more formats and tidy up the repository a bit.