### PR TITLE
google-workspace: add data models

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -13,6 +13,7 @@ zulip-id = 123456   # Zulip ID of the person (required)
 discord-id = 123456 # Discord ID of the person (optional)
 # You can also set `email = false` to explicitly disable the email for the user.
 # This will, for example, avoid adding the person to the mailing lists.
+# Note: if you need Google SSO access, this field is mandatory
 email = "john@doe.com"  # Email address used for mailing lists (optional)
 irc = "jdoe"  # Nickname of the person on IRC, if different than the GitHub one (optional)
 matrix = "@john:doe.com" # Matrix username (MXID) of the person (optional)
@@ -24,6 +25,13 @@ github-sponsors = true
 
 [permissions]
 # Optional, see the permissions documentation
+
+[google-workspace]
+# Optional, available only for users who require managed infrastructure access
+# See https://forge.rust-lang.org/infra/docs
+first-name = "John"  # Your first name
+last-name = "Doe"   # Your last name or preferred surname
+account-handle = "john.doe" # The handle to define a @rust-lang.org account (e.g. john.doe@rust-lang.org)
 ```
 
 The file must be named the same as the GitHub username.
@@ -45,6 +53,11 @@ top-level = true
 # - project-group
 # - marker-team
 kind = "working-group"
+
+# Optional, defaults to false.
+# Set this field to true to grant team members access to specific infrastructure systems via Google Groups.
+# See https://forge.rust-lang.org/infra/docs
+google-workpace-saml-group = false
 
 [people]
 # Leads of the team, can be more than one and must be members of the team.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -82,6 +82,16 @@ pub(crate) struct Funding {
     github_sponsors: bool,
 }
 
+#[allow(dead_code)]
+#[derive(serde::Deserialize, Debug)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub(crate) struct GoogleWorkspace {
+    first_name: String,
+    last_name: String,
+    account_handle: String,
+}
+
+#[allow(dead_code)]
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Person {
@@ -98,6 +108,7 @@ pub(crate) struct Person {
     funding: Funding,
     #[serde(default)]
     permissions: Permissions,
+    google_workspace: Option<GoogleWorkspace>,
 }
 
 impl Person {
@@ -152,6 +163,10 @@ impl Person {
         &self.permissions
     }
 
+    pub(crate) fn google_workspace(&self) -> &Option<GoogleWorkspace> {
+        &self.google_workspace
+    }
+
     pub(crate) fn validate(&self) -> Result<(), Error> {
         if let EmailField::Disabled(true) = &self.email {
             bail!("`email = true` is not valid (for person {})", self.github);
@@ -185,6 +200,7 @@ impl std::fmt::Display for TeamKind {
     }
 }
 
+#[allow(dead_code)]
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Team {
@@ -193,6 +209,7 @@ pub(crate) struct Team {
     kind: TeamKind,
     subteam_of: Option<String>,
     top_level: Option<bool>,
+    google_workspace_saml_group: Option<bool>,
     people: TeamPeople,
     #[serde(default)]
     permissions: Permissions,
@@ -227,6 +244,10 @@ impl Team {
 
     pub(crate) fn top_level(&self) -> Option<bool> {
         self.top_level
+    }
+
+    pub(crate) fn google_workspace_saml_group(&self) -> Option<bool> {
+        self.google_workspace_saml_group
     }
 
     // Return's whether the provided team is a subteam of this team

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -39,6 +39,7 @@ static CHECKS: &[Check<fn(&Data, &mut Vec<String>)>] = checks![
     validate_subteam_of,
     validate_team_leads,
     validate_team_members,
+    validate_team_gws_group,
     validate_duplicate_team_entries,
     validate_alumni,
     validate_archived_teams,
@@ -48,6 +49,7 @@ static CHECKS: &[Check<fn(&Data, &mut Vec<String>)>] = checks![
     validate_list_extra_teams,
     validate_list_addresses,
     validate_people_addresses,
+    validate_people_gws,
     validate_duplicate_permissions,
     validate_permissions,
     validate_rfcbot_labels,
@@ -242,6 +244,27 @@ fn validate_team_members(data: &Data, errors: &mut Vec<String>) {
                     team.name()
                 );
             }
+            Ok(())
+        });
+        Ok(())
+    });
+}
+
+/// Ensure that teams mapped to Google Groups have all Google Workspace (GWS) accounts already provisioned
+fn validate_team_gws_group(data: &Data, errors: &mut Vec<String>) {
+    wrapper(data.teams(), errors, |team, errors| {
+        wrapper(team.members(data)?.iter(), errors, |member, _| {
+            if let Some(person) = data.person(member)
+                && let Some(true) = team.google_workspace_saml_group()
+                && person.google_workspace().is_none()
+            {
+                bail!(
+                    "team `{}` defines a google group but `{}` account is not on google workspace",
+                    team.name(),
+                    member,
+                );
+            }
+
             Ok(())
         });
         Ok(())
@@ -541,6 +564,22 @@ fn validate_people_addresses(data: &Data, errors: &mut Vec<String>) {
         {
             bail!("invalid email address of `{}`: {}", person.github(), email);
         }
+        Ok(())
+    });
+}
+
+/// Ensure personal email provided for people with access to Google Workspace
+fn validate_people_gws(data: &Data, errors: &mut Vec<String>) {
+    wrapper(data.people(), errors, |person, _| {
+        if person.google_workspace().is_some() {
+            return match person.email() {
+                Email::Missing | Email::Disabled => {
+                    bail!("google workspace requires a personal user email")
+                }
+                Email::Present(_) => Ok(()),
+            };
+        }
+
         Ok(())
     });
 }


### PR DESCRIPTION
First PR towards #2363 

A few notes : 

- I preferred to frame naming around `Google Workspace` for now, but happy to discuss
- Added `#[allow(dead_code)]` in some places to make clippy happy, will remove them afterwards
- I'm pointing generically to [rust-forge/infra/docs](https://forge.rust-lang.org/infra/docs) while we don't have a dedicated doc for Google SSO and access management

Regarding data modelling, some considerations on `first-name` and `last-name` requirements.

(1) unfortunately, although the related [UserName](https://developers.google.com/workspace/admin/directory/reference/rest/v1/users#UserName) data object predicts `fullName`, I'm pretty much sure this is a computed field. There is no such option when creating a new user either through the GWS admin console or the [corresponding Terraform Provider](https://registry.terraform.io/providers/hashicorp/googleworkspace/latest/docs/resources/user#required).

(2) we could try to split person#name to fullfill what the GWS Admin API expects, but for some users it won't work ([example](https://github.com/rust-lang/team/blob/main/people/walterhpearce.toml))

Regarding the validation, requesting a personal/work email : that will be used as recovery email address, which is not mandatory, but useful for other purposes, including sending the initial password to the new user. 
