### PR TITLE
Add clarfonthey to libs-contributors

### DIFF
--- a/people/clarfonthey.toml
+++ b/people/clarfonthey.toml
@@ -1,0 +1,5 @@
+name = "Clar Fon"
+github = "clarfonthey"
+github-id = 15850505
+zulip-id = 330161
+email = "usr@ltdk.xyz"

--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -25,6 +25,7 @@ members = [
     "sayantn",
     "m-ou-se",
     "programmerjake",
+    "clarfonthey",
 ]
 alumni = [
     "shepmaster",


### PR DESCRIPTION
Adding Clar Fon as a maintainer for hashbrown, which is managed by the libs-contributors team as part of the standard library.