### PR TITLE
relax github team members validation

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -183,6 +183,8 @@ impl Data {
         self.people.values()
     }
 
+    /// Return the usernames of all active members, i.e. all members of non-alumni teams.
+    /// It also includes members of teams that don't have a `[[github]]` section.
     pub(crate) fn active_members(&self) -> Result<HashSet<&str>, Error> {
         let mut active = HashSet::new();
         for team in self.teams.values().filter(|team| !team.is_alumni_team()) {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -714,10 +714,20 @@ fn validate_github_teams(data: &Data, errors: &mut Vec<String>) {
 
 /// Ensure there are no misspelled GitHub account names
 async fn validate_github_usernames(data: &Data, github: &GitHubApi, errors: &mut Vec<String>) {
+    let active_members = match data.active_members() {
+        Ok(m) => m,
+        Err(err) => {
+            errors.push(format!("couldn't get active members: {err}"));
+            return;
+        }
+    };
+
     let people = data
         .people()
+        .filter(|p| active_members.contains(p.github()))
         .map(|p| (p.github_id(), p))
         .collect::<HashMap<_, _>>();
+
     match github
         .usernames(&people.keys().cloned().collect::<Vec<_>>())
         .await


### PR DESCRIPTION
Sometimes GitHub usernames change and our CI fails.
With this PR, the CI fails only if the user is a member of a team (not alumni).

## Manual test 1

1. Change the username of a member (eg https://github.com/rust-lang/team/blob/main/people/maurer.toml )
   - Change the file name
   - Change the `github` field in the file
   - Change their username in any `members` section they appear.
2. Run `GITHUB_TOKEN=$(gh auth token) cargo run -- check`

Output:
```
[ERROR rust_team::validate] validation error: GitHub user `maurer1` changed username to `maurer`
[ERROR rust_team] 1 validation errors found
```

## Manual test 2

1. Change a username of an alumni ( eg https://github.com/rust-lang/team/blob/main/people/J-ZhengLi.toml )
   - Change the file name
   - Change the `github` field in the file
   - Change their username in any `alumni` section they appear.
2. Run the previous command

The output doesn't report errors