### PR TITLE
Create GPU notification group

### DIFF
--- a/people/Firestar99.toml
+++ b/people/Firestar99.toml
@@ -1,0 +1,4 @@
+name = "Firestar99"
+github = "Firestar99"
+github-id = 31222740
+zulip-id = 1001044

--- a/people/Flakebi.toml
+++ b/people/Flakebi.toml
@@ -1,0 +1,4 @@
+name = "Sebastian Neubauer"
+github = "Flakebi"
+github-id = 6499211
+zulip-id = 815102

--- a/people/LegNeato.toml
+++ b/people/LegNeato.toml
@@ -1,0 +1,4 @@
+name = "Christian Legnitto"
+github = "LegNeato"
+github-id = 368904
+zulip-id = 508834

--- a/people/kjetilkjeka.toml
+++ b/people/kjetilkjeka.toml
@@ -1,0 +1,4 @@
+name = "Kjetil Kjeka"
+github = "kjetilkjeka"
+github-id = 5366742
+zulip-id = 425116

--- a/teams/gpu-target.toml
+++ b/teams/gpu-target.toml
@@ -1,0 +1,27 @@
+# Intended to be a ping group on rust-lang/rust for GPU targets.
+
+name = "gpu-target"
+kind = "marker-team"
+
+[people]
+leads = []
+members = [
+    # AMD
+    "Flakebi",
+    # Nvidia
+    "kjetilkjeka",
+    "LegNeato",
+    "FractalFir",
+    # Intel
+    "karolzwolak",
+    # SPIRV
+    "fee1-dead",
+    "eddyb",
+    "Firestar99",
+    # Offload
+    "Sa4dUs",
+    "ZuseZ4",
+    # other members for T-compiler
+    "RalfJung",
+    "workingjubilee"
+]


### PR DESCRIPTION
As per discussion on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Create.20a.20GPU.20notification.20group.20compiler-team.23960/near/568629680).

@Kobzol before sending pings to everyone mentioned in this new file, can you let me know if this looks correct (never created a notification group before).

Thanks :)