### PR TITLE
Add concurrency block to prevent overlapping scheduled runs

### DIFF
--- a/.github/workflows/check-untracked-repos.yml
+++ b/.github/workflows/check-untracked-repos.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
This  PR  fixes the 1 concurrency-limits finding zizmor flagged under `--persona=pedantic`. I added  a workflow-level `concurrency:` block to the `check-untracked-repos` workflow, preventing multiple runs from overlapping when a scheduled cron and a manual `workflow_dispatch` are triggered around the same time.

Reference: https://woodruffw.github.io/zizmor/audits/#concurrency-limits