### PR TITLE
docs-rs: add environments

### DIFF
--- a/repos/rust-lang/docs.rs.toml
+++ b/repos/rust-lang/docs.rs.toml
@@ -11,3 +11,9 @@ docs-rs-reviewers = 'write'
 [[branch-protections]]
 pattern = 'main'
 required-approvals = 0
+
+[environments.production]
+branches = ["main"]
+
+[environments.staging]
+branches = ["main"]


### PR DESCRIPTION
Add these GitHub environments to only allow publishing AWS ECR images from the main branch in GitHub Actions.

We do the same in bors:

https://github.com/rust-lang/team/blob/b351796e1e1a751da078899ca8c1a0b7caa0bb73/repos/rust-lang/bors.toml#L18-L22

The environments match:

https://github.com/rust-lang/simpleinfra/blob/41b9284d9077c7cac3631080b9e40f3cf1ad87e9/terragrunt/accounts/docs-rs-prod/docs-rs/terragrunt.hcl#L26

and

https://github.com/rust-lang/simpleinfra/blob/41b9284d9077c7cac3631080b9e40f3cf1ad87e9/terragrunt/accounts/docs-rs-staging/docs-rs/terragrunt.hcl#L26