### PR TITLE
Update hashbrown default branch name

### DIFF
--- a/repos/rust-lang/hashbrown.toml
+++ b/repos/rust-lang/hashbrown.toml
@@ -9,7 +9,7 @@ libs = "write"
 libs-contributors = "write"
 
 [[branch-protections]]
-pattern = "master"
+pattern = "main"
 ci-checks = ["conclusion"]
 required-approvals = 0
 merge-queue = { enabled = true }


### PR DESCRIPTION
Needs to be changed on actual repo too, but otherwise there are no other references to the default branch name.