### PR TITLE
allow bots to bypass some rust rulesets

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -92,12 +92,12 @@ prevent-force-push = false
 
 [[branch-protections]]
 pattern = "*"
-allowed-merge-apps = ["promote-release"]
+allowed-merge-apps = ["bors", "promote-release", "rust-timer"]
 prevent-update = true
 
 [[branch-protections]]
 pattern = "*/**/*"
-pr-required = false
+allowed-merge-apps = ["bors", "promote-release", "rust-timer"]
 prevent-update = true
 
 [[branch-protections]]


### PR DESCRIPTION
Discussed in [#t-infra > Moving rust repo to rulesets @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Moving.20rust.20repo.20to.20rulesets/near/587783121)

I think these rules could prevent bots from working correctly.
Out of precaution, let's not apply these rules to bots.