### PR TITLE
sync datadog app

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "rust"
 description = "Empowering everyone to build reliable and efficient software."
 homepage = "https://www.rust-lang.org"
-bots = ["bors", "craterbot", "glacierbot", "log-analyzer", "rustbot", "rfcbot", "rust-timer"]
+bots = ["bors", "craterbot", "glacierbot", "log-analyzer", "rustbot", "rfcbot", "rust-timer", "datadog"]
 
 [access.teams]
 bootstrap = "write"

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -60,8 +60,7 @@ impl GithubApp {
             278306 => Some(GithubApp::Bors),
             // Link for infra admins:
             // https://github.com/organizations/rust-lang/settings/apps/datadog-rust-lang
-            // TODO set the real value after updating triagebot: 3444461
-            1111111 => Some(GithubApp::Datadog),
+            3444461 => Some(GithubApp::Datadog),
             _ => None,
         }
     }


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/team/pull/2427

Triagebot was updated in https://github.com/rust-lang/triagebot/pull/2381

The dry-run is empty because the app is already installed in the rust repo.