### PR TITLE
update getrandom to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,7 @@ name = "rust_team_data"
 version = "1.0.0"
 dependencies = [
  "chacha20poly1305",
- "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "hex",
  "indexmap",
  "serde",
@@ -2057,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ dialoguer = "0.12.0"
 difference = "2.0.0"
 duct = "1.0.0"
 env_logger = { version = "0.11.0", default-features = false }
-getrandom = "0.2.1"
+getrandom = "0.4.2"
 hex = "0.4.2"
 hyper-old-types = "0.11"
 indexmap = "2.6.0"

--- a/rust_team_data/src/email_encryption.rs
+++ b/rust_team_data/src/email_encryption.rs
@@ -20,7 +20,7 @@ const NONCE_LENGTH: usize = 24;
 pub fn encrypt(key: &str, email: &str) -> Result<String, Error> {
     // Generate a random nonce every time something is encrypted.
     let mut nonce = [0u8; NONCE_LENGTH];
-    getrandom::getrandom(&mut nonce).map_err(Error::GetRandom)?;
+    getrandom::fill(&mut nonce).map_err(Error::GetRandom)?;
     let nonce = XNonce::from_slice(&nonce);
 
     let mut encrypted = init_cipher(key)?


### PR DESCRIPTION
fix for https://github.com/rust-lang/team/pull/2288

## Confirmation that the method has been renamed

[version 0.2.11](https://docs.rs/getrandom/0.2.11/getrandom/fn.getrandom.html):
<img width="2356" height="940" alt="image" src="https://github.com/user-attachments/assets/8a3a3c4e-a047-4e92-902c-604535c87c95" />

[version 0.4.2](https://docs.rs/getrandom/0.4.2/getrandom/fn.fill.html):
<img width="2300" height="1178" alt="image" src="https://github.com/user-attachments/assets/76f80d89-1efa-46da-99a8-b9267076d45b" />
