### PR TITLE
Give `leadership-council` team write access to `rust-artwork` repo instead of individual access

### DIFF
--- a/repos/rust-lang/rust-artwork.toml
+++ b/repos/rust-lang/rust-artwork.toml
@@ -4,6 +4,4 @@ description = "Official artwork for the Rust project."
 bots = []
 
 [access.teams]
-
-[access.individuals]
-m-ou-se = "write"
+leadership-council = "write"


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/team/pull/2267#issuecomment-3967067482.

Alternatively, maybe `social-media` team? Not really sure tbh.

cc @ehuss @m-ou-se (if you have preferences instead)