### PR TITLE
Give a couple teams triaging permissions for rust-analyzer

### DIFF
--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -7,6 +7,10 @@ bots = ["rustbot"]
 [access.teams]
 rust-analyzer = "write"
 rust-analyzer-contributors = "triage"
+cargo = "triage"
+clippy = "triage"
+compiler = "triage"
+triage = "triage"
 
 [[branch-protections]]
 pattern = "master"

--- a/teams/rust-analyzer-contributors.toml
+++ b/teams/rust-analyzer-contributors.toml
@@ -5,7 +5,6 @@ subteam-of = "rust-analyzer"
 leads = []
 members = [
     "alibektas",
-    "bjorn3",
     "DropDemBits",
     "Nadrieril",
     "roife",


### PR DESCRIPTION
This allows bjorn3 to keep triaging without being put into the contributors team solely for the permissions, and also allows some project folks to just fill out labels as they see fit when filing issues. (I wonder if we should just put down the `all` team here or whether that would be too much 🤔)