### PR TITLE
add merge queue settings

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -435,7 +435,23 @@ allowed-merge-apps = ["bors"]
 # Merge queue configuration for this branch. (optional)
 merge-queue = {
   # (optional - default `false`)
-  enabled = false
+  enabled = false,
+  # How GitHub merges entries from the queue.
+  # Options are "merge", "rebase", or "squash".
+  # (optional - default `merge`)
+  method = "merge",
+  # Limit the number of queued pull requests requesting checks and workflow runs at the same time.
+  # (optional - default `5`)
+  max-entries-to-build = 5,
+  # The time merge queue should wait after the first PR is added to the queue for the minimum group size to be met. After this time has elapsed, the minimum group size will be ignored and a smaller group will be merged.
+  # (optional - default `5`)
+  min-entries-to-merge-wait-minutes = 5,
+  # The maximum number of PRs that will be merged together in a group.
+  # (optional - default `5`)
+  max-entries-to-merge = 5,
+  # Maximum time for a required status check to report a conclusion. After this much time has elapsed, checks that have not reported a conclusion will be assumed to have failed
+  # (optional - default `60`)
+  check-response-timeout-minutes = 60
 }
 # Whether to prevent branch creation.
 # (optional - default `true`)

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -275,6 +275,15 @@ pub enum ProtectionTarget {
     Tag,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeQueueMethod {
+    #[default]
+    Merge,
+    Squash,
+    Rebase,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BranchProtection {
     pub pattern: String,
@@ -288,6 +297,28 @@ pub struct BranchProtection {
     pub merge_bots: Vec<MergeBot>,
     pub allowed_merge_apps: Vec<MergeBot>,
     pub merge_queue: bool,
+    #[serde(default, skip_serializing_if = "is_default_merge_queue_method")]
+    pub merge_queue_method: MergeQueueMethod,
+    #[serde(
+        default = "default_merge_queue_max_entries_to_build",
+        skip_serializing_if = "is_default_merge_queue_max_entries_to_build"
+    )]
+    pub merge_queue_max_entries_to_build: u32,
+    #[serde(
+        default = "default_merge_queue_min_entries_to_merge_wait_minutes",
+        skip_serializing_if = "is_default_merge_queue_min_entries_to_merge_wait_minutes"
+    )]
+    pub merge_queue_min_entries_to_merge_wait_minutes: u32,
+    #[serde(
+        default = "default_merge_queue_max_entries_to_merge",
+        skip_serializing_if = "is_default_merge_queue_max_entries_to_merge"
+    )]
+    pub merge_queue_max_entries_to_merge: u32,
+    #[serde(
+        default = "default_merge_queue_check_response_timeout_minutes",
+        skip_serializing_if = "is_default_merge_queue_check_response_timeout_minutes"
+    )]
+    pub merge_queue_check_response_timeout_minutes: u32,
     pub prevent_creation: bool,
     pub prevent_update: bool,
     pub prevent_deletion: bool,
