### PR TITLE
ci: setup rust in the deploy step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
       - name: Download built JSON API and sync-team
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
https://github.com/rust-lang/team/pull/2425 failed because it doesn't use the latest stable version.

With this PR, we make sure the Deploy step uses the same Rust version as the other CI jobs.