### PR TITLE
CI: Set minimal `permissions:` blocks in workflows

### DIFF
--- a/.github/workflows/check-untracked-repos.yml
+++ b/.github/workflows/check-untracked-repos.yml
@@ -6,9 +6,13 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-untracked-repos:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -18,6 +18,8 @@ on:
     types:
       - completed
 
+permissions: {}
+
 jobs:
   dry-run:
     runs-on: ubuntu-latest
@@ -27,7 +29,7 @@ jobs:
       group: dry-run-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: true
     permissions:
-      pull-requests: write
+      pull-requests: write  # Needed to post and edit the dry-run result comment on the PR
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || 'deploy' }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     if: github.repository == 'rust-lang/team'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -82,8 +86,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: deploy
     permissions:
-      id-token: write
-      pages: write
+      contents: read
+      id-token: write  # Needed for GitHub Pages OIDC authentication in `actions/deploy-pages`
+      pages: write     # Needed to deploy the built static API to GitHub Pages
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This addresses `excessive-permissions` and `undocumented-permissions` findings reported by `zizmor`. Each workflow now defaults to `permissions: {}` at the top level and grants only the scopes it actually needs at the job level, with inline comments documenting the reason for every non-trivial grant.

See:
- https://docs.zizmor.sh/audits/#excessive-permissions
- https://docs.zizmor.sh/audits/#undocumented-permissions