@@ -324,4 +355,40 @@ pub struct People {
 
 fn is_branch_target(target: &ProtectionTarget) -> bool {
     matches!(target, ProtectionTarget::Branch)
+}
+
+fn is_default_merge_queue_method(method: &MergeQueueMethod) -> bool {
+    matches!(method, MergeQueueMethod::Merge)
+}
+
+fn default_merge_queue_max_entries_to_build() -> u32 {
+    5
+}
+
+fn is_default_merge_queue_max_entries_to_build(value: &u32) -> bool {
+    *value == default_merge_queue_max_entries_to_build()
+}
+
+fn default_merge_queue_min_entries_to_merge_wait_minutes() -> u32 {
+    5
+}
+
+fn is_default_merge_queue_min_entries_to_merge_wait_minutes(value: &u32) -> bool {
+    *value == default_merge_queue_min_entries_to_merge_wait_minutes()
+}
+
+fn default_merge_queue_max_entries_to_merge() -> u32 {
+    5
+}
+
+fn is_default_merge_queue_max_entries_to_merge(value: &u32) -> bool {
+    *value == default_merge_queue_max_entries_to_merge()
+}
+
+fn default_merge_queue_check_response_timeout_minutes() -> u32 {
+    60
+}
+
+fn is_default_merge_queue_check_response_timeout_minutes(value: &u32) -> bool {
+    *value == default_merge_queue_check_response_timeout_minutes()
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -873,8 +873,68 @@ pub(crate) enum ProtectionTarget {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum MergeQueueMethod {
+    #[default]
+    Merge,
+    Squash,
+    Rebase,
+}
+
+impl From<MergeQueueMethod> for rust_team_data::v1::MergeQueueMethod {
+    fn from(method: MergeQueueMethod) -> Self {
+        match method {
+            MergeQueueMethod::Merge => Self::Merge,
+            MergeQueueMethod::Squash => Self::Squash,
+            MergeQueueMethod::Rebase => Self::Rebase,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct MergeQueue {
     pub enabled: bool,
+    #[serde(default)]
+    pub method: MergeQueueMethod,
+    #[serde(default = "merge_queue_default_max_entries_to_build")]
+    pub max_entries_to_build: u32,
+    #[serde(default = "merge_queue_default_min_entries_to_merge_wait_minutes")]
+    pub min_entries_to_merge_wait_minutes: u32,
+    #[serde(default = "merge_queue_default_max_entries_to_merge")]
+    pub max_entries_to_merge: u32,
+    #[serde(default = "merge_queue_default_check_response_timeout_minutes")]
+    pub check_response_timeout_minutes: u32,
+}
+
+impl Default for MergeQueue {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            method: MergeQueueMethod::default(),
+            max_entries_to_build: merge_queue_default_max_entries_to_build(),
+            min_entries_to_merge_wait_minutes:
+                merge_queue_default_min_entries_to_merge_wait_minutes(),
+            max_entries_to_merge: merge_queue_default_max_entries_to_merge(),
+            check_response_timeout_minutes: merge_queue_default_check_response_timeout_minutes(),
+        }
+    }
+}
+
+fn merge_queue_default_max_entries_to_build() -> u32 {
+    5
+}
+
+fn merge_queue_default_min_entries_to_merge_wait_minutes() -> u32 {
+    5
+}
+
+fn merge_queue_default_max_entries_to_merge() -> u32 {
+    5
+}
+
+fn merge_queue_default_check_response_timeout_minutes() -> u32 {
+    60
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -80,6 +80,15 @@ impl<'a> Generator<'a> {
                         })
                         .collect(),
                     merge_queue: b.merge_queue.enabled,
+                    merge_queue_method: b.merge_queue.method.into(),
+                    merge_queue_max_entries_to_build: b.merge_queue.max_entries_to_build,
+                    merge_queue_min_entries_to_merge_wait_minutes: b
+                        .merge_queue
+                        .min_entries_to_merge_wait_minutes,
+                    merge_queue_max_entries_to_merge: b.merge_queue.max_entries_to_merge,
+                    merge_queue_check_response_timeout_minutes: b
+                        .merge_queue
+                        .check_response_timeout_minutes,
                     prevent_creation: b.prevent_creation,
                     prevent_update: b.prevent_update,
                     prevent_deletion: b.prevent_deletion,

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -1011,6 +1011,10 @@ pub(crate) fn convert_pattern_to_ref_pattern(target: ProtectionTarget, pattern: 
     }
 }
 
+fn github_int(value: u32) -> i32 {
+    i32::try_from(value).unwrap_or_else(|_| panic!("Value {value} exceeds GitHub's Int range"))
+}
+
 pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtection) -> api::Ruleset {
     use api::*;
 
@@ -1049,7 +1053,7 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
                 dismiss_stale_reviews_on_push: branch_protection.dismiss_stale_review,
                 require_code_owner_review: REQUIRE_CODE_OWNER_REVIEW_DEFAULT,
                 require_last_push_approval: REQUIRE_LAST_PUSH_APPROVAL_DEFAULT,
-                required_approving_review_count: *required_approvals as i32,
+                required_approving_review_count: github_int(*required_approvals),
                 required_review_thread_resolution: REQUIRED_REVIEW_THREAD_RESOLUTION_DEFAULT,
             },
         });
@@ -1077,10 +1081,25 @@ pub fn construct_ruleset(branch_protection: &rust_team_data::v1::BranchProtectio
     }
 
     if branch_protection.merge_queue {
-        // Enable merge queue with default settings
-        rules.insert(RulesetRule::MergeQueue {
-            parameters: MergeQueueParameters::default(),
-        });
+        let merge_method = match branch_protection.merge_queue_method {
+            rust_team_data::v1::MergeQueueMethod::Merge => MergeQueueMergeMethod::Merge,
+            rust_team_data::v1::MergeQueueMethod::Squash => MergeQueueMergeMethod::Squash,
+            rust_team_data::v1::MergeQueueMethod::Rebase => MergeQueueMergeMethod::Rebase,
+        };
+        let parameters = MergeQueueParameters {
+            check_response_timeout_minutes: github_int(
+                branch_protection.merge_queue_check_response_timeout_minutes,
+            ),
+            max_entries_to_build: github_int(branch_protection.merge_queue_max_entries_to_build),
+            max_entries_to_merge: github_int(branch_protection.merge_queue_max_entries_to_merge),
+            merge_method,
+            min_entries_to_merge_wait_minutes: github_int(
+                branch_protection.merge_queue_min_entries_to_merge_wait_minutes,
+            ),
+            ..MergeQueueParameters::default()
+        };
+
+        rules.insert(RulesetRule::MergeQueue { parameters });
     }
 
     // Build bypass actors from allowed merge apps

