### PR TITLE
prepare for moving cargo from branch protections to rulesets

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -84,6 +84,7 @@ members-without-zulip-id = [
 
 enable-rulesets-repos = [
    "rust-lang/bors",
+#  "rust-lang/cargo",
    "rust-lang/crates.io",
    "rust-lang/rustfmt",
 ]

--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -10,13 +10,21 @@ cargo = "write"
 [[branch-protections]]
 pattern = "master"
 ci-checks = ["conclusion"]
+# merge-queue = true
 
 [[branch-protections]]
 pattern = "rust-1.*"
 ci-checks = ["conclusion"]
 
+# [[branch-protections]]
+# name = "Only allow the release process to publish tags"
+# pattern = "0.*"
+# target = "tag"
+# pr-required = false
+# allowed-merge-apps = ["promote-release"]
+# prevent-update = true
+
 [environments.github-pages]
 
 [environments.release]
 tags = ["*"]
-

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -252,6 +252,7 @@ pub enum MergeBot {
     RustTimer,
     Bors,
     WorkflowsCratesIo,
+    PromoteRelease,
 }
 
 impl MergeBot {
@@ -259,15 +260,26 @@ impl MergeBot {
         match self {
             MergeBot::WorkflowsCratesIo => Some(2201425),
             MergeBot::Bors => Some(278306),
+            MergeBot::PromoteRelease => Some(217112),
             // These are user-based bots, not GitHub Apps
             MergeBot::RustTimer | MergeBot::Homu => None,
         }
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtectionTarget {
+    #[default]
+    Branch,
+    Tag,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BranchProtection {
     pub pattern: String,
+    #[serde(default, skip_serializing_if = "is_branch_target")]
+    pub target: ProtectionTarget,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub dismiss_stale_review: bool,
@@ -276,11 +288,9 @@ pub struct BranchProtection {
     pub merge_bots: Vec<MergeBot>,
     pub allowed_merge_apps: Vec<MergeBot>,
     pub merge_queue: bool,
-    #[serde(default = "default_true")]
     pub prevent_creation: bool,
-    #[serde(default = "default_true")]
+    pub prevent_update: bool,
     pub prevent_deletion: bool,
-    #[serde(default = "default_true")]
     pub prevent_force_push: bool,
 }
 
@@ -312,6 +322,6 @@ pub struct People {
     pub people: IndexMap<String, Person>,
 }
 
-fn default_true() -> bool {
-    true
+fn is_branch_target(target: &ProtectionTarget) -> bool {
+    matches!(target, ProtectionTarget::Branch)
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -861,12 +861,23 @@ pub(crate) enum AllowedMergeApp {
     RustTimer,
     Bors,
     WorkflowsCratesIo,
+    PromoteRelease,
+}
+
+#[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ProtectionTarget {
+    #[default]
+    Branch,
+    Tag,
 }
 
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct BranchProtection {
     pub pattern: String,
+    #[serde(default)]
+    pub target: ProtectionTarget,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
@@ -883,11 +894,13 @@ pub(crate) struct BranchProtection {
     pub allowed_merge_apps: Vec<AllowedMergeApp>,
     #[serde(default)]
     pub merge_queue: bool,
-    #[serde(default = "default_true")]
+    #[serde(default = "branch_protection_default_prevent_creation")]
     pub prevent_creation: bool,
-    #[serde(default = "default_true")]
+    #[serde(default = "branch_protection_default_prevent_update")]
+    pub prevent_update: bool,
+    #[serde(default = "branch_protection_default_prevent_deletion")]
     pub prevent_deletion: bool,
-    #[serde(default = "default_true")]
+    #[serde(default = "branch_protection_default_prevent_force_push")]
     pub prevent_force_push: bool,
 }
 
@@ -914,4 +927,20 @@ pub(crate) struct Environment {
     /// Tag patterns that can deploy to this environment
     #[serde(default)]
     pub tags: Vec<String>,
+}
+
+pub const fn branch_protection_default_prevent_creation() -> bool {
+    true
+}
+
+pub const fn branch_protection_default_prevent_update() -> bool {
+    false
+}
+
+pub const fn branch_protection_default_prevent_deletion() -> bool {
+    true
+}
+
+pub const fn branch_protection_default_prevent_force_push() -> bool {
+    true
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -54,6 +54,10 @@ impl<'a> Generator<'a> {
                 .iter()
                 .map(|b| v1::BranchProtection {
                     pattern: b.pattern.clone(),
+                    target: match b.target {
+                        schema::ProtectionTarget::Branch => v1::ProtectionTarget::Branch,
+                        schema::ProtectionTarget::Tag => v1::ProtectionTarget::Tag,
+                    },
                     name: b.name.clone(),
                     dismiss_stale_review: b.dismiss_stale_review,
                     mode: if b.pr_required {
@@ -72,10 +76,12 @@ impl<'a> Generator<'a> {
                             AllowedMergeApp::RustTimer => v1::MergeBot::RustTimer,
                             AllowedMergeApp::Bors => v1::MergeBot::Bors,
                             AllowedMergeApp::WorkflowsCratesIo => v1::MergeBot::WorkflowsCratesIo,
+                            AllowedMergeApp::PromoteRelease => v1::MergeBot::PromoteRelease,
                         })
                         .collect(),
                     merge_queue: b.merge_queue,
                     prevent_creation: b.prevent_creation,
+                    prevent_update: b.prevent_update,
                     prevent_deletion: b.prevent_deletion,
                     prevent_force_push: b.prevent_force_push,
                     // This field is empty for retrocompatibility with triagebot

--- a/src/sync/github/api/mod.rs
+++ b/src/sync/github/api/mod.rs
@@ -545,23 +545,32 @@ pub(crate) struct Ruleset {
     pub(crate) rules: BTreeSet<RulesetRule>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum RulesetTarget {
+    #[default]
     Branch,
     Tag,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "PascalCase")]
 pub(crate) enum RulesetSourceType {
+    #[default]
     Repository,
     Organization,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum RulesetEnforcement {
+    #[default]
     Active,
     Disabled,
     Evaluate,
@@ -635,19 +644,46 @@ pub(crate) struct MergeQueueParameters {
     pub(crate) min_entries_to_merge_wait_minutes: i32,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub(crate) const DEFAULT_MERGE_QUEUE_TIMEOUT_MINUTES: i32 = 360;
+pub(crate) const DEFAULT_MERGE_QUEUE_MAX_ENTRIES_TO_BUILD: i32 = 5;
+pub(crate) const DEFAULT_MERGE_QUEUE_MAX_ENTRIES_TO_MERGE: i32 = 5;
+pub(crate) const DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE: i32 = 0;
+pub(crate) const DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE_WAIT_MINUTES: i32 = 0;
+
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum MergeQueueGroupingStrategy {
+    #[default]
     Allgreen,
     Headgreen,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum MergeQueueMergeMethod {
+    #[default]
     Merge,
     Squash,
     Rebase,
+}
+
+impl Default for MergeQueueParameters {
+    fn default() -> Self {
+        Self {
+            check_response_timeout_minutes: DEFAULT_MERGE_QUEUE_TIMEOUT_MINUTES,
+            grouping_strategy: MergeQueueGroupingStrategy::default(),
+            max_entries_to_build: DEFAULT_MERGE_QUEUE_MAX_ENTRIES_TO_BUILD,
+            max_entries_to_merge: DEFAULT_MERGE_QUEUE_MAX_ENTRIES_TO_MERGE,
+            merge_method: MergeQueueMergeMethod::default(),
+            min_entries_to_merge: DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE,
+            min_entries_to_merge_wait_minutes:
+                DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE_WAIT_MINUTES,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
@@ -669,6 +705,7 @@ pub(crate) struct RequiredStatusChecksParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) do_not_enforce_on_create: Option<bool>,
     pub(crate) required_status_checks: Vec<RequiredStatusCheck>,
+    /// Whether pull requests targeting a matching branch must be tested with the latest code.
     pub(crate) strict_required_status_checks_policy: bool,
 }
 

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -4,15 +4,16 @@ mod tests;
 
 use self::api::{BranchProtectionOp, TeamPrivacy, TeamRole};
 pub(crate) use self::api::{GitHubApiRead, GitHubWrite, HttpClient};
+use crate::schema;
 use crate::sync::Config;
 use crate::sync::github::api::{
     GithubRead, Login, PushAllowanceActor, RepoPermission, RepoSettings, Ruleset,
 };
 use futures_util::StreamExt;
 use log::debug;
-use rust_team_data::v1::{Bot, BranchProtectionMode, MergeBot};
+use rust_team_data::v1::{Bot, BranchProtectionMode, MergeBot, ProtectionTarget};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::fmt::{Display, Formatter, Write};
+use std::fmt::{Display, Write};
 
 static DEFAULT_DESCRIPTION: &str = "Managed by the rust-lang/team repository.";
 static DEFAULT_PRIVACY: TeamPrivacy = TeamPrivacy::Closed;
@@ -20,6 +21,11 @@ static DEFAULT_PRIVACY: TeamPrivacy = TeamPrivacy::Closed;
 /// GitHub Actions integration ID
 /// Verified via: https://api.github.com/repos/rust-lang/rust/commits/HEAD/check-runs
 const GITHUB_ACTIONS_INTEGRATION_ID: i64 = 15368;
+
+const REQUIRE_CODE_OWNER_REVIEW_DEFAULT: bool = false;
+const REQUIRE_LAST_PUSH_APPROVAL_DEFAULT: bool = false;
+const REQUIRED_REVIEW_THREAD_RESOLUTION_DEFAULT: bool = false;
+const STRICT_REQUIRED_STATUS_CHECKS_POLICY_DEFAULT: bool = false;
 
 pub(crate) async fn create_diff(
     github: Box<dyn GithubRead>,
@@ -959,7 +965,7 @@ pub fn construct_branch_protection(
             MergeBot::RustTimer => PushAllowanceActor::User(api::UserPushAllowanceActor {
                 login: "rust-timer".to_owned(),
             }),
-            MergeBot::Bors | MergeBot::WorkflowsCratesIo => {
+            MergeBot::Bors | MergeBot::WorkflowsCratesIo | MergeBot::PromoteRelease => {
                 // These use GitHub apps, which are not configured through team (set manually).
                 // Their push allowance will be roundtripped by sync-team.
                 continue;
@@ -992,13 +998,17 @@ pub fn construct_branch_protection(
     }
 }
 
-/// Convert a branch pattern to a full ref pattern for use in rulesets.
-/// GitHub rulesets require full ref paths like "refs/heads/main" instead of just "main".
-pub(crate) fn convert_branch_pattern_to_ref_pattern(pattern: &str) -> String {
+/// Convert a branch or tag pattern to a full ref pattern for use in rulesets.
+/// GitHub rulesets require full ref paths like "refs/heads/main" and "refs/tags/0.*".
+pub(crate) fn convert_pattern_to_ref_pattern(target: ProtectionTarget, pattern: &str) -> String {
     if pattern.starts_with("refs/") {
         return pattern.to_string();
     }
-    format!("refs/heads/{pattern}")
+
+    match target {
+        ProtectionTarget::Branch => format!("refs/heads/{pattern}"),
+        ProtectionTarget::Tag => format!("refs/tags/{pattern}"),
+    }
 }
 
 pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtection) -> api::Ruleset {
@@ -1020,6 +1030,10 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
         rules.insert(RulesetRule::Deletion);
     }
 
+    if branch_protection.prevent_update {
+        rules.insert(RulesetRule::Update);
+    }
+
     // Add non-fast-forward protection if requested
     if branch_protection.prevent_force_push {
         rules.insert(RulesetRule::NonFastForward);
@@ -1033,10 +1047,10 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
         rules.insert(RulesetRule::PullRequest {
             parameters: PullRequestParameters {
                 dismiss_stale_reviews_on_push: branch_protection.dismiss_stale_review,
-                require_code_owner_review: false,
-                require_last_push_approval: false,
+                require_code_owner_review: REQUIRE_CODE_OWNER_REVIEW_DEFAULT,
+                require_last_push_approval: REQUIRE_LAST_PUSH_APPROVAL_DEFAULT,
                 required_approving_review_count: *required_approvals as i32,
-                required_review_thread_resolution: false,
+                required_review_thread_resolution: REQUIRED_REVIEW_THREAD_RESOLUTION_DEFAULT,
             },
         });
     }
@@ -1057,7 +1071,7 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
                         integration_id: Some(GITHUB_ACTIONS_INTEGRATION_ID),
                     })
                     .collect(),
-                strict_required_status_checks_policy: false,
+                strict_required_status_checks_policy: STRICT_REQUIRED_STATUS_CHECKS_POLICY_DEFAULT,
             },
         });
     }
@@ -1065,15 +1079,7 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
     if branch_protection.merge_queue {
         // Enable merge queue with default settings
         rules.insert(RulesetRule::MergeQueue {
-            parameters: MergeQueueParameters {
-                check_response_timeout_minutes: 360,
-                grouping_strategy: MergeQueueGroupingStrategy::Allgreen,
-                max_entries_to_build: 5,
-                max_entries_to_merge: 5,
-                merge_method: MergeQueueMergeMethod::Merge,
-                min_entries_to_merge: 0,
-                min_entries_to_merge_wait_minutes: 0,
-            },
+            parameters: MergeQueueParameters::default(),
         });
     }
 
@@ -1096,13 +1102,17 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
             .name
             .clone()
             .unwrap_or_else(|| branch_protection.pattern.to_string()),
-        target: RulesetTarget::Branch,
+        target: match branch_protection.target {
+            ProtectionTarget::Branch => RulesetTarget::Branch,
+            ProtectionTarget::Tag => RulesetTarget::Tag,
+        },
         source_type: RulesetSourceType::Repository,
         enforcement: RulesetEnforcement::Active,
         bypass_actors,
         conditions: RulesetConditions {
             ref_name: RulesetRefNameCondition {
-                include: vec![convert_branch_pattern_to_ref_pattern(
+                include: vec![convert_pattern_to_ref_pattern(
+                    branch_protection.target,
                     &branch_protection.pattern,
                 )],
                 exclude: vec![],
@@ -1743,6 +1753,23 @@ fn log_field<T: PartialEq + std::fmt::Debug>(
     Ok(())
 }
 
+fn log_field_if_not_default<T: PartialEq + std::fmt::Debug + Default>(
+    label: &str,
+    old: &T,
+    new: Option<&T>,
+    result: &mut dyn Write,
+) -> std::fmt::Result {
+    match new {
+        Some(new_val) => log_field(label, old, Some(new_val), result)?,
+        None => {
+            if old != &T::default() {
+                writeln!(result, "        {label}: {old:?}")?;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn log_branch_protection(
     current: &api::BranchProtection,
     new: Option<&api::BranchProtection>,
@@ -1793,88 +1820,178 @@ fn log_ruleset(
     mut result: impl Write,
 ) -> std::fmt::Result {
     // Log basic ruleset properties
-    log_field(
+    log_field_if_not_default(
         "Target",
         &current.target,
         new.map(|n| &n.target),
         &mut result,
     )?;
-    log_field(
+    log_field_if_not_default(
         "Source Type",
         &current.source_type,
         new.map(|n| &n.source_type),
         &mut result,
     )?;
-    log_field(
+    log_field_if_not_default(
         "Enforcement",
         &current.enforcement,
         new.map(|n| &n.enforcement),
         &mut result,
     )?;
 
-    // Log branch conditions
+    let (include_label, exclude_label) = match current.target {
+        api::RulesetTarget::Branch => ("Include Branches", "Exclude Branches"),
+        api::RulesetTarget::Tag => ("Include Tags", "Exclude Tags"),
+    };
+
     let ref_name = &current.conditions.ref_name;
     let new_ref_name = new.map(|n| &n.conditions.ref_name);
     log_field(
-        "Include Branches",
+        include_label,
         &ref_name.include,
         new_ref_name.map(|r| &r.include),
         &mut result,
     )?;
-    log_field(
-        "Exclude Branches",
+    log_field_if_not_default(
+        exclude_label,
         &ref_name.exclude,
         new_ref_name.map(|r| &r.exclude),
         &mut result,
     )?;
 
-    log_field(
+    log_field_if_not_default(
         "Bypass Actors",
         &current.bypass_actors,
         new.map(|n| &n.bypass_actors),
         &mut result,
     )?;
 
-    #[derive(PartialEq)]
+    #[derive(PartialEq, Eq)]
     enum RuleValue {
-        Present,
+        Bool(bool),
+        Number(i32),
         String(String),
     }
 
-    impl Display for RuleValue {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            match self {
-                RuleValue::Present => f.write_str("(present)"),
+    /// Store the default value of a rule (if it has one) to suppress noisy
+    /// logging when a full ruleset is created or a rule is added/removed.
+    #[derive(PartialEq, Eq)]
+    struct LoggedRule {
+        value: RuleValue,
+        default: Option<RuleValue>,
+    }
+
+    impl Display for LoggedRule {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match &self.value {
+                RuleValue::Bool(val) => val.fmt(f),
+                RuleValue::Number(val) => val.fmt(f),
                 RuleValue::String(val) => val.fmt(f),
             }
         }
     }
 
+    impl LoggedRule {
+        fn bool_with_default(value: bool, default: bool) -> Self {
+            Self {
+                value: RuleValue::Bool(value),
+                default: Some(RuleValue::Bool(default)),
+            }
+        }
+
+        fn number(value: i32) -> Self {
+            Self {
+                value: RuleValue::Number(value),
+                default: None,
+            }
+        }
+
+        fn number_with_default(value: i32, default: i32) -> Self {
+            Self {
+                value: RuleValue::Number(value),
+                default: Some(RuleValue::Number(default)),
+            }
+        }
+
+        fn string(value: String) -> Self {
+            Self {
+                value: RuleValue::String(value),
+                default: None,
+            }
+        }
+
+        fn string_with_default(value: String, default: String) -> Self {
+            Self {
+                value: RuleValue::String(value),
+                default: Some(RuleValue::String(default)),
+            }
+        }
+
+        fn is_default(&self) -> bool {
+            self.default.as_ref() == Some(&self.value)
+        }
+    }
+
     // The list representation of rules makes it a bit annoying to diff and print
     // So we normalize the rules to a set of key-value pairs, and then diff those
-    fn record_rules(ruleset: &Ruleset) -> HashMap<&'static str, RuleValue> {
+    fn record_rules(ruleset: &Ruleset) -> HashMap<&'static str, LoggedRule> {
         let mut rules = HashMap::new();
         for rule in &ruleset.rules {
             match rule {
                 api::RulesetRule::Creation => {
-                    rules.insert("Restrict creations", RuleValue::Present);
+                    rules.insert(
+                        "Restrict creations",
+                        LoggedRule::bool_with_default(
+                            true,
+                            schema::branch_protection_default_prevent_creation(),
+                        ),
+                    );
                 }
                 api::RulesetRule::Update => {
-                    rules.insert("Restrict updates", RuleValue::Present);
+                    rules.insert(
+                        "Restrict updates",
+                        LoggedRule::bool_with_default(
+                            true,
+                            schema::branch_protection_default_prevent_update(),
+                        ),
+                    );
                 }
                 api::RulesetRule::Deletion => {
-                    rules.insert("Restrict deletions", RuleValue::Present);
+                    rules.insert(
+                        "Restrict deletions",
+                        LoggedRule::bool_with_default(
+                            true,
+                            schema::branch_protection_default_prevent_deletion(),
+                        ),
+                    );
                 }
                 api::RulesetRule::RequiredLinearHistory => {
-                    rules.insert("Require linear history", RuleValue::Present);
+                    rules.insert(
+                        "Require linear history",
+                        LoggedRule::bool_with_default(true, false),
+                    );
                 }
                 api::RulesetRule::RequiredSignatures => {
-                    rules.insert("Require signed commits", RuleValue::Present);
+                    rules.insert(
+                        "Require signed commits",
+                        LoggedRule::bool_with_default(true, false),
+                    );
                 }
                 api::RulesetRule::NonFastForward => {
-                    rules.insert("Forbid force pushes", RuleValue::Present);
+                    rules.insert(
+                        "Forbid force pushes",
+                        LoggedRule::bool_with_default(
+                            true,
+                            schema::branch_protection_default_prevent_force_push(),
+                        ),
+                    );
                 }
                 api::RulesetRule::MergeQueue { parameters } => {
+                    let default_parameters = api::MergeQueueParameters::default();
+                    rules.insert(
+                        "Require merge queue",
+                        LoggedRule::bool_with_default(true, false),
+                    );
                     let api::MergeQueueParameters {
                         check_response_timeout_minutes,
                         grouping_strategy,
@@ -1886,60 +2003,94 @@ fn log_ruleset(
                     } = parameters;
                     rules.insert(
                         "Merge queue timeout",
-                        RuleValue::String(check_response_timeout_minutes.to_string()),
+                        LoggedRule::number_with_default(
+                            *check_response_timeout_minutes,
+                            default_parameters.check_response_timeout_minutes,
+                        ),
                     );
                     rules.insert(
                         "Merge queue grouping strategy",
-                        RuleValue::String(format!("{:?}", grouping_strategy)),
+                        LoggedRule::string_with_default(
+                            format!("{grouping_strategy:?}"),
+                            format!("{:?}", default_parameters.grouping_strategy),
+                        ),
                     );
                     rules.insert(
                         "Merge queue max entries to build",
-                        RuleValue::String(max_entries_to_build.to_string()),
+                        LoggedRule::number_with_default(
+                            *max_entries_to_build,
+                            default_parameters.max_entries_to_build,
+                        ),
                     );
                     rules.insert(
                         "Merge queue max entries to merge",
-                        RuleValue::String(max_entries_to_merge.to_string()),
+                        LoggedRule::number_with_default(
+                            *max_entries_to_merge,
+                            default_parameters.max_entries_to_merge,
+                        ),
                     );
                     rules.insert(
                         "Merge queue min entries to merge",
-                        RuleValue::String(min_entries_to_merge.to_string()),
+                        LoggedRule::number_with_default(
+                            *min_entries_to_merge,
+                            default_parameters.min_entries_to_merge,
+                        ),
                     );
                     rules.insert(
                         "Merge queue merge_method",
-                        RuleValue::String(format!("{merge_method:?}")),
+                        LoggedRule::string_with_default(
+                            format!("{merge_method:?}"),
+                            format!("{:?}", default_parameters.merge_method),
+                        ),
                     );
                     rules.insert(
                         "Merge queue wait time for min group size",
-                        RuleValue::String(min_entries_to_merge_wait_minutes.to_string()),
+                        LoggedRule::number_with_default(
+                            *min_entries_to_merge_wait_minutes,
+                            default_parameters.min_entries_to_merge_wait_minutes,
+                        ),
                     );
                 }
                 api::RulesetRule::PullRequest { parameters } => {
                     rules.insert(
                         "Dismiss stale reviews on push",
-                        RuleValue::String(parameters.dismiss_stale_reviews_on_push.to_string()),
+                        LoggedRule::bool_with_default(
+                            parameters.dismiss_stale_reviews_on_push,
+                            false,
+                        ),
                     );
                     rules.insert(
                         "Require code owner review",
-                        RuleValue::String(parameters.require_code_owner_review.to_string()),
+                        LoggedRule::bool_with_default(
+                            parameters.require_code_owner_review,
+                            REQUIRE_CODE_OWNER_REVIEW_DEFAULT,
+                        ),
                     );
                     rules.insert(
                         "Require last push approval",
-                        RuleValue::String(parameters.require_last_push_approval.to_string()),
+                        LoggedRule::bool_with_default(
+                            parameters.require_last_push_approval,
+                            REQUIRE_LAST_PUSH_APPROVAL_DEFAULT,
+                        ),
                     );
                     rules.insert(
                         "Required approvals",
-                        RuleValue::String(parameters.required_approving_review_count.to_string()),
+                        LoggedRule::number(parameters.required_approving_review_count),
                     );
                     rules.insert(
                         "Require review thread resolution",
-                        RuleValue::String(parameters.required_review_thread_resolution.to_string()),
+                        LoggedRule::bool_with_default(
+                            parameters.required_review_thread_resolution,
+                            REQUIRED_REVIEW_THREAD_RESOLUTION_DEFAULT,
+                        ),
                     );
                 }
                 api::RulesetRule::RequiredStatusChecks { parameters } => {
                     rules.insert(
                         "Strict policy for status checks",
-                        RuleValue::String(
-                            parameters.strict_required_status_checks_policy.to_string(),
+                        LoggedRule::bool_with_default(
+                            parameters.strict_required_status_checks_policy,
+                            STRICT_REQUIRED_STATUS_CHECKS_POLICY_DEFAULT,
                         ),
                     );
                     let mut checks: Vec<String> = parameters
@@ -1956,7 +2107,7 @@ fn log_ruleset(
                     checks.sort();
                     rules.insert(
                         "Required status checks",
-                        RuleValue::String(checks.join(", ")),
+                        LoggedRule::string(checks.join(", ")),
                     );
                 }
                 api::RulesetRule::RequiredDeployments { parameters } => {
@@ -1964,7 +2115,7 @@ fn log_ruleset(
                     envs.sort();
                     rules.insert(
                         "Required deployment environments",
-                        RuleValue::String(envs.join(", ")),
+                        LoggedRule::string(envs.join(", ")),
                     );
                 }
             }
@@ -1979,16 +2130,17 @@ fn log_ruleset(
         for (name, old_value) in &old_rules {
             if let Some(new_value) = new_rules.get(name) {
                 // Updated rule
-                if new_value != old_value {
+                if new_value.value != old_value.value {
                     writeln!(result, "        {name}: {old_value} => {new_value}")?;
                 }
             } else {
-                // Deleted rule
+                // The rule is not present anymore in the new ruleset, so it was deleted
                 writeln!(
                     result,
                     "        {name}: {}",
-                    match old_value {
-                        RuleValue::Present => "yes => no".to_string(),
+                    match &old_value.value {
+                        RuleValue::Bool(val) => format!("deleting `{val}`"),
+                        RuleValue::Number(val) => format!("deleting `{val}`"),
                         RuleValue::String(val) => format!("deleting `{val}`"),
                     }
                 )?;
@@ -1998,26 +2150,18 @@ fn log_ruleset(
         // Created rules
         for (name, new_value) in new_rules {
             if !old_rules.contains_key(name) {
-                writeln!(
-                    result,
-                    "        {name}: {}",
-                    match &new_value {
-                        RuleValue::Present => "yes",
-                        RuleValue::String(val) => val,
-                    }
-                )?;
+                writeln!(result, "        {name}: {new_value}")?;
             }
         }
     } else {
+        // The entire ruleset is new
         for (name, value) in old_rules {
-            writeln!(
-                result,
-                "        {name}: {}",
-                match &value {
-                    RuleValue::Present => "yes",
-                    RuleValue::String(val) => &val,
-                }
-            )?;
+            if value.is_default() {
+                // Hide default-valued rules on creation as
+                // they don't represent a meaningful change to the user.
+                continue;
+            }
+            writeln!(result, "        {name}: {value}")?;
         }
     }
 

--- a/src/sync/github/tests/test_utils.rs
+++ b/src/sync/github/tests/test_utils.rs
@@ -4,10 +4,11 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use derive_builder::Builder;
 use rust_team_data::v1::{
-    self, Bot, BranchProtectionMode, Environment, GitHubTeam, MergeBot, Person, RepoPermission,
-    TeamGitHub, TeamKind,
+    self, Bot, BranchProtectionMode, Environment, GitHubTeam, MergeBot, Person, ProtectionTarget,
+    RepoPermission, TeamGitHub, TeamKind,
 };
 
+use crate::schema;
 use crate::sync::Config;
 use crate::sync::github::api::{
     BranchPolicy, BranchProtection, GithubRead, Repo, RepoTeam, RepoUser, Ruleset, Team,
@@ -432,12 +433,14 @@ impl RepoDataBuilder {
 pub struct BranchProtectionBuilder {
     pub name: Option<String>,
     pub pattern: String,
+    pub target: ProtectionTarget,
     pub dismiss_stale_review: bool,
     pub mode: BranchProtectionMode,
     pub allowed_merge_teams: Vec<String>,
     pub allowed_merge_apps: Vec<MergeBot>,
     pub merge_queue: bool,
     pub prevent_creation: bool,
+    pub prevent_update: bool,
     pub prevent_deletion: bool,
     pub prevent_force_push: bool,
 }
@@ -461,24 +464,28 @@ impl BranchProtectionBuilder {
         let BranchProtectionBuilder {
             name,
             pattern,
+            target,
             dismiss_stale_review,
             mode,
             allowed_merge_teams,
             allowed_merge_apps,
             merge_queue,
             prevent_creation,
+            prevent_update,
             prevent_deletion,
             prevent_force_push,
         } = self;
         v1::BranchProtection {
             name,
             pattern,
+            target,
             dismiss_stale_review,
             mode,
             allowed_merge_teams,
             allowed_merge_apps,
             merge_queue,
             prevent_creation,
+            prevent_update,
             prevent_deletion,
             prevent_force_push,
             // Maintain compatibility with triagebot
@@ -490,14 +497,16 @@ impl BranchProtectionBuilder {
         Self {
             name: None,
             pattern: pattern.to_string(),
+            target: ProtectionTarget::Branch,
             mode,
             dismiss_stale_review: false,
             allowed_merge_teams: vec![],
             allowed_merge_apps: vec![],
             merge_queue: false,
-            prevent_creation: true,
-            prevent_deletion: true,
-            prevent_force_push: true,
+            prevent_creation: schema::branch_protection_default_prevent_creation(),
+            prevent_update: schema::branch_protection_default_prevent_update(),
+            prevent_deletion: schema::branch_protection_default_prevent_deletion(),
+            prevent_force_push: schema::branch_protection_default_prevent_force_push(),
         }
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1153,10 +1153,11 @@ fn validate_branch_protections(data: &Data, errors: &mut Vec<String>) {
         let mut patterns = HashSet::new();
 
         for protection in &repo.branch_protections {
-            if !patterns.insert(&protection.pattern) {
+            if !patterns.insert((protection.target, &protection.pattern)) {
                 bail!(
-                    r#"repo '{}' uses multiple branch protections with the pattern `{}`"#,
+                    r#"repo '{}' uses multiple {:?} protections with the pattern `{}`"#,
                     repo.name,
+                    protection.target,
                     protection.pattern,
                 );
             }

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -25,6 +25,7 @@
           "allowed_merge_apps": [],
           "merge_queue": false,
           "prevent_creation": true,
+          "prevent_update": false,
           "prevent_deletion": true,
           "prevent_force_push": true
         }
@@ -71,6 +72,7 @@
           "allowed_merge_apps": [],
           "merge_queue": false,
           "prevent_creation": true,
+          "prevent_update": false,
           "prevent_deletion": true,
           "prevent_force_push": true
         }

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -23,6 +23,7 @@
       "allowed_merge_apps": [],
       "merge_queue": false,
       "prevent_creation": true,
+      "prevent_update": false,
       "prevent_deletion": true,
       "prevent_force_push": true
     }

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -34,6 +34,7 @@
       "allowed_merge_apps": [],
       "merge_queue": false,
       "prevent_creation": true,
+      "prevent_update": false,
       "prevent_deletion": true,
       "prevent_force_push": true
     }


### PR DESCRIPTION
I ran a script to detect existing rulesets in our orgs. `rust-lang/cargo` is the only repository that has a ruleset not tracked in this repo.

This PR:
- Adds this ruleset (`"Only allow the release process to publish tags"`) to the `team` repository. You can verify that the dry run doesn't mention this repo, so we are just writing down without editing the ruleset in github
- Migrate `cargo` from classic branch protections to rulesets
- Improve the logging of rulesets, so that only relevant fields are showed in the dry run (default values are omitted)

In the following, I post the screenshots of the resources this PR touches:
- as a backup in case something goes wrong
- to better review the dry run

- [ ] For triagebot retrocompatibility we should first merge the code changes, update triagebot and then edit `cargo.toml`. After this PR is approved, I will comment the changes to `cargo.toml` before merging this.

## Existing branch protections
### `Master`
<img width="2300" height="5720" alt="github com_rust-lang_cargo_settings_branch_protection_rules_593520" src="https://github.com/user-attachments/assets/3c112156-65cf-470e-9ccc-e8ebac0820ad" />

### `rust-1.*`

(download to see the full picture)

<img width="2300" height="13868" alt="github com_rust-lang_cargo_settings_branch_protection_rules_593520 (2)" src="https://github.com/user-attachments/assets/b02c70f1-0c96-4794-9c24-139e23c62660" />


## Existing ruleset
<img width="2300" height="3536" alt="github com_rust-lang_cargo_settings_rules_1162109" src="https://github.com/user-attachments/assets/82f65aef-f0e6-45f4-987c-8138343e74ff" />
