### PR TITLE
remove support for branch protections

### DIFF
--- a/src/sync/github/api/mod.rs
+++ b/src/sync/github/api/mod.rs
@@ -377,7 +377,6 @@ pub(crate) struct RepoAppInstallation {
 
 #[derive(serde::Deserialize, Debug, Clone)]
 pub(crate) struct Repo {
-    pub(crate) node_id: String,
     #[serde(rename = "id")]
     pub(crate) repo_id: u64,
     pub(crate) name: String,
@@ -528,11 +527,6 @@ pub(crate) struct AppPushAllowanceActor {
     pub(crate) name: String,
     /// Node ID, which can be used as a push actor ID
     pub(crate) id: String,
-}
-
-pub(crate) enum BranchProtectionOp {
-    CreateForRepo(String),
-    UpdateBranchProtection(String),
 }
 
 #[derive(PartialEq, Debug)]

--- a/src/sync/github/api/read.rs
+++ b/src/sync/github/api/read.rs
@@ -416,7 +416,6 @@ impl GithubRead for GitHubApiRead {
         static QUERY: &str = r#"
             query($owner: String!, $name: String!) {
                 repository(owner: $owner, name: $name) {
-                    id
                     databaseId
                     autoMergeAllowed
                     description
@@ -435,8 +434,6 @@ impl GithubRead for GitHubApiRead {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct RepoResponse {
-            // Equivalent of `node_id` of the Rest API
-            id: String,
             // Equivalent of `id` of the Rest API
             database_id: u64,
             auto_merge_allowed: Option<bool>,
@@ -461,7 +458,6 @@ impl GithubRead for GitHubApiRead {
 
         let repo = result.and_then(|r| r.repository).map(|repo_response| Repo {
             repo_id: repo_response.database_id,
-            node_id: repo_response.id,
             name: repo.to_string(),
             description: repo_response.description.unwrap_or_default(),
             allow_auto_merge: repo_response.auto_merge_allowed,

--- a/src/sync/github/api/write.rs
+++ b/src/sync/github/api/write.rs
@@ -4,9 +4,8 @@ use std::collections::HashSet;
 
 use crate::sync::github::api::url::GitHubUrl;
 use crate::sync::github::api::{
-    AppPushAllowanceActor, BranchProtection, BranchProtectionOp, GitHubApiRead, GithubRead,
-    HttpClient, Login, PushAllowanceActor, Repo, RepoPermission, RepoSettings, Ruleset, RulesetOp,
-    Team, TeamPrivacy, TeamPushAllowanceActor, TeamRole, UserPushAllowanceActor, allow_not_found,
+    GitHubApiRead, GithubRead, HttpClient, Repo, RepoPermission, RepoSettings, Ruleset, RulesetOp,
+    Team, TeamPrivacy, TeamRole, allow_not_found,
 };
 use crate::sync::utils::ResponseExt;
 
@@ -21,66 +20,6 @@ impl GitHubWrite {
             client: client.clone(),
             dry_run,
         })
-    }
-
-    async fn user_id(&self, name: &str, org: &str) -> anyhow::Result<String> {
-        #[derive(serde::Serialize)]
-        struct Params<'a> {
-            name: &'a str,
-        }
-        let query = "
-            query($name: String!) {
-                user(login: $name) {
-                    id
-                }
-            }
-        ";
-        #[derive(serde::Deserialize)]
-        struct Data {
-            user: User,
-        }
-        #[derive(serde::Deserialize)]
-        struct User {
-            id: String,
-        }
-
-        let data: Data = self.client.graphql(query, Params { name }, org).await?;
-        Ok(data.user.id)
-    }
-
-    async fn team_id(&self, org: &str, name: &str) -> anyhow::Result<String> {
-        #[derive(serde::Serialize)]
-        struct Params<'a> {
-            org: &'a str,
-            team: &'a str,
-        }
-        let query = "
-            query($org: String!, $team: String!) {
-                organization(login: $org) {
-                    team(slug: $team) {
-                        id
-                    }
-                }
-            }
-        ";
-        #[derive(serde::Deserialize)]
-        struct Data {
-            organization: Organization,
-        }
-        #[derive(serde::Deserialize)]
-        struct Organization {
-            team: Team,
-        }
-        #[derive(serde::Deserialize)]
-        struct Team {
-            id: String,
-        }
-
-        let data: Data = self
-            .client
-            .graphql(query, Params { org, team: name }, org)
-            .await?;
-        Ok(data.organization.team.id)
     }
 
     /// Create a team in a org
@@ -244,7 +183,6 @@ impl GitHubWrite {
         debug!("Creating the repo {org}/{name} with {req:?}");
         if self.dry_run {
             Ok(Repo {
-                node_id: String::from("ID"),
                 repo_id: 0,
                 name: name.to_string(),
                 org: org.to_string(),
@@ -442,115 +380,6 @@ impl GitHubWrite {
             let url = &GitHubUrl::repos(org, repo, &format!("collaborators/{collaborator}"))?;
             let resp = self.client.req(method.clone(), url)?.send().await?;
             allow_not_found(resp, method, url.url()).await?;
-        }
-        Ok(())
-    }
-
-    /// Create or update a branch protection.
-    pub(crate) async fn upsert_branch_protection(
-        &self,
-        op: BranchProtectionOp,
-        pattern: &str,
-        branch_protection: &BranchProtection,
-        org: &str,
-    ) -> anyhow::Result<()> {
-        debug!("Updating '{pattern}' branch protection");
-        #[derive(Debug, serde::Serialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Params<'a> {
-            id: &'a str,
-            pattern: &'a str,
-            contexts: &'a [String],
-            allows_force_pushes: bool,
-            dismiss_stale: bool,
-            requires_conversation_resolution: bool,
-            requires_linear_history: bool,
-            requires_strict_status_checks: bool,
-            review_count: u8,
-            restricts_pushes: bool,
-            // Is a PR required to push into this branch?
-            requires_approving_reviews: bool,
-            push_actor_ids: &'a [String],
-        }
-        let mutation_name = match op {
-            BranchProtectionOp::CreateForRepo(_) => "createBranchProtectionRule",
-            BranchProtectionOp::UpdateBranchProtection(_) => "updateBranchProtectionRule",
-        };
-        let id_field = match op {
-            BranchProtectionOp::CreateForRepo(_) => "repositoryId",
-            BranchProtectionOp::UpdateBranchProtection(_) => "branchProtectionRuleId",
-        };
-        let id = &match op {
-            BranchProtectionOp::CreateForRepo(id) => id,
-            BranchProtectionOp::UpdateBranchProtection(id) => id,
-        };
-        let query = format!("
-        mutation($id: ID!, $pattern:String!, $contexts: [String!], $allowsForcePushes: Boolean, $dismissStale: Boolean, $requiresConversationResolution: Boolean, $requiresLinearHistory: Boolean, $requiresStrictStatusChecks: Boolean, $reviewCount: Int, $pushActorIds: [ID!], $restrictsPushes: Boolean, $requiresApprovingReviews: Boolean) {{
-            {mutation_name}(input: {{
-                {id_field}: $id,
-                pattern: $pattern,
-                requiresStatusChecks: true,
-                requiredStatusCheckContexts: $contexts,
-                requiresStrictStatusChecks: $requiresStrictStatusChecks,
-                isAdminEnforced: true,
-                allowsForcePushes: $allowsForcePushes,
-                requiredApprovingReviewCount: $reviewCount,
-                dismissesStaleReviews: $dismissStale,
-                requiresConversationResolution: $requiresConversationResolution,
-                requiresLinearHistory: $requiresLinearHistory,
-                requiresApprovingReviews: $requiresApprovingReviews,
-                restrictsPushes: $restrictsPushes,
-                pushActorIds: $pushActorIds
-            }}) {{
-              branchProtectionRule {{
-                id
-              }}
-            }}
-          }}
-        ");
-        let mut push_actor_ids = vec![];
-        for actor in &branch_protection.push_allowances {
-            match actor {
-                PushAllowanceActor::User(UserPushAllowanceActor { login: name }) => {
-                    push_actor_ids.push(self.user_id(name, org).await?);
-                }
-                PushAllowanceActor::Team(TeamPushAllowanceActor {
-                    organization: Login { login: org },
-                    name,
-                }) => push_actor_ids.push(self.team_id(org, name).await?),
-                PushAllowanceActor::App(AppPushAllowanceActor { id, .. }) => {
-                    push_actor_ids.push(id.clone())
-                }
-            }
-        }
-
-        if !self.dry_run {
-            let _: serde_json::Value = self
-                .client
-                .graphql(
-                    &query,
-                    Params {
-                        id,
-                        pattern,
-                        contexts: &branch_protection.required_status_check_contexts,
-                        allows_force_pushes: branch_protection.allows_force_pushes,
-                        dismiss_stale: branch_protection.dismisses_stale_reviews,
-                        requires_conversation_resolution: branch_protection
-                            .requires_conversation_resolution,
-                        requires_linear_history: branch_protection.requires_linear_history,
-                        requires_strict_status_checks: branch_protection
-                            .requires_strict_status_checks,
-                        review_count: branch_protection.required_approving_review_count,
-                        // We restrict merges, if we have explicitly set some actors to be
-                        // able to merge (i.e., we allow allow those with write permissions
-                        // to merge *or* we only allow those in `push_actor_ids`)
-                        restricts_pushes: !push_actor_ids.is_empty(),
-                        push_actor_ids: &push_actor_ids,
-                        requires_approving_reviews: branch_protection.requires_approving_reviews,
-                    },
-                    org,
-                )
-                .await?;
         }
         Ok(())
     }

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -2,17 +2,15 @@ mod api;
 #[cfg(test)]
 mod tests;
 
-use self::api::{BranchProtectionOp, TeamPrivacy, TeamRole};
 pub(crate) use self::api::{GitHubApiRead, GitHubWrite, HttpClient};
+use self::api::{TeamPrivacy, TeamRole};
 use crate::schema;
 use crate::sync::Config;
-use crate::sync::github::api::{
-    GithubRead, Login, PushAllowanceActor, RepoPermission, RepoSettings, Ruleset,
-};
+use crate::sync::github::api::{GithubRead, RepoPermission, RepoSettings, Ruleset};
 use anyhow::Context as _;
 use futures_util::StreamExt;
 use log::debug;
-use rust_team_data::v1::{Bot, BranchProtectionMode, MergeBot, ProtectionTarget};
+use rust_team_data::v1::{Bot, BranchProtectionMode, ProtectionTarget};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::{Display, Formatter, Write};
 
@@ -447,12 +445,6 @@ impl SyncGitHub {
         Ok(diffs)
     }
 
-    /// Check if a repository should use rulesets instead of branch protections
-    fn should_use_rulesets(&self, _repo: &rust_team_data::v1::Repo) -> bool {
-        // TODO delete this function in the future since we don't need it anymore
-        true
-    }
-
     async fn construct_ruleset(
         &self,
         expected_repo: &rust_team_data::v1::Repo,
@@ -547,23 +539,12 @@ impl SyncGitHub {
                     Default::default(),
                 )?;
 
-                let mut branch_protections = Vec::new();
-                for branch_protection in &expected_repo.branch_protections {
-                    branch_protections.push((
-                        branch_protection.pattern.clone(),
-                        construct_branch_protection(expected_repo, branch_protection),
-                    ));
-                }
-
                 let mut rulesets = Vec::new();
-                let use_rulesets = self.should_use_rulesets(expected_repo);
-                if use_rulesets {
-                    for branch_protection in &expected_repo.branch_protections {
-                        let ruleset = self
-                            .construct_ruleset(expected_repo, branch_protection)
-                            .await?;
-                        rulesets.push(ruleset);
-                    }
+                for branch_protection in &expected_repo.branch_protections {
+                    let ruleset = self
+                        .construct_ruleset(expected_repo, branch_protection)
+                        .await?;
+                    rulesets.push(ruleset);
                 }
 
                 return Ok(RepoDiff::Create(CreateRepoDiff {
@@ -576,12 +557,6 @@ impl SyncGitHub {
                         auto_merge_enabled: expected_repo.auto_merge_enabled,
                     },
                     permissions,
-                    // Don't create branch protections if using rulesets
-                    branch_protections: if use_rulesets {
-                        vec![]
-                    } else {
-                        branch_protections
-                    },
                     rulesets,
                     environments: expected_repo
                         .environments
@@ -603,15 +578,9 @@ impl SyncGitHub {
 
         let permission_diffs = self.diff_permissions(expected_repo).await?;
 
-        let branch_protection_diffs = self
-            .diff_branch_protections(&actual_repo, expected_repo)
-            .await?;
+        let branch_protection_diffs = self.diff_branch_protections(&actual_repo).await?;
 
-        let ruleset_diffs = if self.should_use_rulesets(expected_repo) {
-            self.diff_rulesets(expected_repo).await?
-        } else {
-            Vec::new()
-        };
+        let ruleset_diffs = self.diff_rulesets(expected_repo).await?;
 
         let environment_diffs = self.diff_environments(expected_repo).await?;
         let old_settings = RepoSettings {
@@ -652,7 +621,6 @@ impl SyncGitHub {
         Ok(RepoDiff::Update(UpdateRepoDiff {
             org: expected_repo.org.clone(),
             name: actual_repo.name,
-            repo_node_id: actual_repo.node_id,
             repo_id: actual_repo.repo_id,
             settings_diff: (old_settings, new_settings),
             permission_diffs,
@@ -685,10 +653,11 @@ impl SyncGitHub {
         calculate_permission_diffs(expected_repo, actual_teams, actual_collaborators)
     }
 
+    /// We use Rulesets instead of branch protections, so the diff consists only on deletions.
+    /// This is useful to detect (and later delete) branch protections that were created manually.
     async fn diff_branch_protections(
         &self,
         actual_repo: &api::Repo,
-        expected_repo: &rust_team_data::v1::Repo,
     ) -> anyhow::Result<Vec<BranchProtectionDiff>> {
         // The rust-lang/rust repository uses GitHub apps push allowance actors for its branch
         // protections, which cannot be read without a PAT.
@@ -697,73 +666,18 @@ impl SyncGitHub {
             return Ok(vec![]);
         }
 
-        let mut branch_protection_diffs = Vec::new();
-        let mut actual_protections = self
+        let actual_protections = self
             .github
             .branch_protections(&actual_repo.org, &actual_repo.name)
             .await?;
 
-        // If rulesets are enabled, delete all existing branch protections
-        // to avoid conflicts between branch protections and rulesets
-        if self.should_use_rulesets(expected_repo) {
-            return Ok(actual_protections
-                .into_iter()
-                .map(|(name, (id, _))| BranchProtectionDiff {
-                    pattern: name,
-                    operation: BranchProtectionDiffOperation::Delete(id),
-                })
-                .collect());
-        }
-        for branch_protection in &expected_repo.branch_protections {
-            let actual_branch_protection = actual_protections.remove(&branch_protection.pattern);
-            let mut expected_branch_protection =
-                construct_branch_protection(expected_repo, branch_protection);
-
-            // We don't model GitHub App push allowance actors in team.
-            // However, we don't want to remove existing accesses of GH apps to
-            // branches.
-            // So if there is an existing branch protection, we copy its GitHub app
-            // push allowances into the expected branch protection, to roundtrip the app access.
-            if let Some((_, actual_branch_protection)) = &actual_branch_protection {
-                expected_branch_protection.push_allowances.extend(
-                    actual_branch_protection
-                        .push_allowances
-                        .iter()
-                        .filter(|allowance| matches!(allowance, PushAllowanceActor::App(_)))
-                        .cloned(),
-                );
-            }
-
-            let operation = {
-                match actual_branch_protection {
-                    Some((database_id, bp)) if bp != expected_branch_protection => {
-                        BranchProtectionDiffOperation::Update(
-                            database_id,
-                            bp,
-                            expected_branch_protection,
-                        )
-                    }
-                    None => BranchProtectionDiffOperation::Create(expected_branch_protection),
-                    // The branch protection doesn't need to change
-                    Some(_) => continue,
-                }
-            };
-            branch_protection_diffs.push(BranchProtectionDiff {
-                pattern: branch_protection.pattern.clone(),
-                operation,
-            });
-        }
-
-        // `actual_branch_protections` now contains the branch protections that were not expected
-        // but are still on GitHub. We want to delete them.
-        branch_protection_diffs.extend(actual_protections.into_iter().map(|(name, (id, _))| {
-            BranchProtectionDiff {
+        Ok(actual_protections
+            .into_iter()
+            .map(|(name, (id, _))| BranchProtectionDiff {
                 pattern: name,
                 operation: BranchProtectionDiffOperation::Delete(id),
-            }
-        }));
-
-        Ok(branch_protection_diffs)
+            })
+            .collect())
     }
 
     async fn diff_environments(
@@ -1159,92 +1073,6 @@ pub fn convert_permission(p: &rust_team_data::v1::RepoPermission) -> RepoPermiss
     }
 }
 
-fn get_branch_protection_mode(
-    branch_protection: &rust_team_data::v1::BranchProtection,
-) -> BranchProtectionMode {
-    let is_managed_by_bors = branch_protection
-        .allowed_merge_apps
-        .contains(&MergeBot::Bors);
-    // When bors manages a branch, we should not require a PR nor approvals
-    // for that branch, because it will (force) push to these branches directly.
-    if is_managed_by_bors {
-        BranchProtectionMode::PrNotRequired
-    } else {
-        branch_protection.mode.clone()
-    }
-}
-
-pub fn construct_branch_protection(
-    expected_repo: &rust_team_data::v1::Repo,
-    branch_protection: &rust_team_data::v1::BranchProtection,
-) -> api::BranchProtection {
-    let branch_protection_mode = get_branch_protection_mode(branch_protection);
-
-    let required_approving_review_count: u8 = match branch_protection_mode {
-        BranchProtectionMode::PrRequired {
-            required_approvals, ..
-        } => required_approvals
-            .try_into()
-            .expect("Too large required approval count"),
-        BranchProtectionMode::PrNotRequired => 0,
-    };
-    let mut push_allowances: Vec<PushAllowanceActor> = branch_protection
-        .allowed_merge_teams
-        .iter()
-        .map(|team| {
-            api::PushAllowanceActor::Team(api::TeamPushAllowanceActor {
-                organization: Login {
-                    login: expected_repo.org.clone(),
-                },
-                name: team.to_string(),
-            })
-        })
-        .collect();
-
-    for merge_bot in &branch_protection.allowed_merge_apps {
-        let allowance = match merge_bot {
-            MergeBot::Homu => PushAllowanceActor::User(api::UserPushAllowanceActor {
-                login: "bors".to_owned(),
-            }),
-            MergeBot::RustTimer => PushAllowanceActor::User(api::UserPushAllowanceActor {
-                login: "rust-timer".to_owned(),
-            }),
-            MergeBot::Bors | MergeBot::WorkflowsCratesIo | MergeBot::PromoteRelease => {
-                // These use GitHub apps, which are not configured through team (set manually).
-                // Their push allowance will be roundtripped by sync-team.
-                continue;
-            }
-        };
-        push_allowances.push(allowance);
-    }
-
-    let mut checks = match &branch_protection_mode {
-        BranchProtectionMode::PrRequired { ci_checks, .. } => ci_checks.clone(),
-        BranchProtectionMode::PrNotRequired => {
-            vec![]
-        }
-    };
-    // Normalize check order to avoid diffs based only on the ordering difference
-    checks.sort();
-
-    api::BranchProtection {
-        pattern: branch_protection.pattern.clone(),
-        is_admin_enforced: true,
-        allows_force_pushes: !branch_protection.prevent_force_push,
-        dismisses_stale_reviews: branch_protection.dismiss_stale_review,
-        requires_conversation_resolution: branch_protection.require_conversation_resolution,
-        requires_linear_history: branch_protection.require_linear_history,
-        requires_strict_status_checks: branch_protection.require_up_to_date_branches,
-        required_approving_review_count,
-        required_status_check_contexts: checks,
-        push_allowances,
-        requires_approving_reviews: matches!(
-            branch_protection_mode,
-            BranchProtectionMode::PrRequired { .. }
-        ),
-    }
-}
-
 /// Convert a branch or tag pattern to a full ref pattern for use in rulesets.
 /// GitHub rulesets require full ref paths like "refs/heads/main" and "refs/tags/0.*".
 pub(crate) fn convert_pattern_to_ref_pattern(target: ProtectionTarget, pattern: &str) -> String {
@@ -1513,7 +1341,6 @@ struct CreateRepoDiff {
     name: String,
     settings: RepoSettings,
     permissions: Vec<RepoPermissionAssignmentDiff>,
-    branch_protections: Vec<(String, api::BranchProtection)>,
     rulesets: Vec<api::Ruleset>,
     environments: Vec<(String, rust_team_data::v1::Environment)>,
     app_installations: Vec<AppInstallationDiff>,
@@ -1529,17 +1356,7 @@ impl CreateRepoDiff {
             permission.apply(sync, &self.org, &self.name).await?;
         }
 
-        // Apply branch protections
-        for (branch, protection) in &self.branch_protections {
-            BranchProtectionDiff {
-                pattern: branch.clone(),
-                operation: BranchProtectionDiffOperation::Create(protection.clone()),
-            }
-            .apply(sync, &self.org, &self.name, &repo.node_id)
-            .await?;
-        }
-
-        // Apply rulesets (in addition to branch protections if configured)
+        // Apply rulesets for all configured branch protection policies.
         for ruleset in &self.rulesets {
             RulesetDiff {
                 name: ruleset.name.clone(),
@@ -1569,7 +1386,6 @@ impl std::fmt::Display for CreateRepoDiff {
             name,
             settings,
             permissions,
-            branch_protections,
             rulesets,
             environments,
             app_installations,
@@ -1591,14 +1407,6 @@ impl std::fmt::Display for CreateRepoDiff {
         writeln!(f, "  Permissions:")?;
         for diff in permissions {
             write!(f, "{diff}")?;
-        }
-
-        if !branch_protections.is_empty() {
-            writeln!(f, "  Branch Protections:")?;
-            for (branch_name, branch_protection) in branch_protections {
-                writeln!(&mut f, "    {branch_name}")?;
-                log_branch_protection(branch_protection, None, &mut f)?;
-            }
         }
 
         if !rulesets.is_empty() {
@@ -1635,7 +1443,6 @@ impl std::fmt::Display for CreateRepoDiff {
 struct UpdateRepoDiff {
     org: String,
     name: String,
-    repo_node_id: String,
     repo_id: u64,
     // old, new
     settings_diff: (RepoSettings, RepoSettings),
@@ -1670,7 +1477,6 @@ impl UpdateRepoDiff {
         let UpdateRepoDiff {
             org: _,
             name: _,
-            repo_node_id: _,
             repo_id: _,
             settings_diff,
             permission_diffs,
@@ -1719,9 +1525,7 @@ impl UpdateRepoDiff {
         }
 
         for branch_protection in &self.branch_protection_diffs {
-            branch_protection
-                .apply(sync, &self.org, &self.name, &self.repo_node_id)
-                .await?;
+            branch_protection.apply(sync, &self.org, &self.name).await?;
         }
 
         for ruleset in &self.ruleset_diffs {
@@ -1773,7 +1577,6 @@ impl std::fmt::Display for UpdateRepoDiff {
         let UpdateRepoDiff {
             org,
             name,
-            repo_node_id: _,
             repo_id: _,
             settings_diff,
             permission_diffs,
@@ -1976,32 +1779,8 @@ struct BranchProtectionDiff {
 }
 
 impl BranchProtectionDiff {
-    async fn apply(
-        &self,
-        sync: &GitHubWrite,
-        org: &str,
-        repo_name: &str,
-        repo_id: &str,
-    ) -> anyhow::Result<()> {
+    async fn apply(&self, sync: &GitHubWrite, org: &str, repo_name: &str) -> anyhow::Result<()> {
         match &self.operation {
-            BranchProtectionDiffOperation::Create(bp) => {
-                sync.upsert_branch_protection(
-                    BranchProtectionOp::CreateForRepo(repo_id.to_string()),
-                    &self.pattern,
-                    bp,
-                    org,
-                )
-                .await?;
-            }
-            BranchProtectionDiffOperation::Update(id, _, bp) => {
-                sync.upsert_branch_protection(
-                    BranchProtectionOp::UpdateBranchProtection(id.clone()),
-                    &self.pattern,
-                    bp,
-                    org,
-                )
-                .await?;
-            }
             BranchProtectionDiffOperation::Delete(id) => {
                 debug!(
                     "Deleting branch protection '{}' on '{}/{}' as \
@@ -2020,10 +1799,6 @@ impl std::fmt::Display for BranchProtectionDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "      {}", self.pattern)?;
         match &self.operation {
-            BranchProtectionDiffOperation::Create(bp) => log_branch_protection(bp, None, f),
-            BranchProtectionDiffOperation::Update(_, old, new) => {
-                log_branch_protection(old, Some(new), f)
-            }
             BranchProtectionDiffOperation::Delete(_) => {
                 writeln!(f, "        Deleting branch protection")
             }
@@ -2066,68 +1841,6 @@ fn log_field_if_not_default<T: PartialEq + std::fmt::Debug + Default>(
             }
         }
     }
-    Ok(())
-}
-
-fn log_branch_protection(
-    current: &api::BranchProtection,
-    new: Option<&api::BranchProtection>,
-    mut result: impl Write,
-) -> std::fmt::Result {
-    log_field(
-        "Require branches to be up to date",
-        &current.requires_strict_status_checks,
-        new.map(|n| &n.requires_strict_status_checks),
-        &mut result,
-    )?;
-    log_field(
-        "Dismiss Stale Reviews",
-        &current.dismisses_stale_reviews,
-        new.map(|n| &n.dismisses_stale_reviews),
-        &mut result,
-    )?;
-    log_field(
-        "Require conversation resolution",
-        &current.requires_conversation_resolution,
-        new.map(|n| &n.requires_conversation_resolution),
-        &mut result,
-    )?;
-    log_field(
-        "Require linear history",
-        &current.requires_linear_history,
-        new.map(|n| &n.requires_linear_history),
-        &mut result,
-    )?;
-    log_field(
-        "Is admin enforced",
-        &current.is_admin_enforced,
-        new.map(|n| &n.is_admin_enforced),
-        &mut result,
-    )?;
-    log_field(
-        "Required Approving Review Count",
-        &current.required_approving_review_count,
-        new.map(|n| &n.required_approving_review_count),
-        &mut result,
-    )?;
-    log_field(
-        "Requires PR",
-        &current.requires_approving_reviews,
-        new.map(|n| &n.requires_approving_reviews),
-        &mut result,
-    )?;
-    log_field(
-        "Required Checks",
-        &current.required_status_check_contexts,
-        new.map(|n| &n.required_status_check_contexts),
-        &mut result,
-    )?;
-    log_field(
-        "Allowances",
-        &current.push_allowances,
-        new.map(|n| &n.push_allowances),
-        &mut result,
-    )?;
     Ok(())
 }
 
@@ -2525,8 +2238,6 @@ fn log_ruleset(
 
 #[derive(Debug)]
 enum BranchProtectionDiffOperation {
-    Create(api::BranchProtection),
-    Update(String, api::BranchProtection, api::BranchProtection),
     Delete(String),
 }
 

--- a/src/sync/github/tests/mod.rs
+++ b/src/sync/github/tests/mod.rs
@@ -216,7 +216,6 @@ async fn repo_change_description() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -257,7 +256,6 @@ async fn repo_change_homepage() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -333,7 +331,6 @@ async fn repo_create() {
                         ),
                     },
                 ],
-                branch_protections: [],
                 rulesets: [
                     Ruleset {
                         id: None,
@@ -411,7 +408,6 @@ async fn repo_add_member() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -467,7 +463,6 @@ async fn repo_change_member_permissions() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -519,7 +514,6 @@ async fn repo_remove_member() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -572,7 +566,6 @@ async fn repo_add_team() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -623,7 +616,6 @@ async fn repo_change_team_permissions() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -675,7 +667,6 @@ async fn repo_remove_team() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -726,7 +717,6 @@ async fn repo_archive_repo() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -771,7 +761,6 @@ async fn repo_add_branch_protection() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -922,7 +911,6 @@ async fn repo_update_branch_protection() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -1078,7 +1066,6 @@ async fn repo_remove_branch_protection() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -1214,7 +1201,6 @@ async fn repo_environment_create() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -1275,7 +1261,6 @@ async fn repo_environment_delete() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -1343,7 +1328,6 @@ async fn repo_environment_update() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
@@ -1405,7 +1389,6 @@ async fn repo_environment_update_branches() {
             UpdateRepoDiff {
                 org: "rust-lang",
                 name: "repo1",
-                repo_node_id: "0",
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {

--- a/src/sync/github/tests/test_utils.rs
+++ b/src/sync/github/tests/test_utils.rs
@@ -136,7 +136,6 @@ impl DataModel {
             org.repos.insert(
                 repo.name.clone(),
                 Repo {
-                    node_id: org.repos.len().to_string(),
                     repo_id: org.repos.len() as u64,
                     name: repo.name.clone(),
                     org: repo.org.clone(),


### PR DESCRIPTION
Remove logic to create and update branch protections (it was dead code anyway)
Branch protections are still detected and deleted if present so that we prevent people from creating them manually.