### PR TITLE
Make Zulip t-lang/with-advisors automaticaly managed via teams

### DIFF
--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -39,3 +39,7 @@ extra-teams = ["lang"]
 
 [[zulip-groups]]
 name = "T-lang-advisors"
+
+[[zulip-streams]]
+name = "t-lang/with-advisors"
+extra-teams = ["lang"]


### PR DESCRIPTION
This should make new lang or lang-advisors members automatically get
access.
