### PR TITLE
Define two new subteams for rustdoc to better split everyone's work

### DIFF
--- a/teams/rustdoc-internals.toml
+++ b/teams/rustdoc-internals.toml
@@ -1,16 +1,19 @@
-name = "rustdoc-frontend"
+name = "rustdoc-internals"
 subteam-of = "rustdoc"
 
 [people]
 leads = []
 members = [
-    "notriddle",
     "GuillaumeGomez",
     "camelid",
+    "notriddle",
+    "fmease",
     "lolbinarycat",
+    "yotamofek",
+    "Urgau",
+    "Manishearth",
 ]
 alumni = [
-    "jsha",
 ]
 
 [permissions]
@@ -22,11 +25,11 @@ perf = true
 orgs = ["rust-lang", "rust-lang-nursery"]
 
 [website]
-name = "Rustdoc web frontend"
-description = "Rustdoc frontend design, UI, UX and development"
+name = "Rustdoc internals"
+description = "Rustdoc internals development"
 zulip-stream = "t-rustdoc"
 
 [rfcbot]
-label = "T-rustdoc-frontend"
-name = "Rustdoc frontend"
-ping = "rust-lang/rustdoc-frontend"
+label = "T-rustdoc-internals"
+name = "Rustdoc internals"
+ping = "rust-lang/rustdoc-internals"

--- a/teams/rustdoc-json.toml
+++ b/teams/rustdoc-json.toml
@@ -1,0 +1,30 @@
+name = "rustdoc-json-backend"
+subteam-of = "rustdoc"
+
+[people]
+leads = []
+members = [
+    "aDotInTheVoid",
+    "GuillaumeGomez",
+    "Urgau",
+]
+alumni = [
+]
+
+[permissions]
+bors.rust.review = true
+dev-desktop = true
+perf = true
+
+[[github]]
+orgs = ["rust-lang", "rust-lang-nursery"]
+
+[website]
+name = "Rustdoc JSON backend"
+description = "Rustdoc JSON backend development"
+zulip-stream = "t-rustdoc"
+
+[rfcbot]
+label = "T-rustdoc-json-backend"
+name = "Rustdoc JSON backend"
+ping = "rust-lang/rustdoc-json-backend"


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust-forge/pull/993.

As discussed in the rust-forge, to better reflect what everyone is working on and to ensure people are only pinged to FCPs relative to what they're interested into, this PR creates two new subteams.

Important: If a member is not in any subteam, it means they will only be pinged on general FCPs.

Important 2: Please don't hesitate to tell me if someone wants to be added/removed from one of the groups so I can update the PR before it's merged.

cc @rust-lang/rustdoc 