### PR TITLE
move rustfmt to GitHub rulesets

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -85,4 +85,5 @@ members-without-zulip-id = [
 enable-rulesets-repos = [
    "rust-lang/bors",
    "rust-lang/crates.io",
+   "rust-lang/rustfmt",
 ]

--- a/repos/rust-lang/rustfmt.toml
+++ b/repos/rust-lang/rustfmt.toml
@@ -37,4 +37,3 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["main"]
-


### PR DESCRIPTION
rustfmt has multiple branch protections, so it's interesting to see if `team` handles this correctly.

See https://github.com/rust-lang/team/blob/main/repos/rust-lang/rustfmt.toml