### PR TITLE
simplify default ruleset name

### DIFF
--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -8,7 +8,6 @@ bots = ["renovate", "rustbot", "heroku-deploy-access"]
 crates-io = "write"
 
 [[branch-protections]]
-name = "main"
 pattern = "main"
 ci-checks = [
     "Backend / Lint",

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -1059,7 +1059,7 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
         name: branch_protection
             .name
             .clone()
-            .unwrap_or_else(|| format!("Ruleset for {}", branch_protection.pattern)),
+            .unwrap_or_else(|| branch_protection.pattern.to_string()),
         target: RulesetTarget::Branch,
         source_type: RulesetSourceType::Repository,
         enforcement: RulesetEnforcement::Active,


### PR DESCRIPTION
I don't like this default prefix in ruleset names. It's verbose and adds no extra information.
<img width="702" height="418" alt="image" src="https://github.com/user-attachments/assets/b1e18720-8966-4b69-af6f-f1717999d6d3" />
