### PR TITLE
Add hashcatHitman to the survey team

### DIFF
--- a/people/hashcatHitman.toml
+++ b/people/hashcatHitman.toml
@@ -1,0 +1,5 @@
+name = "Sam Kellam"
+github = "hashcatHitman"
+github-id = 155700084
+zulip-id = 981988
+email = "trait.to.implement661@passmail.net"

--- a/teams/survey.toml
+++ b/teams/survey.toml
@@ -2,8 +2,16 @@ name = "survey"
 subteam-of = "launching-pad"
 
 [people]
-leads = ["Kobzol", "apiraino"]
-members = ["graciegregory", "Kobzol", "apiraino"]
+leads = [
+    "Kobzol",
+    "apiraino"
+]
+members = [
+    "graciegregory",
+    "Kobzol",
+    "apiraino",
+    "hashcatHitman"
+]
 alumni = [
     "Manishearth",
     "nikomatsakis",


### PR DESCRIPTION
@hashcatHitman did a great job with the recent debugging survey, both in gathering feedback and preparing the survey contents, and also with a follow-up analysis. We would like to extend an invitation for him to join the Survey team. Welcome! :tada:

(e-mail will have to be set to appease CI)

CC @apiraino
