### PR TITLE
update rust version in CI automatically

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,20 @@
     ":maintainLockFilesMonthly",
     "helpers:pinGitHubActionDigests"
   ],
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: [
+        '/^\\.github/workflows/main\\.yml$/',
+      ],
+      matchStrings: [
+        "RUST_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      depNameTemplate: "rust-lang/rust",
+      datasourceTemplate: 'github-tags',
+      versioningTemplate: 'semver',
+    }
+  ],
   packageRules: [
     {
       matchCategories: [


### PR DESCRIPTION
I use a similar configuration in:

https://github.com/release-plz/release-plz/blob/be3b5350baf61882bd7bc56a0bd03e17c2dc6d94/.github/renovate.json5#L18

and this is the result: https://github.com/release-plz/release-plz/pull/2710