### PR TITLE
don't require pr on rust timer branches

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -79,12 +79,14 @@ allowed-merge-apps = ["bors"]
 [[branch-protections]]
 pattern = "try-perf"
 allowed-merge-apps = ["rust-timer"]
+pr-required = false
 
 # Required for unrolled PR builds created by perfbot.
 # Must support force-pushes.
 [[branch-protections]]
 pattern = "perf-tmp"
 allowed-merge-apps = ["rust-timer"]
+pr-required = false
 
 [environments.bors]
 branches = ["automation/bors/auto", "automation/bors/try", "try-perf"]


### PR DESCRIPTION
Discussed in [#t-infra > Missing perf builds @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Missing.20perf.20builds/near/582053715)