### PR TITLE
Add teor to the project goal owner list

### DIFF
--- a/people/teor.toml
+++ b/people/teor.toml
@@ -1,0 +1,6 @@
+name = 'teor'
+github = 'teor2345'
+github-id = 8951843
+email = 'teor@riseup.net'
+discord-id = 706774417706844223
+zulip-id = 325209

--- a/teams/goal-owners.toml
+++ b/teams/goal-owners.toml
@@ -37,7 +37,7 @@ members = [
     "yaahc",
     "nxsaken",
     "JoelMarcey",
-    "teor2345",
+    "teor",
 ]
 included-teams = []
 alumni = [


### PR DESCRIPTION
@teor2345 will also be working on the C++/Rust Interop Problem Space Mapping goal and I would like them to have the ability to comment without having to ask for manual permission changes.

I also removed the comment that the file is autogenerated as I don't think that is true any longer