### PR TITLE
renovate: don't raise individual PRs for crates non breaking changes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,10 +24,10 @@
       matchCategories: [
         "rust"
       ],
-      matchUpdateTypes: [
-        "patch"
+      matchJsonata: [
+        "isBreaking != true"
       ],
-      // Disable patch updates for single dependencies because patches
+      // Disable non-breaking change updates because they
       // are updated periodically with lockfile maintainance.
       enabled: false,
     },


### PR DESCRIPTION
Before this PR, we were receiving PRs when crate `1.2.3` was updated to `1.3.0`.
With this PR, we should receive PRs only when `2.0.0` is out.

Similar to https://github.com/rust-lang/crates-io-auth-action/pull/220