### PR TITLE
renovate: rename updateTypes field

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,7 +24,7 @@
       matchCategories: [
         "rust"
       ],
-      updateTypes: [
+      matchUpdateTypes: [
         "patch"
       ],
       // Disable patch updates for single dependencies because patches


### PR DESCRIPTION
Renovate renamed this field.
I manually triggered the renovate migration PR and renovate opened https://github.com/rust-lang/team/pull/2358

However that PR changes too much and removes the comments, so I opened this PR instead.
