### PR TITLE
rulesets: log when default fields change

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -107,6 +107,7 @@ enable-rulesets-repos = [
    "rust-lang/crates-build-env",
    "rust-lang/crates-io-auth-action",
    "rust-lang/crates.io",
+   "rust-lang/crates.io-index-archive",
    "rust-lang/docs.rs",
    "rust-lang/edition-guide",
    "rust-lang/ena",

--- a/repos/rust-lang/crates.io-index-archive.toml
+++ b/repos/rust-lang/crates.io-index-archive.toml
@@ -9,6 +9,7 @@ crates-io = "maintain"
 [[branch-protections]]
 pattern = "snapshot-*"
 pr-required = false
+prevent-creation = false
 
 [[branch-protections]]
 pattern = "main"

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -22,6 +22,7 @@ static DEFAULT_PRIVACY: TeamPrivacy = TeamPrivacy::Closed;
 /// Verified via: https://api.github.com/repos/rust-lang/rust/commits/HEAD/check-runs
 const GITHUB_ACTIONS_INTEGRATION_ID: i64 = 15368;
 
+const REQUIRE_PULL_REQUESTS_DEFAULT: bool = true;
 const REQUIRE_CODE_OWNER_REVIEW_DEFAULT: bool = false;
 const REQUIRE_LAST_PUSH_APPROVAL_DEFAULT: bool = false;
 const REQUIRED_REVIEW_THREAD_RESOLUTION_DEFAULT: bool = false;
@@ -1987,13 +1988,47 @@ fn log_ruleset(
 
     // The list representation of rules makes it a bit annoying to diff and print
     // So we normalize the rules to a set of key-value pairs, and then diff those
-    fn record_rules(ruleset: &Ruleset) -> HashMap<&'static str, LoggedRule> {
-        let mut rules = HashMap::new();
+    fn record_rules(ruleset: &Ruleset) -> BTreeMap<&'static str, LoggedRule> {
+        const FORBID_FORCE_PUSHES: &str = "Forbid force pushes";
+        const REQUIRE_PULL_REQUESTS: &str = "Require pull requests";
+        const RESTRICT_CREATIONS: &str = "Restrict creations";
+        const RESTRICT_DELETIONS: &str = "Restrict deletions";
+
+        // Some default-true toggles are represented by the presence of a rule,
+        // so seed their disabled state to keep non-default `false` values visible.
+        let mut rules = BTreeMap::from([
+            (
+                FORBID_FORCE_PUSHES,
+                LoggedRule::bool_with_default(
+                    false,
+                    schema::branch_protection_default_prevent_force_push(),
+                ),
+            ),
+            (
+                REQUIRE_PULL_REQUESTS,
+                LoggedRule::bool_with_default(false, REQUIRE_PULL_REQUESTS_DEFAULT),
+            ),
+            (
+                RESTRICT_CREATIONS,
+                LoggedRule::bool_with_default(
+                    false,
+                    schema::branch_protection_default_prevent_creation(),
+                ),
+            ),
+            (
+                RESTRICT_DELETIONS,
+                LoggedRule::bool_with_default(
+                    false,
+                    schema::branch_protection_default_prevent_deletion(),
+                ),
+            ),
+        ]);
+
         for rule in &ruleset.rules {
             match rule {
                 api::RulesetRule::Creation => {
                     rules.insert(
-                        "Restrict creations",
+                        RESTRICT_CREATIONS,
                         LoggedRule::bool_with_default(
                             true,
                             schema::branch_protection_default_prevent_creation(),
@@ -2011,7 +2046,7 @@ fn log_ruleset(
                 }
                 api::RulesetRule::Deletion => {
                     rules.insert(
-                        "Restrict deletions",
+                        RESTRICT_DELETIONS,
                         LoggedRule::bool_with_default(
                             true,
                             schema::branch_protection_default_prevent_deletion(),
@@ -2032,7 +2067,7 @@ fn log_ruleset(
                 }
                 api::RulesetRule::NonFastForward => {
                     rules.insert(
-                        "Forbid force pushes",
+                        FORBID_FORCE_PUSHES,
                         LoggedRule::bool_with_default(
                             true,
                             schema::branch_protection_default_prevent_force_push(),
@@ -2105,6 +2140,10 @@ fn log_ruleset(
                     );
                 }
                 api::RulesetRule::PullRequest { parameters } => {
+                    rules.insert(
+                        REQUIRE_PULL_REQUESTS,
+                        LoggedRule::bool_with_default(true, REQUIRE_PULL_REQUESTS_DEFAULT),
+                    );
                     rules.insert(
                         "Dismiss stale reviews on push",
                         LoggedRule::bool_with_default(

--- a/src/sync/github/tests/mod.rs
+++ b/src/sync/github/tests/mod.rs
@@ -1,3 +1,4 @@
+use super::{construct_ruleset, log_ruleset};
 use crate::sync::github::tests::test_utils::{
     BranchProtectionBuilder, DEFAULT_ORG, DataModel, RepoData, TeamData,
 };
@@ -943,6 +944,42 @@ async fn repo_remove_branch_protection() {
         ),
     ]
     "#);
+}
+
+#[test]
+fn ruleset_creation_logs_non_default_disabled_flags() {
+    let mut protection = BranchProtectionBuilder::pr_not_required("main").build();
+
+    // Change defaults
+    protection.prevent_creation = false;
+    protection.prevent_deletion = false;
+    protection.prevent_force_push = false;
+
+    let ruleset = construct_ruleset(&protection);
+    let mut rendered = String::new();
+    log_ruleset(&ruleset, None, &mut rendered).unwrap();
+
+    assert!(rendered.contains("Restrict creations: false"));
+    assert!(rendered.contains("Restrict deletions: false"));
+    assert!(rendered.contains("Forbid force pushes: false"));
+    assert!(rendered.contains("Require pull requests: false"));
+}
+
+#[test]
+fn ruleset_updates_log_disabled_toggle_rules_as_false() {
+    let old =
+        construct_ruleset(&BranchProtectionBuilder::pr_required("main", &["test"], 1).build());
+
+    let mut new_protection = BranchProtectionBuilder::pr_required("main", &["test"], 1).build();
+
+    // Change default
+    new_protection.prevent_force_push = false;
+
+    let new = construct_ruleset(&new_protection);
+    let mut rendered = String::new();
+    log_ruleset(&old, Some(&new), &mut rendered).unwrap();
+
+    assert!(rendered.contains("Forbid force pushes: true => false"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fix https://github.com/rust-lang/team/issues/2376

I also convert `crates.io-index-archive` to prove that this PR works. In fact, the dry run now shows `prevent-creation = false`