### PR TITLE
prepare datadog github app installation

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -350,6 +350,17 @@ bots = ["bors", "rustbot", "rust-timer"]
 private-non-synced = false
 ```
 
+#### Bots
+
+Here are the available bots that can be added to the `bots` array:
+- `datadog`: installs a GitHub App used by DataDog. Used for [CI Visibility](https://www.datadoghq.com/product/ci-cd-monitoring/). It has read access to organization members, and repository
+  actions, administration, checks, code scanning alerts, commit statuses, contents,
+  deployments, issues, pull requests, secret scanning alerts and secrets.
+  It only works on `rust-lang` org repositories. If you need this for other repositories,
+  ask in [`#t-infra`](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra) on Zulip.
+- `renovate`, `forking-renovate`: See the [Renovate Forge docs](https://forge.rust-lang.org/infra/docs/renovate.html).
+- TODO: Document other bots.
+
 ### Repository access
 
 Access to a repository is given on a per-team basis. Teams who are responsible for a repository may give access to other teams at their discretion.
@@ -432,7 +443,7 @@ dismiss-stale-review = false
 # (optional - default `false`)
 require-conversation-resolution = false
 # Prevent merge commits from being pushed to matching branches.
-# When this option is set, one cannot use `merge` as merging method 
+# When this option is set, one cannot use `merge` as merging method
 # for a Merge Queue. Use squash or rebase instead.
 # (optional - default `false`)
 require-linear-history = false

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -210,6 +210,7 @@ pub enum Bot {
     Craterbot,
     Glacierbot,
     LogAnalyzer,
+    Datadog,
     Renovate,
     ForkingRenovate,
     HerokuDeployAccess,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -855,6 +855,7 @@ pub(crate) enum Bot {
     Craterbot,
     Glacierbot,
     LogAnalyzer,
+    Datadog,
     Renovate,
     ForkingRenovate,
     HerokuDeployAccess,

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -119,6 +119,7 @@ impl<'a> Generator<'a> {
                         Bot::Craterbot => v1::Bot::Craterbot,
                         Bot::Glacierbot => v1::Bot::Glacierbot,
                         Bot::LogAnalyzer => v1::Bot::LogAnalyzer,
+                        Bot::Datadog => v1::Bot::Datadog,
                         Bot::Renovate => v1::Bot::Renovate,
                         Bot::ForkingRenovate => v1::Bot::ForkingRenovate,
                         Bot::HerokuDeployAccess => v1::Bot::HerokuDeployAccess,

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -47,6 +47,7 @@ enum GithubApp {
     RenovateBot,
     ForkingRenovateBot,
     Bors,
+    Datadog,
 }
 
 impl GithubApp {
@@ -57,6 +58,10 @@ impl GithubApp {
             2740 => Some(GithubApp::RenovateBot),
             7402 => Some(GithubApp::ForkingRenovateBot),
             278306 => Some(GithubApp::Bors),
+            // Link for infra admins:
+            // https://github.com/organizations/rust-lang/settings/apps/datadog-rust-lang
+            // TODO set the real value after updating triagebot: 3444461
+            1111111 => Some(GithubApp::Datadog),
             _ => None,
         }
     }
@@ -68,6 +73,7 @@ impl Display for GithubApp {
             GithubApp::ForkingRenovateBot => f.write_str("Forking RenovateBot"),
             GithubApp::RenovateBot => f.write_str("RenovateBot"),
             GithubApp::Bors => f.write_str("Bors"),
+            GithubApp::Datadog => f.write_str("Datadog"),
         }
     }
 }
@@ -964,6 +970,7 @@ impl SyncGitHub {
             Bot::Renovate => Some(GithubApp::RenovateBot),
             Bot::ForkingRenovate => Some(GithubApp::ForkingRenovateBot),
             Bot::Bors => Some(GithubApp::Bors),
+            Bot::Datadog => Some(GithubApp::Datadog),
             Bot::Highfive
             | Bot::Rfcbot
             | Bot::RustTimer
@@ -1135,7 +1142,7 @@ impl From<&Bot> for BotDetails {
             Bot::Craterbot => write_access("craterbot"),
             Bot::Glacierbot => write_access("rust-lang-glacier-bot"),
             Bot::LogAnalyzer => write_access("rust-log-analyzer"),
-            Bot::Renovate | Bot::ForkingRenovate => BotDetails::GitHubApp,
+            Bot::Datadog | Bot::Renovate | Bot::ForkingRenovate => BotDetails::GitHubApp,
             // Unfortunately linking to Heroku requires admin access, since the integration creates
             // GitHub webhooks, which require admin access.
             Bot::HerokuDeployAccess => admin_access("rust-heroku-deploy-access"),


### PR DESCRIPTION
Required to enable [CI visibility](https://www.datadoghq.com/product/ci-cd-monitoring/) in the rust repo.

- [ ] Update triagebot after merging this.

I created a custom GitHub App via DataDog. 

## App installation

It only allowed one organization, so I set `rust-lang` of course.
If other organizations need this integration, we can investigate how to integrate DataDog with multiple GitHub organizations in the future.

## App permission

* I left all read permission that DataDog asks so that if we want to try more DataDog products in the future, we can do it easily. If you have concerns, I can remove some settings.
* I removed all the write permission that DataDog asks.
