### PR TITLE
fix fetching environment branch policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,5 +68,6 @@ serde_json = "1.0"
 serde-untagged = "0.1"
 sync-team = { path = "sync-team" }
 tempfile = "3.19.1"
+thiserror = "2.0.18"
 toml = "1.0"
 walkdir = "2.3.1"

--- a/sync-team/Cargo.toml
+++ b/sync-team/Cargo.toml
@@ -14,6 +14,7 @@ hyper-old-types.workspace = true
 serde_json.workspace = true
 secrecy.workspace = true
 indexmap.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 indexmap.workspace = true

--- a/sync-team/src/github/api/mod.rs
+++ b/sync-team/src/github/api/mod.rs
@@ -18,11 +18,26 @@ use reqwest::{
 use secrecy::ExposeSecret;
 use serde::{Deserialize, de::DeserializeOwned};
 use std::fmt;
+use thiserror::Error;
 use tokens::GitHubTokens;
 use url::GitHubUrl;
 
 pub(crate) use read::{GitHubApiRead, GithubRead};
 pub(crate) use write::GitHubWrite;
+
+#[derive(Debug, Error)]
+pub(crate) enum RestPaginatedError {
+    #[error("{method} request to '{url}' failed with status {status}")]
+    Http {
+        method: Method,
+        url: String,
+        status: StatusCode,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
 
 #[derive(Clone)]
 pub(crate) struct HttpClient {
@@ -157,7 +172,12 @@ impl HttpClient {
         })
     }
 
-    fn rest_paginated<F, T>(&self, method: &Method, url: &GitHubUrl, mut f: F) -> anyhow::Result<()>
+    fn rest_paginated<F, T>(
+        &self,
+        method: &Method,
+        url: &GitHubUrl,
+        mut f: F,
+    ) -> Result<(), RestPaginatedError>
     where
         F: FnMut(T) -> anyhow::Result<()>,
         T: DeserializeOwned,
@@ -167,12 +187,25 @@ impl HttpClient {
             let resp = self
                 .req(method.clone(), &next_url)?
                 .send()
-                .with_context(|| format!("failed to send request to {}", next_url.url()))?
-                .custom_error_for_status()?;
+                .with_context(|| format!("failed to send request to {}", next_url.url()))?;
+
+            let status = resp.status();
+            let resp =
+                resp.custom_error_for_status()
+                    .map_err(|source| RestPaginatedError::Http {
+                        method: method.clone(),
+                        url: next_url.url().to_string(),
+                        status,
+                        source,
+                    })?;
 
             // Extract the next page
             if let Some(links) = resp.headers().get(header::LINK) {
-                let links: Link = links.to_str()?.parse()?;
+                let links: Link = links
+                    .to_str()
+                    .context("failed to convert LINK header to string")?
+                    .parse()
+                    .context("failed to parse LINK header")?;
                 for link in links.values() {
                     if link
                         .rel()
@@ -636,4 +669,16 @@ pub(crate) struct RequiredStatusCheck {
 pub(crate) enum RulesetOp {
     CreateForRepo,
     UpdateRuleset(i64),
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct BranchPolicy {
+    pub(crate) id: u64,
+    pub(crate) name: String,
+    #[serde(rename = "type", default = "default_branch_policy_type")]
+    pattern_type: String,
+}
+
+fn default_branch_policy_type() -> String {
+    "branch".to_string()
 }

--- a/sync-team/src/github/api/read.rs
+++ b/sync-team/src/github/api/read.rs
@@ -1,10 +1,11 @@
-use crate::github::api::Ruleset;
+use crate::github::api::{BranchPolicy, Ruleset};
 use crate::github::api::{
     BranchProtection, GraphNode, GraphNodes, GraphPageInfo, HttpClient, Login, Repo, RepoTeam,
-    RepoUser, Team, TeamMember, TeamRole, team_node_id, url::GitHubUrl, user_node_id,
+    RepoUser, RestPaginatedError, Team, TeamMember, TeamRole, team_node_id, url::GitHubUrl,
+    user_node_id,
 };
 use anyhow::Context as _;
-use reqwest::Method;
+use reqwest::{Method, StatusCode};
 use rust_team_data::v1::Environment;
 use std::collections::{HashMap, HashSet};
 
@@ -68,6 +69,13 @@ pub(crate) trait GithubRead {
         org: &str,
         repo: &str,
     ) -> anyhow::Result<Vec<crate::github::api::Ruleset>>;
+
+    fn environment_branch_policies(
+        &self,
+        org: &str,
+        repo: &str,
+        environment: &str,
+    ) -> anyhow::Result<Vec<BranchPolicy>>;
 }
 
 pub(crate) struct GitHubApiRead {
@@ -479,22 +487,6 @@ impl GithubRead for GitHubApiRead {
             environments: Vec<GitHubEnvironment>,
         }
 
-        #[derive(serde::Deserialize)]
-        struct BranchPolicy {
-            name: String,
-            #[serde(rename = "type", default = "default_branch_type")]
-            pattern_type: String,
-        }
-
-        fn default_branch_type() -> String {
-            "branch".to_string()
-        }
-
-        #[derive(serde::Deserialize)]
-        struct BranchPoliciesResponse {
-            branch_policies: Vec<BranchPolicy>,
-        }
-
         let mut env_infos = Vec::new();
 
         // Fetch all environments with their protection_rules metadata
@@ -522,23 +514,21 @@ impl GithubRead for GitHubApiRead {
                 let (branches, tags) = if has_branch_policies {
                     let mut branches = Vec::new();
                     let mut tags = Vec::new();
-                    self.client.rest_paginated(
-                        &Method::GET,
-                        &GitHubUrl::repos(
-                            org,
-                            repo,
-                            &format!("environments/{}/deployment-branch-policies", env_info.name),
-                        )?,
-                        |resp: BranchPoliciesResponse| {
-                            for p in resp.branch_policies {
-                                match p.pattern_type.as_str() {
-                                    "tag" => tags.push(p.name),
-                                    _ => branches.push(p.name),
-                                }
-                            }
-                            Ok(())
-                        },
-                    )?;
+                    let policies =
+                        self.environment_branch_policies(org, repo, &env_info.name).with_context(
+                            || {
+                                format!(
+                                    "failed to load deployment branch policies for environment '{}' in '{org}/{repo}'",
+                                    env_info.name
+                                )
+                            },
+                        )?;
+                    for p in policies {
+                        match p.pattern_type.as_str() {
+                            "tag" => tags.push(p.name),
+                            _ => branches.push(p.name),
+                        }
+                    }
                     (branches, tags)
                 } else {
                     (Vec::new(), Vec::new())
@@ -569,5 +559,50 @@ impl GithubRead for GitHubApiRead {
         )?;
 
         Ok(rulesets)
+    }
+
+    fn environment_branch_policies(
+        &self,
+        org: &str,
+        repo: &str,
+        environment: &str,
+    ) -> anyhow::Result<Vec<BranchPolicy>> {
+        #[derive(serde::Deserialize)]
+        struct BranchPoliciesResponse {
+            branch_policies: Vec<BranchPolicy>,
+        }
+
+        let mut policies = Vec::new();
+        let url = GitHubUrl::repos(
+            org,
+            repo,
+            &format!("environments/{environment}/deployment-branch-policies"),
+        )?;
+
+        if let Err(err) =
+            self.client
+                .rest_paginated(&Method::GET, &url, |resp: BranchPoliciesResponse| {
+                    policies.extend(resp.branch_policies);
+                    Ok(())
+                })
+        {
+            match err {
+                // If the environment doesn't have branch policies, GitHub returns a 404.
+                // In this case, we return an empty list of policies.
+                RestPaginatedError::Http {
+                    status: StatusCode::NOT_FOUND,
+                    ..
+                } => return Ok(policies),
+                other => {
+                    return Err(anyhow::Error::from(other)).with_context(|| {
+                        format!(
+                            "failed to fetch deployment branch policies for environment '{environment}' in '{org}/{repo}'"
+                        )
+                    });
+                }
+            }
+        }
+
+        Ok(policies)
     }
 }

--- a/sync-team/src/github/api/write.rs
+++ b/sync-team/src/github/api/write.rs
@@ -4,18 +4,11 @@ use std::collections::HashSet;
 
 use crate::github::api::url::GitHubUrl;
 use crate::github::api::{
-    AppPushAllowanceActor, BranchProtection, BranchProtectionOp, HttpClient, Login,
-    PushAllowanceActor, Repo, RepoPermission, RepoSettings, Team, TeamPrivacy,
+    AppPushAllowanceActor, BranchProtection, BranchProtectionOp, GitHubApiRead, GithubRead,
+    HttpClient, Login, PushAllowanceActor, Repo, RepoPermission, RepoSettings, Team, TeamPrivacy,
     TeamPushAllowanceActor, TeamRole, UserPushAllowanceActor, allow_not_found,
 };
 use crate::utils::ResponseExt;
-
-#[derive(Debug)]
-struct BranchPolicyInfo {
-    id: u64,
-    name: String,
-    pattern_type: String,
-}
 
 pub(crate) struct GitHubWrite {
     client: HttpClient,
@@ -570,50 +563,6 @@ impl GitHubWrite {
         Ok(())
     }
 
-    /// Get existing branch policies for an environment
-    fn get_environment_branch_policies(
-        &self,
-        org: &str,
-        repo: &str,
-        environment: &str,
-    ) -> anyhow::Result<Vec<BranchPolicyInfo>> {
-        #[derive(serde::Deserialize)]
-        struct BranchPolicy {
-            id: u64,
-            name: String,
-            #[serde(rename = "type", default = "default_branch_type")]
-            pattern_type: String,
-        }
-
-        fn default_branch_type() -> String {
-            "branch".to_string()
-        }
-
-        #[derive(serde::Deserialize)]
-        struct BranchPoliciesResponse {
-            branch_policies: Vec<BranchPolicy>,
-        }
-
-        let url = GitHubUrl::repos(
-            org,
-            repo,
-            &format!("environments/{}/deployment-branch-policies", environment),
-        )?;
-
-        let response: BranchPoliciesResponse =
-            self.client.req(Method::GET, &url)?.send()?.json()?;
-
-        Ok(response
-            .branch_policies
-            .into_iter()
-            .map(|bp| BranchPolicyInfo {
-                id: bp.id,
-                name: bp.name,
-                pattern_type: bp.pattern_type,
-            })
-            .collect())
-    }
-
     /// Delete a specific branch policy by ID
     fn delete_environment_branch_policy(
         &self,
@@ -649,7 +598,8 @@ impl GitHubWrite {
         tags: &[String],
     ) -> anyhow::Result<()> {
         // 1. Fetch existing policies
-        let existing_policies = self.get_environment_branch_policies(org, repo, environment)?;
+        let existing_policies = GitHubApiRead::from_client(self.client.clone())?
+            .environment_branch_policies(org, repo, environment)?;
 
         #[derive(Hash, Eq, PartialEq)]
         struct PatternKey {

--- a/sync-team/src/github/tests/test_utils.rs
+++ b/sync-team/src/github/tests/test_utils.rs
@@ -10,7 +10,8 @@ use rust_team_data::v1::{
 
 use crate::Config;
 use crate::github::api::{
-    BranchProtection, GithubRead, Repo, RepoTeam, RepoUser, Team, TeamMember, TeamPrivacy, TeamRole,
+    BranchPolicy, BranchProtection, GithubRead, Repo, RepoTeam, RepoUser, Team, TeamMember,
+    TeamPrivacy, TeamRole,
 };
 use crate::github::{
     OrgMembershipDiff, RepoDiff, SyncGitHub, TeamDiff, api, construct_branch_protection,
@@ -647,6 +648,17 @@ impl GithubRead for GithubMock {
             .get(repo)
             .cloned()
             .unwrap_or_default())
+    }
+
+    fn environment_branch_policies(
+        &self,
+        _org: &str,
+        _repo: &str,
+        _environment: &str,
+    ) -> anyhow::Result<Vec<BranchPolicy>> {
+        unimplemented!(
+            "call the function repo_environments instead, and read branch policies from there"
+        )
     }
 }
 


### PR DESCRIPTION
this PR tries to fix the error we got while applying https://github.com/rust-lang/team/pull/2261:

```
Error: rust_team] failed: error decoding response body
Error: rust_team] caused by: missing field `branch_policies` at line 1 column 149
Error: Process completed with exit code 1.
```
