### PR TITLE
manage "allow force push" in branch protections

### DIFF
--- a/repos/rust-lang/crates.io-index.toml
+++ b/repos/rust-lang/crates.io-index.toml
@@ -10,3 +10,4 @@ crates-io-on-call = "write"
 [[branch-protections]]
 pattern = "master"
 pr-required = false
+prevent-force-push = false

--- a/repos/rust-lang/staging.crates.io-index.toml
+++ b/repos/rust-lang/staging.crates.io-index.toml
@@ -10,3 +10,4 @@ crates-io-on-call = "write"
 [[branch-protections]]
 pattern = "master"
 pr-required = false
+prevent-force-push = false

--- a/src/sync/github/api/mod.rs
+++ b/src/sync/github/api/mod.rs
@@ -437,6 +437,7 @@ fn team_node_id(id: u64) -> String {
 pub(crate) struct BranchProtection {
     pub(crate) pattern: String,
     pub(crate) is_admin_enforced: bool,
+    pub(crate) allows_force_pushes: bool,
     pub(crate) dismisses_stale_reviews: bool,
     #[serde(default, deserialize_with = "nullable")]
     pub(crate) required_approving_review_count: u8,

--- a/src/sync/github/api/read.rs
+++ b/src/sync/github/api/read.rs
@@ -401,6 +401,7 @@ impl GithubRead for GitHubApiRead {
                             id,
                             pattern,
                             isAdminEnforced,
+                            allowsForcePushes,
                             dismissesStaleReviews,
                             requiredStatusCheckContexts,
                             requiredApprovingReviewCount,

--- a/src/sync/github/api/write.rs
+++ b/src/sync/github/api/write.rs
@@ -390,6 +390,7 @@ impl GitHubWrite {
             id: &'a str,
             pattern: &'a str,
             contexts: &'a [String],
+            allows_force_pushes: bool,
             dismiss_stale: bool,
             review_count: u8,
             restricts_pushes: bool,
@@ -410,7 +411,7 @@ impl GitHubWrite {
             BranchProtectionOp::UpdateBranchProtection(id) => id,
         };
         let query = format!("
-        mutation($id: ID!, $pattern:String!, $contexts: [String!], $dismissStale: Boolean, $reviewCount: Int, $pushActorIds: [ID!], $restrictsPushes: Boolean, $requiresApprovingReviews: Boolean) {{
+        mutation($id: ID!, $pattern:String!, $contexts: [String!], $allowsForcePushes: Boolean, $dismissStale: Boolean, $reviewCount: Int, $pushActorIds: [ID!], $restrictsPushes: Boolean, $requiresApprovingReviews: Boolean) {{
             {mutation_name}(input: {{
                 {id_field}: $id,
                 pattern: $pattern,
@@ -419,6 +420,7 @@ impl GitHubWrite {
                 # Disable 'Require branch to be up-to-date before merging'
                 requiresStrictStatusChecks: false,
                 isAdminEnforced: true,
+                allowsForcePushes: $allowsForcePushes,
                 requiredApprovingReviewCount: $reviewCount,
                 dismissesStaleReviews: $dismissStale,
                 requiresApprovingReviews: $requiresApprovingReviews,
@@ -454,6 +456,7 @@ impl GitHubWrite {
                     id,
                     pattern,
                     contexts: &branch_protection.required_status_check_contexts,
+                    allows_force_pushes: branch_protection.allows_force_pushes,
                     dismiss_stale: branch_protection.dismisses_stale_reviews,
                     review_count: branch_protection.required_approving_review_count,
                     // We restrict merges, if we have explicitly set some actors to be

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -942,6 +942,7 @@ pub fn construct_branch_protection(
     api::BranchProtection {
         pattern: branch_protection.pattern.clone(),
         is_admin_enforced: true,
+        allows_force_pushes: !branch_protection.prevent_force_push,
         dismisses_stale_reviews: branch_protection.dismiss_stale_review,
         required_approving_review_count,
         required_status_check_contexts: checks,

--- a/src/sync/github/tests/mod.rs
+++ b/src/sync/github/tests/mod.rs
@@ -334,6 +334,7 @@ fn repo_create() {
                         BranchProtection {
                             pattern: "main",
                             is_admin_enforced: true,
+                            allows_force_pushes: false,
                             dismisses_stale_reviews: false,
                             required_approving_review_count: 1,
                             required_status_check_contexts: [
@@ -742,6 +743,7 @@ fn repo_add_branch_protection() {
                             BranchProtection {
                                 pattern: "master",
                                 is_admin_enforced: true,
+                                allows_force_pushes: false,
                                 dismisses_stale_reviews: false,
                                 required_approving_review_count: 0,
                                 required_status_check_contexts: [
@@ -759,6 +761,7 @@ fn repo_add_branch_protection() {
                             BranchProtection {
                                 pattern: "beta",
                                 is_admin_enforced: true,
+                                allows_force_pushes: false,
                                 dismisses_stale_reviews: false,
                                 required_approving_review_count: 0,
                                 required_status_check_contexts: [],
@@ -804,6 +807,7 @@ fn repo_update_branch_protection() {
         BranchProtectionMode::PrNotRequired => unreachable!(),
     }
     protection.dismiss_stale_review = true;
+    protection.prevent_force_push = false;
 
     let diff = model.diff_repos(gh);
     insta::assert_debug_snapshot!(diff, @r#"
@@ -836,6 +840,7 @@ fn repo_update_branch_protection() {
                             BranchProtection {
                                 pattern: "master",
                                 is_admin_enforced: true,
+                                allows_force_pushes: false,
                                 dismisses_stale_reviews: false,
                                 required_approving_review_count: 1,
                                 required_status_check_contexts: [
@@ -847,6 +852,7 @@ fn repo_update_branch_protection() {
                             BranchProtection {
                                 pattern: "master",
                                 is_admin_enforced: true,
+                                allows_force_pushes: true,
                                 dismisses_stale_reviews: true,
                                 required_approving_review_count: 0,
                                 required_status_check_contexts: [


### PR DESCRIPTION
In #2323 I noticed some repos allow force pushes, but this setting isn't tracked in the repo toml file.
This PR adds this field, so that it is easier to migrate to rulesets.