### PR TITLE
Added zizmor CI workflow to catch future workflow issues

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic
+          advanced-security: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      - dry-run.yml
+  secrets-outside-env:
+    ignore:
+      - dry-run.yml
+  concurrency-limits:
+    ignore:
+      - check-untracked-repos.yml
+      - zizmor.yml


### PR DESCRIPTION
This PR  adds a zizmor CI workflow that runs on every PR and on pushes to main, using `--persona=pedantic`. 
Two files  were added:

1. `.github/workflows/zizmor.yml` :  the CI workflow itself, using the official zizmorcore/zizmor-action pinned to SHA https://docs.zizmor.sh/integrations/

2.  `.github/zizmor.yml` :config file that tells zizmor to skip findings that were already reviewed and accepted as unfixable in   #2409 
https://docs.zizmor.sh/configuration/

I used ignore in the config so these rules are  skipped for the specific files listed. 
