### PR TITLE
Add Program marker team and repo

### DIFF
--- a/repos/rust-lang/program-team.toml
+++ b/repos/rust-lang/program-team.toml
@@ -1,0 +1,9 @@
+org = "rust-lang"
+name = "program-team"
+description = "Home of the Rust program team"
+bots = ["rustbot", "rfcbot"]
+
+[access.teams]
+edition = "maintain"
+goals = "maintain"
+program = "maintain"

--- a/teams/program.toml
+++ b/teams/program.toml
@@ -1,0 +1,34 @@
+# The Program team (AKA Program Management, PM) lists the staff hired
+# by the Project (via the Foundation) in support of program management
+# and those Project members who (via the delegation by the council to
+# the Edition and Goals teams) provide oversight and guidance for this
+# program.
+
+name = "program"
+kind = "marker-team"
+subteam-of = "edition" # And of goals.
+
+[people]
+leads = []
+members = [
+    "traviscross",
+    "ehuss",
+    "nikomatsakis",
+    "tomassedovic",
+    "nxsaken",
+]
+
+[[github]]
+orgs = ["rust-lang"]
+
+[permissions]
+bors.rust.review = true
+crater = true
+dev-desktop = true
+perf = true
+
+[[lists]]
+address = "program@rust-lang.org"
+
+[[zulip-groups]]
+name = "T-program"


### PR DESCRIPTION
Now that we have more than one program manager on staff, we need some infrastructure for coordination.  Let's create a marker team for this. It will include those staff hired by the Project (via the Foundation) in support of program management and those Project members who (via the delegation by the council to the Edition and Goals teams) provide oversight and guidance for this program.

We'll create a repository for this marker team so that the PMs can create project boards and store documentation specific to this program.

cc @tomassedovic @nxsaken @ehuss @nikomatsakis
