### PR TITLE
Remove kobzol from `relnotes-interest-group`

### DIFF
--- a/teams/relnotes-interest-group.toml
+++ b/teams/relnotes-interest-group.toml
@@ -10,7 +10,6 @@ members = [
     "alex-semenyuk",
     "jieyouxu",
     "joshtriplett",
-    "Kobzol",
     "lcnr",
     "traviscross",
 ]


### PR DESCRIPTION
I didn't usually have much time/energy to go through the release notes. And worse, I realized that I don't like the spoilers and I'd rather read the final version to share the excitement from new Rust features with everyone else :joy:

I don't think it makes sense to have alumni here, so I just removed myself from the team.
