### PR TITLE
Add teor2345 to the project goal owner list

### DIFF
--- a/people/teor2345.toml
+++ b/people/teor2345.toml
@@ -1,0 +1,6 @@
+name = 'teor'
+github = 'teor2345'
+github-id = 8951843
+email = 'teor@riseup.net'
+discord-id = 706774417706844223
+zulip-id = 325209

--- a/teams/goal-owners.toml
+++ b/teams/goal-owners.toml
@@ -38,6 +38,7 @@ members = [
     "yaahc",
     "nxsaken",
     "JoelMarcey",
+    "teor2345",
 ]
 included-teams = []
 alumni = [


### PR DESCRIPTION
@teor2345 will also be working on the C++/Rust Interop Problem Space Mapping goal and I would like them to have the ability to comment without having to ask for manual permission changes.