--- a/src/sync/github/tests/test_utils.rs
+++ b/src/sync/github/tests/test_utils.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::vec;
 
 use derive_builder::Builder;
 use rust_team_data::v1::{
-    self, Bot, BranchProtectionMode, Environment, GitHubTeam, MergeBot, Person, ProtectionTarget,
-    RepoPermission, TeamGitHub, TeamKind,
+    self, Bot, BranchProtectionMode, Environment, GitHubTeam, MergeBot, MergeQueueMethod, Person,
+    ProtectionTarget, RepoPermission, TeamGitHub, TeamKind,
 };
 
 use crate::schema;
@@ -439,6 +440,11 @@ pub struct BranchProtectionBuilder {
     pub allowed_merge_teams: Vec<String>,
     pub allowed_merge_apps: Vec<MergeBot>,
     pub merge_queue: bool,
+    pub merge_queue_method: MergeQueueMethod,
+    pub merge_queue_max_entries_to_build: u32,
+    pub merge_queue_min_entries_to_merge_wait_minutes: u32,
+    pub merge_queue_max_entries_to_merge: u32,
+    pub merge_queue_check_response_timeout_minutes: u32,
     pub prevent_creation: bool,
     pub prevent_update: bool,
     pub prevent_deletion: bool,
@@ -470,6 +476,11 @@ impl BranchProtectionBuilder {
             allowed_merge_teams,
             allowed_merge_apps,
             merge_queue,
+            merge_queue_method,
+            merge_queue_max_entries_to_build,
+            merge_queue_min_entries_to_merge_wait_minutes,
+            merge_queue_max_entries_to_merge,
+            merge_queue_check_response_timeout_minutes,
             prevent_creation,
             prevent_update,
             prevent_deletion,
@@ -484,6 +495,11 @@ impl BranchProtectionBuilder {
             allowed_merge_teams,
             allowed_merge_apps,
             merge_queue,
+            merge_queue_method,
+            merge_queue_max_entries_to_build,
+            merge_queue_min_entries_to_merge_wait_minutes,
+            merge_queue_max_entries_to_merge,
+            merge_queue_check_response_timeout_minutes,
             prevent_creation,
             prevent_update,
             prevent_deletion,
@@ -494,15 +510,24 @@ impl BranchProtectionBuilder {
     }
 
     fn create(pattern: &str, mode: BranchProtectionMode) -> Self {
+        let merge_queue_defaults = schema::MergeQueue::default();
+
         Self {
             name: None,
             pattern: pattern.to_string(),
-            target: ProtectionTarget::Branch,
+            target: ProtectionTarget::default(),
             mode,
             dismiss_stale_review: false,
             allowed_merge_teams: vec![],
             allowed_merge_apps: vec![],
-            merge_queue: false,
+            merge_queue: merge_queue_defaults.enabled,
+            merge_queue_method: merge_queue_defaults.method.into(),
+            merge_queue_max_entries_to_build: merge_queue_defaults.max_entries_to_build,
+            merge_queue_min_entries_to_merge_wait_minutes: merge_queue_defaults
+                .min_entries_to_merge_wait_minutes,
+            merge_queue_max_entries_to_merge: merge_queue_defaults.max_entries_to_merge,
+            merge_queue_check_response_timeout_minutes: merge_queue_defaults
+                .check_response_timeout_minutes,
             prevent_creation: schema::branch_protection_default_prevent_creation(),
             prevent_update: schema::branch_protection_default_prevent_update(),
             prevent_deletion: schema::branch_protection_default_prevent_deletion(),


### PR DESCRIPTION
This PR makes merge queue configurable to allow to encode in the toml files the remaining repositories listed in https://github.com/rust-lang/team/issues/1735#issuecomment-4147589452

I made no data changes to the repositories and the v1 API doesn't return the new fields if the data is the default so that triagebot is retrocompatible. Because the V1 API JSON response shouldn't differ after we merge this PR.

- [ ] After this PR is merged, update triagebot

After we update triagebot, we can configure the remaining merge queues in the toml files.

GitHub docs at https://docs.github.com/en/rest/repos/rules?apiVersion=2026-03-10#create-a-repository-ruleset--parameters