### PR TITLE
Add Pete to the Edition team

### DIFF
--- a/teams/edition.toml
+++ b/teams/edition.toml
@@ -9,6 +9,7 @@ leads = [
 members = [
     "traviscross",
     "ehuss",
+    "PLeVasseur",
 ]
 alumni = [
     "bstrie",


### PR DESCRIPTION
By unanimous agreement, we're pleased to welcome Pete LeVasseur to the Edition team and are thrilled that he's volunteering his efforts and considerable talents to push forward this important work.

cc @ehuss @PLeVasseur