### PR TITLE
Added CLI command to automate team and repo archival

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -152,9 +152,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -191,22 +191,22 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
 dependencies = [
  "serde",
  "serde_core",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -308,7 +308,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dab3fe76c1571ecd5cfe878b61bce3fedf4adbde5d8a8653b2a7956ffd14628"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -458,15 +458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -703,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fiat-crypto"
@@ -914,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -980,9 +971,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes 1.11.1",
@@ -994,6 +985,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1018,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.9"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http",
  "hyper",
@@ -1028,6 +1020,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1095,13 +1088,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1109,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1122,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1136,15 +1128,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1156,15 +1148,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1210,12 +1202,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -1231,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "99322078b2c076829a1db959d49da554fabc4342257fc0ba5a070a1eb3a01cd8"
 dependencies = [
  "console",
  "once_cell",
@@ -1334,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1375,9 +1367,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1387,9 +1379,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
@@ -1584,21 +1576,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1871,6 +1869,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml",
+ "toml_edit",
  "walkdir",
 ]
 
@@ -1917,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1981,9 +1980,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2061,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.28"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
  "serde_core",
@@ -2137,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -2432,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2457,9 +2456,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes 1.11.1",
  "libc",
@@ -2472,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2506,42 +2505,66 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+name = "toml_edit"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "winnow",
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+name = "toml_parser"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+dependencies = [
+ "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"
@@ -2624,9 +2647,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicase"
@@ -2738,11 +2761,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2751,14 +2774,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2769,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2779,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2789,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2802,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -2845,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2866,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3187,9 +3210,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"
@@ -3199,12 +3231,6 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -3287,9 +3313,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x25519-dalek"
@@ -3305,9 +3331,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3316,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3348,18 +3374,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3389,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3400,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3411,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "toml_edit",
  "walkdir",
 ]
 
@@ -2508,6 +2509,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,6 +3117,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", default-features = false, features = ["net", "rt-multi-
 tempfile = "3.19.1"
 thiserror = "2.0.18"
 toml = "1.0"
+toml_edit = "0.22"
 
 [dev-dependencies]
 ansi_term = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", default-features = false, features = ["net", "rt-multi-
 tempfile = "3.19.1"
 thiserror = "2.0.18"
 toml = "1.0"
+toml_edit = "0.25"
 
 [dev-dependencies]
 ansi_term = "0.12.1"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,0 +1,194 @@
+use anyhow::{Context, bail, format_err};
+use indexmap::IndexSet;
+use log::info;
+use std::path::Path;
+
+fn get_access_teams(doc: &mut toml_edit::DocumentMut) -> Option<&mut toml_edit::Table> {
+    doc.get_mut("access")?.get_mut("teams")?.as_table_mut()
+}
+
+fn archive_toml_file<F>(
+    src: &Path,
+    dest_dir: &Path,
+    dest: &Path,
+    entity: &str,
+    transform: F,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(&mut toml_edit::DocumentMut),
+{
+    if !src.is_file() {
+        bail!("{entity} file not found: {}", src.display());
+    }
+    if dest.is_file() {
+        bail!("{entity} is already archived: {}", dest.display());
+    }
+
+    let mut doc = read_toml_mut(src)?;
+
+    transform(&mut doc);
+
+    std::fs::create_dir_all(dest_dir)
+        .with_context(|| format!("failed to create directory {dest_dir:?}"))?;
+    std::fs::write(dest, doc.to_string()).with_context(|| format!("failed to write {dest:?}"))?;
+    std::fs::remove_file(src).with_context(|| format!("failed to remove {src:?}"))?;
+
+    info!("archived {entity} {src:?} -> {dest:?}");
+    Ok(())
+}
+
+fn read_toml_mut(src: &Path) -> anyhow::Result<toml_edit::DocumentMut> {
+    let content =
+        std::fs::read_to_string(src).with_context(|| format!("failed to read {src:?}"))?;
+    let doc: toml_edit::DocumentMut = content
+        .parse()
+        .with_context(|| format!("failed to parse {src:?}"))?;
+    Ok(doc)
+}
+
+/// Archive a repository by moving its TOML file to `repos/archive/<org>/`
+/// and clearing every entry from the `[access.teams]` table.
+pub fn archive_repo(data_dir: &Path, name: &str) -> anyhow::Result<()> {
+    let (org, repo_name) = name
+        .split_once('/')
+        .ok_or_else(|| format_err!("repository must be in 'org/name' format, got '{name}'"))?;
+
+    let repos_dir = data_dir.join("repos");
+    let src = repos_dir.join(org).join(format!("{repo_name}.toml"));
+    let dest_dir = repos_dir.join("archive").join(org);
+    let dest = dest_dir.join(format!("{repo_name}.toml"));
+
+    archive_toml_file(&src, &dest_dir, &dest, "repo", |doc| {
+        if let Some(table) = get_access_teams(doc) {
+            table.clear();
+        }
+    })
+}
+
+/// Gather every username from a team's `leads`, `members`, and `alumni`
+/// arrays into a single deduplicated, order-preserving set.
+///
+/// Handles both bare strings (`"alice"`) and inline tables (`{ github = "alice" }`),
+/// skipping any entries that don't match either shape or that have an empty
+/// `github` field.
+fn collect_all_team_members(people_table: &toml_edit::Table) -> IndexSet<String> {
+    let mut all = IndexSet::new();
+    for key in ["leads", "members", "alumni"] {
+        let Some(arr) = people_table.get(key).and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for item in arr.iter() {
+            let username = if let Some(s) = item.as_str() {
+                s.to_string()
+            } else if let Some(tbl) = item.as_inline_table() {
+                match tbl.get("github").and_then(|v| v.as_str()) {
+                    Some(s) => s.to_string(),
+                    None => continue,
+                }
+            } else {
+                continue;
+            };
+            if !username.is_empty() {
+                all.insert(username);
+            }
+        }
+    }
+    all
+}
+
+/// Build a TOML array of usernames laid out one per line with `    ` indentation
+/// and a trailing comma — matching the style used elsewhere in the team repo.
+fn build_alumni_array(usernames: &IndexSet<String>) -> toml_edit::Array {
+    let mut arr = toml_edit::Array::new();
+    for person in usernames {
+        let mut val = toml_edit::Value::from(person.as_str());
+        val.decor_mut().set_prefix("\n    ");
+        arr.push_formatted(val);
+    }
+    arr.set_trailing("\n");
+    arr.set_trailing_comma(true);
+    arr
+}
+
+/// Move everyone listed in a team's `leads`, `members`, and existing `alumni`
+/// into a single `alumni` array, leaving `leads` and `members` empty.
+///
+/// No-op if the document has no `[people]` table.
+fn move_team_members_to_alumni(doc: &mut toml_edit::DocumentMut) {
+    let Some(people_table) = doc.get_mut("people").and_then(|v| v.as_table_mut()) else {
+        return;
+    };
+
+    let all_alumni = collect_all_team_members(people_table);
+
+    people_table.insert("leads", toml_edit::Array::new().into());
+    people_table.insert("members", toml_edit::Array::new().into());
+    people_table.insert("alumni", build_alumni_array(&all_alumni).into());
+}
+
+/// Archive a team by moving its TOML file to `teams/archive/`, collapsing
+/// every `leads`/`members`/`alumni` entry into a single `alumni` array,
+/// and removing the team from every repo's `[access.teams]` table.
+pub fn archive_team(data_dir: &Path, name: &str) -> anyhow::Result<()> {
+    let teams_dir = data_dir.join("teams");
+    let src = teams_dir.join(format!("{name}.toml"));
+    let dest_dir = teams_dir.join("archive");
+    let dest = dest_dir.join(format!("{name}.toml"));
+
+    archive_toml_file(&src, &dest_dir, &dest, "team", move_team_members_to_alumni)?;
+    remove_team_from_repos(data_dir, name)?;
+    Ok(())
+}
+
+fn remove_team_from_repos(data_dir: &Path, team_name: &str) -> anyhow::Result<()> {
+    let repos_dir = data_dir.join("repos");
+    assert!(repos_dir.is_dir(), "`repos` directory does not exist");
+
+    for org_entry in
+        std::fs::read_dir(&repos_dir).with_context(|| format!("failed to read {repos_dir:?}"))?
+    {
+        let org_path = org_entry?.path();
+        assert!(
+            org_path.is_dir(),
+            "unexpected non-directory entry: `repos/{org_path:?}`"
+        );
+        if org_path.file_name() == Some(std::ffi::OsStr::new("archive")) {
+            continue;
+        }
+
+        for repo_entry in
+            std::fs::read_dir(&org_path).with_context(|| format!("failed to read {org_path:?}"))?
+        {
+            let repo_path = repo_entry?.path();
+            remove_team_from_repository(team_name, &repo_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn remove_team_from_repository(team_name: &str, repo_path: &Path) -> anyhow::Result<()> {
+    assert!(
+        repo_path.is_file(),
+        "unexpected non-file entry: `repos/{repo_path:?}`"
+    );
+    assert!(
+        repo_path.extension() == Some(std::ffi::OsStr::new("toml")),
+        "unexpected non-TOML file: `repos/{repo_path:?}`"
+    );
+
+    let mut doc = read_toml_mut(repo_path)?;
+
+    let removed = if let Some(table) = get_access_teams(&mut doc) {
+        table.remove(team_name).is_some()
+    } else {
+        false
+    };
+
+    if removed {
+        std::fs::write(repo_path, doc.to_string())
+            .with_context(|| format!("failed to write {repo_path:?}"))?;
+        info!("removed team '{team_name}' from {repo_path:?}");
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,10 @@ use crate::sync::team_api::TeamApi;
 use anyhow::{Context, Error, bail, format_err};
 use api::github;
 use clap::Parser;
+use indexmap::IndexSet;
 use log::{error, info, warn};
 use std::collections::{BTreeMap, HashMap};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -106,6 +107,9 @@ enum RootOpts {
     DecryptEmail,
     /// Generate a x25519 key for use with the email encryption module
     GenerateKey,
+    /// Archive a repo or team, moving it to the archive directory
+    #[clap(subcommand)]
+    Archive(ArchiveOpts),
     /// CI scripts
     #[clap(subcommand)]
     Ci(CiOpts),
@@ -131,6 +135,20 @@ enum CiOpts {
     CheckCodeowners,
     /// Check for untracked repositories in GitHub organizations
     CheckUntrackedRepos,
+}
+
+#[derive(clap::Parser, Clone, Debug)]
+enum ArchiveOpts {
+    /// Archive a repository
+    Repo {
+        /// Repository in "org/name" format (e.g. "rust-lang/homu")
+        name: String,
+    },
+    /// Archive a team
+    Team {
+        /// Team name (e.g. "project-generic-associated-types")
+        name: String,
+    },
 }
 
 #[derive(clap::Parser, Clone, Debug)]
@@ -563,6 +581,14 @@ async fn run() -> Result<(), Error> {
             let (secret, public) = rust_team_data::email_encryption::generate_x25519_keypair();
             println!("Generated keypair: secret: {} - public: {}", secret, public);
         }
+        RootOpts::Archive(opts) => match opts {
+            ArchiveOpts::Repo { ref name } => {
+                archive_repo(&cli.data_dir, name)?;
+            }
+            ArchiveOpts::Team { ref name } => {
+                archive_team(&cli.data_dir, name)?;
+            }
+        },
         RootOpts::Ci(opts) => match opts {
             CiOpts::GenerateCodeowners => generate_codeowners_file(data)?,
             CiOpts::CheckCodeowners => check_codeowners(data)?,
@@ -646,4 +672,163 @@ async fn perform_sync(opts: SyncOpts, data: Data) -> anyhow::Result<()> {
         data.get_sync_team_config()?,
     )
     .await
+}
+
+fn get_access_teams(doc: &mut toml_edit::DocumentMut) -> Option<&mut toml_edit::Table> {
+    doc.get_mut("access")?.get_mut("teams")?.as_table_mut()
+}
+
+fn archive_repo(data_dir: &Path, name: &str) -> Result<(), Error> {
+    let (org, repo_name) = name
+        .split_once('/')
+        .ok_or_else(|| format_err!("repository must be in 'org/name' format, got '{}'", name))?;
+
+    let src = data_dir
+        .join("repos")
+        .join(org)
+        .join(format!("{repo_name}.toml"));
+    let dest_dir = data_dir.join("repos").join("archive").join(org);
+    let dest = dest_dir.join(format!("{repo_name}.toml"));
+
+    if !src.is_file() {
+        bail!("repo file not found: {}", src.display());
+    }
+    if dest.is_file() {
+        bail!("repo is already archived: {}", dest.display());
+    }
+
+    let content = std::fs::read_to_string(&src)
+        .with_context(|| format!("failed to read {}", src.display()))?;
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .with_context(|| format!("failed to parse {}", src.display()))?;
+
+    if let Some(table) = get_access_teams(&mut doc) {
+        table.clear();
+    }
+
+    std::fs::create_dir_all(&dest_dir)
+        .with_context(|| format!("failed to create directory {}", dest_dir.display()))?;
+    std::fs::write(&dest, doc.to_string())
+        .with_context(|| format!("failed to write {}", dest.display()))?;
+    std::fs::remove_file(&src).with_context(|| format!("failed to remove {}", src.display()))?;
+
+    info!("archived repo {} -> {}", src.display(), dest.display());
+    Ok(())
+}
+
+fn archive_team(data_dir: &Path, name: &str) -> Result<(), Error> {
+    let src = data_dir.join("teams").join(format!("{name}.toml"));
+    let dest_dir = data_dir.join("teams").join("archive");
+    let dest = dest_dir.join(format!("{name}.toml"));
+
+    if !src.is_file() {
+        bail!("team file not found: {}", src.display());
+    }
+    if dest.is_file() {
+        bail!("team is already archived: {}", dest.display());
+    }
+
+    let content = std::fs::read_to_string(&src)
+        .with_context(|| format!("failed to read {}", src.display()))?;
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .with_context(|| format!("failed to parse {}", src.display()))?;
+
+    if let Some(people) = doc.get_mut("people")
+        && let Some(people_table) = people.as_table_mut()
+    {
+        let mut all_alumni = IndexSet::new();
+
+        // Collect everyone from leads, members, and existing alumni
+        for key in &["leads", "members", "alumni"] {
+            if let Some(arr) = people_table.get(key).and_then(|v| v.as_array()) {
+                for item in arr.iter() {
+                    let username = if let Some(s) = item.as_str() {
+                        s.to_string()
+                    } else if let Some(tbl) = item.as_inline_table() {
+                        match tbl.get("github").and_then(|v| v.as_str()) {
+                            Some(s) => s.to_string(),
+                            None => continue,
+                        }
+                    } else {
+                        continue;
+                    };
+                    if !username.is_empty() {
+                        all_alumni.insert(username);
+                    }
+                }
+            }
+        }
+
+        people_table.insert("leads", toml_edit::Array::new().into());
+        people_table.insert("members", toml_edit::Array::new().into());
+
+        let mut alumni_array = toml_edit::Array::new();
+        for person in &all_alumni {
+            let mut val = toml_edit::Value::from(person.as_str());
+            val.decor_mut().set_prefix("\n    ");
+            alumni_array.push_formatted(val);
+        }
+        alumni_array.set_trailing("\n");
+        alumni_array.set_trailing_comma(true);
+        people_table.insert("alumni", alumni_array.into());
+    }
+
+    std::fs::create_dir_all(&dest_dir)
+        .with_context(|| format!("failed to create directory {}", dest_dir.display()))?;
+    std::fs::write(&dest, doc.to_string())
+        .with_context(|| format!("failed to write {}", dest.display()))?;
+    std::fs::remove_file(&src).with_context(|| format!("failed to remove {}", src.display()))?;
+
+    info!("archived team {} -> {}", src.display(), dest.display());
+
+    remove_team_from_repos(data_dir, name)?;
+
+    Ok(())
+}
+
+fn remove_team_from_repos(data_dir: &Path, team_name: &str) -> Result<(), Error> {
+    let repos_dir = data_dir.join("repos");
+    if !repos_dir.is_dir() {
+        return Ok(());
+    }
+
+    for org_entry in std::fs::read_dir(&repos_dir)
+        .with_context(|| format!("failed to read {}", repos_dir.display()))?
+    {
+        let org_path = org_entry?.path();
+        if !org_path.is_dir() || org_path.file_name() == Some(std::ffi::OsStr::new("archive")) {
+            continue;
+        }
+
+        for repo_entry in std::fs::read_dir(&org_path)
+            .with_context(|| format!("failed to read {}", org_path.display()))?
+        {
+            let repo_path = repo_entry?.path();
+            if !repo_path.is_file() || repo_path.extension() != Some(std::ffi::OsStr::new("toml")) {
+                continue;
+            }
+
+            let content = std::fs::read_to_string(&repo_path)
+                .with_context(|| format!("failed to read {}", repo_path.display()))?;
+            let mut doc: toml_edit::DocumentMut = content
+                .parse()
+                .with_context(|| format!("failed to parse {}", repo_path.display()))?;
+
+            let removed = if let Some(table) = get_access_teams(&mut doc) {
+                table.remove(team_name).is_some()
+            } else {
+                false
+            };
+
+            if removed {
+                std::fs::write(&repo_path, doc.to_string())
+                    .with_context(|| format!("failed to write {}", repo_path.display()))?;
+                info!("removed team '{}' from {}", team_name, repo_path.display());
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod data;
 #[macro_use]
 mod permissions;
 mod api;
+mod archive;
 mod ci;
 mod schema;
 mod static_api;
@@ -24,6 +25,7 @@ use api::zulip::ZulipApi;
 use data::Data;
 use schema::{Email, Team, TeamKind};
 
+use crate::archive::{archive_repo, archive_team};
 use crate::ci::{check_codeowners, generate_codeowners_file};
 use crate::schema::RepoPermission;
 use crate::sync::run_sync_team;
@@ -112,6 +114,9 @@ enum RootOpts {
     DecryptEmail,
     /// Generate a x25519 key for use with the email encryption module
     GenerateKey,
+    /// Archive a repo or team, moving it to the archive directory
+    #[clap(subcommand)]
+    Archive(ArchiveOpts),
     /// CI scripts
     #[clap(subcommand)]
     Ci(CiOpts),
@@ -137,6 +142,20 @@ enum CiOpts {
     CheckCodeowners,
     /// Check for untracked repositories in GitHub organizations
     CheckUntrackedRepos,
+}
+
+#[derive(clap::Parser, Clone, Debug)]
+enum ArchiveOpts {
+    /// Archive a repository
+    Repo {
+        /// Repository in "org/name" format (e.g. "rust-lang/homu")
+        name: String,
+    },
+    /// Archive a team
+    Team {
+        /// Team name (e.g. "project-generic-associated-types")
+        name: String,
+    },
 }
 
 #[derive(clap::Parser, Clone, Debug)]
@@ -569,6 +588,14 @@ async fn run() -> Result<(), Error> {
             let (secret, public) = rust_team_data::email_encryption::generate_x25519_keypair();
             println!("Generated keypair: secret: {} - public: {}", secret, public);
         }
+        RootOpts::Archive(opts) => match opts {
+            ArchiveOpts::Repo { ref name } => {
+                archive_repo(&cli.data_dir, name)?;
+            }
+            ArchiveOpts::Team { ref name } => {
+                archive_team(&cli.data_dir, name)?;
+            }
+        },
         RootOpts::Ci(opts) => match opts {
             CiOpts::GenerateCodeowners => generate_codeowners_file(data)?,
             CiOpts::CheckCodeowners => check_codeowners(data)?,


### PR DESCRIPTION
This PR  adds a new archive subcommand to the CLI that handles moving TOML files to the archive/ directory, clearing team access on repos, and moving team members to alumni .
Example usage:

- `cargo run -- archive repo rust-lang/homu`

- `cargo run -- archive team project-generic-associated-types`

For repos, it moves the file to repos/archive/{org}/ and clears all entries under` [access.teams]`.
For teams, it moves the file to teams/archive/, sets leads and members to empty, and moves everyone into alumni.

I used toml_edit to modify the TOML files so that only the parts that need to change are touched  everything else (comments, formatting, ordering) stays the same.

Closes #1547 