### PR TITLE
rulesets: check compatibility between merge queue and linear history

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -419,6 +419,8 @@ dismiss-stale-review = false
 # (optional - default `false`)
 require-conversation-resolution = false
 # Prevent merge commits from being pushed to matching branches.
+# When this option is set, one cannot use `merge` as merging method 
+# for a Merge Queue. Use squash or rebase instead.
 # (optional - default `false`)
 require-linear-history = false
 # Is a PR required when making changes to this branch?

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2,8 +2,8 @@ use crate::api::github::GitHubApi;
 use crate::api::zulip::ZulipApi;
 use crate::data::Data;
 use crate::schema::{
-    AllowedMergeApp, Bot, Email, Permissions, Repo, RepoPermission, Team, TeamKind, TeamPeople,
-    ZulipMember,
+    AllowedMergeApp, Bot, Email, MergeQueueMethod, Permissions, Repo, RepoPermission, Team,
+    TeamKind, TeamPeople, ZulipMember,
 };
 use anyhow::{Context as _, Error, bail};
 use log::{error, warn};
@@ -1216,6 +1216,17 @@ but that team is not mentioned in [access.teams]"#,
             if protection.merge_queue.enabled && protection.pattern.contains('*') {
                 bail!(
                     r#"repo '{}' uses a GitHub rule for {} that enables `merge-queue`, but GitHub merge queues only support exact ref names patterns"#,
+                    repo.name,
+                    protection.pattern,
+                );
+            }
+
+            if protection.require_linear_history
+                && protection.merge_queue.enabled
+                && protection.merge_queue.method == MergeQueueMethod::Merge
+            {
+                bail!(
+                    r"repo '{}' uses a branch protection for {} that requires linear commit history, but also requires a merge queue using the default merging method `merge`, which is not compatible",
                     repo.name,
                     protection.pattern,
                 );


### PR DESCRIPTION
When a `linear commit history` is required in a classical branch protection or ruleset, the default merge method for MQs (`merge`) should not be used. We add a validation for that. 

<img width="1658" height="1246" alt="image" src="https://github.com/user-attachments/assets/ba386949-a3dd-4e59-9744-c3ca2f26fb09" />
