### PR TITLE
change prevent-update default

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -447,8 +447,8 @@ prevent-deletion = true
 # (optional - default `true`)
 prevent-force-push = true
 # Whether to prevent updates to the branch.
-# (optional - default `false`)
-prevent-update = false
+# (optional - default matches `pr-required`)
+prevent-update = true
 # Whether the protection applies to branches or tags.
 # Options are "branch" or "tag".
 # (optional - default `branch`)

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -245,6 +245,12 @@ pub enum BranchProtectionMode {
     PrNotRequired,
 }
 
+impl BranchProtectionMode {
+    pub fn is_pr_required(&self) -> bool {
+        matches!(self, BranchProtectionMode::PrRequired { .. })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum MergeBot {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -901,12 +901,18 @@ pub(crate) struct BranchProtection {
     pub merge_queue: MergeQueue,
     #[serde(default = "branch_protection_default_prevent_creation")]
     pub prevent_creation: bool,
-    #[serde(default = "branch_protection_default_prevent_update")]
-    pub prevent_update: bool,
+    #[serde(default)]
+    prevent_update: Option<bool>,
     #[serde(default = "branch_protection_default_prevent_deletion")]
     pub prevent_deletion: bool,
     #[serde(default = "branch_protection_default_prevent_force_push")]
     pub prevent_force_push: bool,
+}
+
+impl BranchProtection {
+    pub(crate) fn prevent_update(&self) -> bool {
+        self.prevent_update.unwrap_or(self.pr_required)
+    }
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -938,14 +944,38 @@ pub const fn branch_protection_default_prevent_creation() -> bool {
     true
 }
 
-pub const fn branch_protection_default_prevent_update() -> bool {
-    false
-}
-
 pub const fn branch_protection_default_prevent_deletion() -> bool {
     true
 }
 
 pub const fn branch_protection_default_prevent_force_push() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BranchProtection;
+
+    #[test]
+    fn prevent_update_defaults_to_true_when_pr_is_required() {
+        let protection: BranchProtection = toml::from_str(r#"pattern = "main""#).unwrap();
+        assert!(protection.pr_required);
+        assert!(protection.prevent_update());
+    }
+
+    #[test]
+    fn prevent_update_defaults_to_false_when_pr_is_not_required() {
+        let protection: BranchProtection =
+            toml::from_str("pattern = \"main\"\npr-required = false").unwrap();
+        assert!(!protection.pr_required);
+        assert!(!protection.prevent_update());
+    }
+
+    #[test]
+    fn explicit_prevent_update_still_overrides_default() {
+        let protection: BranchProtection =
+            toml::from_str("pattern = \"main\"\nprevent-update = false").unwrap();
+        assert!(protection.pr_required);
+        assert!(!protection.prevent_update());
+    }
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -81,7 +81,7 @@ impl<'a> Generator<'a> {
                         .collect(),
                     merge_queue: b.merge_queue.enabled,
                     prevent_creation: b.prevent_creation,
-                    prevent_update: b.prevent_update,
+                    prevent_update: b.prevent_update(),
                     prevent_deletion: b.prevent_deletion,
                     prevent_force_push: b.prevent_force_push,
                     // This field is empty for retrocompatibility with triagebot

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -1932,6 +1932,16 @@ fn log_ruleset(
         }
     }
 
+    fn ruleset_default_prevent_update(ruleset: &Ruleset) -> bool {
+        ruleset.rules.iter().any(|rule| {
+            matches!(
+                rule,
+                api::RulesetRule::PullRequest { .. }
+                    | api::RulesetRule::RequiredStatusChecks { .. }
+            )
+        })
+    }
+
     // The list representation of rules makes it a bit annoying to diff and print
     // So we normalize the rules to a set of key-value pairs, and then diff those
     fn record_rules(ruleset: &Ruleset) -> HashMap<&'static str, LoggedRule> {
@@ -1952,7 +1962,7 @@ fn log_ruleset(
                         "Restrict updates",
                         LoggedRule::bool_with_default(
                             true,
-                            schema::branch_protection_default_prevent_update(),
+                            ruleset_default_prevent_update(ruleset),
                         ),
                     );
                 }

--- a/src/sync/github/tests/test_utils.rs
+++ b/src/sync/github/tests/test_utils.rs
@@ -494,6 +494,7 @@ impl BranchProtectionBuilder {
     }
 
     fn create(pattern: &str, mode: BranchProtectionMode) -> Self {
+        let prevent_update = mode.is_pr_required();
         Self {
             name: None,
             pattern: pattern.to_string(),
@@ -504,7 +505,7 @@ impl BranchProtectionBuilder {
             allowed_merge_apps: vec![],
             merge_queue: false,
             prevent_creation: schema::branch_protection_default_prevent_creation(),
-            prevent_update: schema::branch_protection_default_prevent_update(),
+            prevent_update,
             prevent_deletion: schema::branch_protection_default_prevent_deletion(),
             prevent_force_push: schema::branch_protection_default_prevent_force_push(),
         }

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -25,7 +25,7 @@
           "allowed_merge_apps": [],
           "merge_queue": false,
           "prevent_creation": true,
-          "prevent_update": false,
+          "prevent_update": true,
           "prevent_deletion": true,
           "prevent_force_push": true
         }
@@ -72,7 +72,7 @@
           "allowed_merge_apps": [],
           "merge_queue": false,
           "prevent_creation": true,
-          "prevent_update": false,
+          "prevent_update": true,
           "prevent_deletion": true,
           "prevent_force_push": true
         }

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -23,7 +23,7 @@
       "allowed_merge_apps": [],
       "merge_queue": false,
       "prevent_creation": true,
-      "prevent_update": false,
+      "prevent_update": true,
       "prevent_deletion": true,
       "prevent_force_push": true
     }

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -34,7 +34,7 @@
       "allowed_merge_apps": [],
       "merge_queue": false,
       "prevent_creation": true,
-      "prevent_update": false,
+      "prevent_update": true,
       "prevent_deletion": true,
       "prevent_force_push": true
     }


### PR DESCRIPTION
Discussed in https://github.com/rust-lang/team/pull/2327#discussion_r2987717972

The dry run sets "Restrict updates: true" to all rulesets that have `pr-required: true`, which I think is good.