### PR TITLE
CI: Fix zizmor anonymous-definition by naming every job

### DIFF
--- a/.github/workflows/check-untracked-repos.yml
+++ b/.github/workflows/check-untracked-repos.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   check-untracked-repos:
+    name: Check untracked repositories
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -22,6 +22,7 @@ permissions: {}
 
 jobs:
   dry-run:
+    name: Dry run
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,8 @@ jobs:
   # Summary job for the merge queue.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
   CI:
+    # Keep `name` matching the status check.
+    name: CI
     needs: [ test, deploy ]
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to


### PR DESCRIPTION
This PR addresses `anonymous-definition` findings reported by `zizmor` in pedantic mode. Each job in `.github/workflows/` now has an explicit `name:` field. The merge queue summary job in `main.yml` keeps `name: CI` (matching its job key) on purpose, so the required `CI / CI` status check in branch protection keeps working.

Reference:
https://docs.zizmor.sh/audits/#anonymous-definition
