### PR TITLE
Fixed zizmor pedantic findings across workflow files

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -101,12 +101,13 @@ jobs:
           cat comment.txt
 
       - name: Extract PR number
+        id: extract-pr
         run: |
           # We read the PR number that is stored in the uploaded archive
           # and check that it is an integer (as the workflow could upload whatever it wants).
           UNSANITIZED_PR=`cat team-api/pr.txt`
           if [[ ${UNSANITIZED_PR} =~ ^[0-9]+$ ]]; then
-            echo "PR_NUMBER=${UNSANITIZED_PR}" >> $GITHUB_ENV
+            echo "pr_number=${UNSANITIZED_PR}" >> $GITHUB_OUTPUT
           else
             echo "Invalid PR number passed: ${UNSANITIZED_PR}"
             exit 1
@@ -115,8 +116,8 @@ jobs:
       - name: Send comment
         env:
           GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.extract-pr.outputs.pr_number }}
         run: |
-          PR=${PR_NUMBER}
           echo "Pull request ${PR}"
           gh pr comment ${PR} --repo rust-lang/team --body-file comment.txt \
             --edit-last \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 50
+          persist-credentials: false
 
       - name: Install Rust Stable
         env:
@@ -73,7 +74,9 @@ jobs:
 
       - name: Write PR number into the uploaded archive
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo "${{ github.event.pull_request.number }}" > build/pr.txt
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > build/pr.txt
 
       - name: Upload the built JSON as a GitHub artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -139,8 +142,10 @@ jobs:
     steps:
       # Manually check the status of all dependencies. `if: failure()` does not work.
       - name: Conclusion
+        env:
+          NEEDS: ${{ toJson(needs) }}
         run: |
           # Print the dependent jobs to see them in the CI log
-          jq -C <<< '${{ toJson(needs) }}'
+          jq -C <<< "$NEEDS"
           # Check if all jobs that we depend on (in the needs array) were successful.
-          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '${{ toJson(needs) }}'
+          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< "$NEEDS"


### PR DESCRIPTION
zizmor flagged 10  findings in the workflow files under` --persona=pedantic`.I was able to fix 6 out of the 10 findings .

- Added `persist-credentials: false` to the test job checkout in main.yml (https://docs.zizmor.sh/audits/#artipacked)
-  Moved `${{ }} `expressions in `run: `blocks into` env: `vars in main.yml (3 findings) (https://docs.zizmor.sh/audits/#template-injection)
- Replaced` $GITHUB_ENV` with `$GITHUB_OUTPUT` for the PR number step in dry-run.yml (https://docs.zizmor.sh/audits/#github-env)


4 findings remain unfixed:

- `secrets-outside-env `(3):  I think fixing this requires a GitHub environment to be set up in the repo settings first, so I didnt fix it (https://docs.zizmor.sh/audits/#secrets-outside-env)

- `dangerous-triggers` (1): The `workflow_run` trigger in `dry-run.yml` this runs in the default branch context so the workflow can safely post PR comments without checking out untrusted code [(https://docs.zizmor.sh/audits/#secrets-outside-env)](https://docs.zizmor.sh/audits/#dangerous-triggers)