### PR TITLE
Error sync if a private repo is not marked as private in team

### DIFF
--- a/sync-team/src/github/api/mod.rs
+++ b/sync-team/src/github/api/mod.rs
@@ -329,6 +329,7 @@ pub(crate) struct Repo {
     pub(crate) description: String,
     pub(crate) homepage: Option<String>,
     pub(crate) archived: bool,
+    pub(crate) private: bool,
     #[serde(default)]
     pub(crate) allow_auto_merge: Option<bool>,
 }

--- a/sync-team/src/github/api/read.rs
+++ b/sync-team/src/github/api/read.rs
@@ -298,6 +298,7 @@ impl GithubRead for GitHubApiRead {
                     description
                     homepageUrl
                     isArchived
+                    isPrivate
                 }
             }
         "#;
@@ -317,6 +318,7 @@ impl GithubRead for GitHubApiRead {
             description: Option<String>,
             homepage_url: Option<String>,
             is_archived: bool,
+            is_private: bool,
         }
 
         let result: Option<Wrapper> = self
@@ -339,6 +341,7 @@ impl GithubRead for GitHubApiRead {
             archived: repo_response.is_archived,
             homepage: repo_response.homepage_url,
             org: org.to_string(),
+            private: repo_response.is_private,
         });
 
         Ok(repo)

--- a/sync-team/src/github/api/write.rs
+++ b/sync-team/src/github/api/write.rs
@@ -250,6 +250,7 @@ impl GitHubWrite {
                 description: settings.description.clone(),
                 homepage: settings.homepage.clone(),
                 archived: false,
+                private: false,
                 allow_auto_merge: Some(settings.auto_merge_enabled),
             })
         } else {

--- a/sync-team/src/github/mod.rs
+++ b/sync-team/src/github/mod.rs
@@ -398,6 +398,14 @@ impl SyncGitHub {
             }
         };
 
+        if !expected_repo.private && actual_repo.private {
+            return Err(anyhow::anyhow!(
+                "Repository `{}/{}` is private on GitHub, but not marked as private in team. This can be a security concern!",
+                actual_repo.org,
+                actual_repo.name
+            ));
+        }
+
         let permission_diffs = self.diff_permissions(expected_repo)?;
 
         let branch_protection_diffs = self.diff_branch_protections(&actual_repo, expected_repo)?;

--- a/sync-team/src/github/tests/test_utils.rs
+++ b/sync-team/src/github/tests/test_utils.rs
@@ -140,6 +140,7 @@ impl DataModel {
                     description: repo.description.clone(),
                     homepage: repo.homepage.clone(),
                     archived: false,
+                    private: false,
                     allow_auto_merge: None,
                 },
             );


### PR DESCRIPTION
If a repository is private, we have to properly mark it as such in the `team` database, because some bots can depend on this.

Note that we cannot check this only in validation, because we could not distinguish private and missing repositories without a privileged auth token (a non-privileged one, such as the one in PR CI, would just see that the repo does not exist).