### PR TITLE
use same rust version in every action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,15 +1,28 @@
 name: Setup Rust
-description: Install Rust stable toolchain and setup caching
+description: Install Rust toolchain and setup caching
+
+inputs:
+  components:
+    description: Whitespace-separated Rust components to install
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
     - name: Install Rust Stable
       shell: bash
+      env:
+        RUST_VERSION: "1.95.0"
+        COMPONENTS: ${{ inputs.components }}
       run: |
         rustc -vV
-        rustup update stable
-        rustup default stable
+        rustup toolchain install "$RUST_VERSION"
+        rustup default "$RUST_VERSION"
+        if [[ -n "$COMPONENTS" ]]; then
+          # COMPONENTS is intentionally unquoted for word-splitting of whitespace-separated components.
+          rustup component add --toolchain "$RUST_VERSION" $COMPONENTS
+        fi
         rustc -vV
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
     {
       customType: "regex",
       managerFilePatterns: [
-        '/^\\.github/workflows/main\\.yml$/',
+        '/^\\.github/actions/setup-rust/action\\.yml$/',
       ],
       matchStrings: [
         "RUST_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,17 +35,10 @@ jobs:
           fetch-depth: 50
           persist-credentials: false
 
-      - name: Install Rust Stable
-        env:
-          RUST_VERSION: "1.95.0"
-        run: |
-          rustc -vV
-          rustup toolchain install $RUST_VERSION
-          rustup default $RUST_VERSION
-          rustup component add rustfmt clippy
-          rustc -vV
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt clippy
 
       - name: Build the team binary
         run: RUSTFLAGS="--deny warnings" cargo build


### PR DESCRIPTION
The Deploy job in https://github.com/rust-lang/team/pull/2425 failed with the following error:
```
error: rustc 1.94.1 is not supported by the following package:
  constant_time_eq@0.4.3 requires rustc 1.95.0
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.94.1
```

This PR fixes these issues because we use the same rust version in all workflows.