### PR TITLE
CODEOWNERS: remove ` /repos/rust-lang/sync-team.toml` configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,6 @@
 
 # Modifying these files requires admin approval.
 /repos/rust-lang/team.toml @Mark-Simulacrum @emilyalbini @jdno @marcoieni @ubiratansoares
-/repos/rust-lang/sync-team.toml @Mark-Simulacrum @emilyalbini @jdno @marcoieni @ubiratansoares
 /repos/rust-lang/rust.toml @Mark-Simulacrum @emilyalbini @jdno @marcoieni @ubiratansoares
 /teams/infra-admins.toml @Mark-Simulacrum @emilyalbini @jdno @marcoieni @ubiratansoares
 /teams/team-repo-admins.toml @Mark-Simulacrum @emilyalbini @jdno @marcoieni @ubiratansoares

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -30,7 +30,6 @@ pub fn check_codeowners(data: Data) -> anyhow::Result<()> {
 /// PRs that modify them need to be approved by an infra-admin.
 const PROTECTED_PATHS: &[&str] = &[
     "/repos/rust-lang/team.toml",
-    "/repos/rust-lang/sync-team.toml",
     "/repos/rust-lang/rust.toml",
     "/teams/infra-admins.toml",
     "/teams/team-repo-admins.toml",


### PR DESCRIPTION
The rust-lang/sync-team repository was archived after the code was moved into this repo, see #1736. The code is now located in the `sync-team` directory, which is covered by the catch-all ownership rule and already requires admin approval.