### PR TITLE
Make library team zulip channels managed by teams repo

### DIFF
--- a/teams/libs-contributors.toml
+++ b/teams/libs-contributors.toml
@@ -45,3 +45,10 @@ orgs = ["rust-lang", "rust-lang-nursery"]
 weight = -100
 name = "Library contributors"
 description = "Contributing to the Rust standard library on a regular basis"
+
+[[zulip-groups]]
+name = "T-libs-contributors"
+
+[[zulip-streams]]
+name = "t-libs/reviewers"
+extra-teams = ["libs", "libs-api"]

--- a/teams/libs.toml
+++ b/teams/libs.toml
@@ -49,3 +49,7 @@ address = "library-team@rust-lang.org"
 
 [[zulip-groups]]
 name = "T-libs"
+
+[[zulip-streams]]
+name = "t-libs/private"
+extra-teams = ["libs-api"]


### PR DESCRIPTION
This makes sure we don't miss adding people to these channels.
