### PR TITLE
apply github defaults to ruleset merge queues

### DIFF
--- a/src/sync/github/api/mod.rs
+++ b/src/sync/github/api/mod.rs
@@ -644,11 +644,11 @@ pub(crate) struct MergeQueueParameters {
     pub(crate) min_entries_to_merge_wait_minutes: i32,
 }
 
-pub(crate) const DEFAULT_MERGE_QUEUE_TIMEOUT_MINUTES: i32 = 360;
+pub(crate) const DEFAULT_MERGE_QUEUE_TIMEOUT_MINUTES: i32 = 60;
 pub(crate) const DEFAULT_MERGE_QUEUE_MAX_ENTRIES_TO_BUILD: i32 = 5;
 pub(crate) const DEFAULT_MERGE_QUEUE_MAX_ENTRIES_TO_MERGE: i32 = 5;
-pub(crate) const DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE: i32 = 0;
-pub(crate) const DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE_WAIT_MINUTES: i32 = 0;
+pub(crate) const DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE: i32 = 1;
+pub(crate) const DEFAULT_MERGE_QUEUE_MIN_ENTRIES_TO_MERGE_WAIT_MINUTES: i32 = 5;
 
 #[derive(
     Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,


### PR DESCRIPTION
As far as I remember, all the merge queues we configured use the github defaults. 

For example, you can verify from the screenshot in https://github.com/rust-lang/team/pull/2333#issue-4091869423 that these were the settings for the cargo merge queue.

Close https://github.com/rust-lang/team/issues/2196