### PR TITLE
add compiler-builtins environments

### DIFF
--- a/repos/rust-lang/compiler-builtins.toml
+++ b/repos/rust-lang/compiler-builtins.toml
@@ -10,3 +10,9 @@ crate-maintainers = "maintain"
 pattern = "main"
 ci-checks = ["success"]
 required-approvals = 0
+
+[environments.rustc-pull]
+branches = ["main"]
+
+[environments.publish]
+branches = ["main"]


### PR DESCRIPTION
Add two environments:

- `rustc-pull`: to use with https://github.com/rust-lang/compiler-builtins/blob/main/.github/workflows/rustc-pull.yml so that we can put the secrets in an environment
- `publish`: to enable trusted publishing for https://github.com/rust-lang/compiler-builtins/blob/main/.github/workflows/publish.yaml

Discussed in [#t-infra > RISC-V runner in compiler builtins @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/RISC-V.20runner.20in.20compiler.20builtins/near/579679347)