### PR TITLE
rename branch-protections to rulesets

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -397,29 +397,27 @@ compiler = "write"
 octocat = "write"
 ```
 
-### Repository branch protections
+### Repository rulesets
 
-[Branch protections] restrict actions on specified branches. It is strongly encouraged to set up branch protections on the default branch (e.g. `main` or `master`).
+[Rulesets] restrict actions on specified branches or tags. It is strongly encouraged to set up a ruleset on the default branch (e.g. `main` or `master`).
 
-The behavior of branch protections depends on whether or not `bors` is enabled in the `bots` key mentioned above:
+The behavior of rulesets depends on whether or not `bors` is enabled in the `bots` key mentioned above:
 
 - If bors is not enabled, then the default will be to require at least one approving review (via GitHub's PR UI).
 - If bors is enabled, approvals via GitHub's UI is not required (since we count the `@bors r+` comment as an approval). Also, bors will be added to the "allowed pushers".
 
 Users with the "maintain" or "admin" role are allowed to merge PRs via the GitHub UI. If you have bors enabled, you should only give users the "write" role so that the "Merge" button is disabled, forcing the user to use the `@bors r+` comment instead.
 
-The branch protection requires a PR to push changes. You cannot push directly to the branch.
+Admins cannot override these rulesets. If an admin needs to do that, they will need to temporarily edit the repository ruleset in the GitHub settings.
 
-Admins cannot override these branch protections. If an admin needs to do that, they will need to temporarily edit the branch protection in the GitHub settings.
-
-[Branch protections]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
+[Rulesets]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
 
 ```toml
-# The branch protections (optional)
-[[branch-protections]]
-# The pattern matching the branches to be protected (required)
+# The repository rulesets (optional)
+[[rulesets]]
+# The pattern matching the branches or tags to be protected (required)
 pattern = "main"
-# Custom name for the GitHub ruleset created from this branch protection.
+# Custom name for the GitHub ruleset created from this entry.
 # If not specified, defaults to "Ruleset for <pattern>".
 # (optional)
 name = "My custom ruleset name"

--- a/repos/archive/rust-embedded/cortex-m-rt.toml
+++ b/repos/archive/rust-embedded/cortex-m-rt.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 dismiss-stale-review = true
 required-approvals = 0

--- a/repos/archive/rust-embedded/cortex-m-semihosting.toml
+++ b/repos/archive/rust-embedded/cortex-m-semihosting.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["bors"]
 dismiss-stale-review = true

--- a/repos/archive/rust-embedded/itm.toml
+++ b/repos/archive/rust-embedded/itm.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["bors"]
 dismiss-stale-review = true

--- a/repos/archive/rust-embedded/panic-itm.toml
+++ b/repos/archive/rust-embedded/panic-itm.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["bors"]
 dismiss-stale-review = true

--- a/repos/archive/rust-embedded/panic-semihosting.toml
+++ b/repos/archive/rust-embedded/panic-semihosting.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["bors"]
 dismiss-stale-review = true

--- a/repos/archive/rust-embedded/r0.toml
+++ b/repos/archive/rust-embedded/r0.toml
@@ -5,6 +5,6 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 dismiss-stale-review = true

--- a/repos/archive/rust-embedded/riscv-rt.toml
+++ b/repos/archive/rust-embedded/riscv-rt.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["build-check", "rustfmt", "changelog-check", "clippy-check"]
 dismiss-stale-review = true

--- a/repos/archive/rust-lang-deprecated/rust-buildbot.toml
+++ b/repos/archive/rust-lang-deprecated/rust-buildbot.toml
@@ -2,7 +2,7 @@ org = "rust-lang-deprecated"
 name = "rust-buildbot"
 description = "Buildbot configs for the Rust project"
 bots = []
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 pr-required = false

--- a/repos/archive/rust-lang/homu.toml
+++ b/repos/archive/rust-lang/homu.toml
@@ -5,6 +5,6 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = []

--- a/repos/archive/rust-lang/libm.toml
+++ b/repos/archive/rust-lang/libm.toml
@@ -5,7 +5,7 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ['success']
 required-approvals = 0

--- a/repos/archive/rust-lang/rust-installer.toml
+++ b/repos/archive/rust-lang/rust-installer.toml
@@ -5,5 +5,5 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"

--- a/repos/rust-analyzer/expect-test.toml
+++ b/repos/rust-analyzer/expect-test.toml
@@ -7,7 +7,7 @@ bots = []
 rust-analyzer = "write"
 expect-test = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["test"]
 merge-queue = { enabled = true, check-response-timeout-minutes = 30 }

--- a/repos/rust-lang-nursery/rust-toolstate.toml
+++ b/repos/rust-lang-nursery/rust-toolstate.toml
@@ -7,7 +7,7 @@ bots = ["highfive"]
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 pr-required = false
 

--- a/repos/rust-lang/a-mir-formality.toml
+++ b/repos/rust-lang/a-mir-formality.toml
@@ -10,7 +10,7 @@ lang-docs = "maintain"
 types = "maintain"
 formality = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["conclusion"]
 merge-queue = { enabled = true }

--- a/repos/rust-lang/annotate-snippets-rs.toml
+++ b/repos/rust-lang/annotate-snippets-rs.toml
@@ -7,7 +7,7 @@ bots = ["renovate"]
 cargo = "write"
 wg-diagnostics = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["CI"]
 required-approvals = 0

--- a/repos/rust-lang/arewewebyet.toml
+++ b/repos/rust-lang/arewewebyet.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 arewewebyet = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'master'
 
 [environments.github-pages]

--- a/repos/rust-lang/async-fundamentals-initiative.toml
+++ b/repos/rust-lang/async-fundamentals-initiative.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 wg-async = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 

--- a/repos/rust-lang/backtrace-rs.toml
+++ b/repos/rust-lang/backtrace-rs.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'master'
 
 [environments.github-pages]

--- a/repos/rust-lang/beyond-refs.toml
+++ b/repos/rust-lang/beyond-refs.toml
@@ -21,7 +21,7 @@ types = "maintain"
 wg-async = "maintain"
 wg-safe-transmute = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["build"]
 required-approvals = 0

--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -10,7 +10,7 @@ website = "maintain"
 # For Rust release blog posts
 release = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = [
     "lint",

--- a/repos/rust-lang/book.toml
+++ b/repos/rust-lang/book.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 book = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = []
 required-approvals = 0

--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -10,7 +10,7 @@ infra-bors = "write"
 infra-admins = "write"
 infra-bors-admins = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["Test", "Test Docker"]
 required-approvals = 0

--- a/repos/rust-lang/calendar-generation.toml
+++ b/repos/rust-lang/calendar-generation.toml
@@ -15,5 +15,5 @@ libs = "write"
 release = "write"
 wg-async = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"

--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -16,7 +16,7 @@ libs = "maintain"
 release = "maintain"
 wg-async = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 pr-required = false
 

--- a/repos/rust-lang/cargo-bisect-rustc.toml
+++ b/repos/rust-lang/cargo-bisect-rustc.toml
@@ -10,7 +10,7 @@ compiler = "write"
 [access.individuals]
 ehuss = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 

--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -7,17 +7,17 @@ bots = ["rustbot", "rfcbot", "renovate"]
 [access.teams]
 cargo = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["conclusion"]
 merge-queue = { enabled = true }
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "rust-1.*"
 ci-checks = ["conclusion"]
 prevent-creation = false
 
-[[branch-protections]]
+[[rulesets]]
 name = "Only allow the release process to publish tags"
 pattern = "0.*"
 target = "tag"

--- a/repos/rust-lang/cc-rs.toml
+++ b/repos/rust-lang/cc-rs.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'main'
 required-approvals = 0
 ci-checks = ['Tests pass']

--- a/repos/rust-lang/ci-mirrors.toml
+++ b/repos/rust-lang/ci-mirrors.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["Build finished"]
 dismiss-stale-review = true

--- a/repos/rust-lang/cmake-rs.toml
+++ b/repos/rust-lang/cmake-rs.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ['success']
 require-up-to-date-branches = true

--- a/repos/rust-lang/compiler-builtins.toml
+++ b/repos/rust-lang/compiler-builtins.toml
@@ -6,7 +6,7 @@ bots = ["rustbot", "forking-renovate"]
 [access.teams]
 crate-maintainers = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["success"]
 required-approvals = 0

--- a/repos/rust-lang/compiler-team.toml
+++ b/repos/rust-lang/compiler-team.toml
@@ -9,7 +9,7 @@ compiler = "write"
 compiler-ops = "write"
 types = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 

--- a/repos/rust-lang/crater.toml
+++ b/repos/rust-lang/crater.toml
@@ -7,7 +7,7 @@ bots = ["highfive"]
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/crates-build-env.toml
+++ b/repos/rust-lang/crates-build-env.toml
@@ -7,5 +7,5 @@ bots = ["rustbot"]
 docs-rs = 'write'
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'master'

--- a/repos/rust-lang/crates-io-auth-action.toml
+++ b/repos/rust-lang/crates-io-auth-action.toml
@@ -8,7 +8,7 @@ crates-io-infra-admins = "write"
 infra-admins = "write"
 infra = "triage"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["Conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/crates.io-index-archive.toml
+++ b/repos/rust-lang/crates.io-index-archive.toml
@@ -6,11 +6,11 @@ bots = []
 [access.teams]
 crates-io = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "snapshot-*"
 pr-required = false
 prevent-creation = false
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 pr-required = false

--- a/repos/rust-lang/crates.io-index.toml
+++ b/repos/rust-lang/crates.io-index.toml
@@ -7,7 +7,7 @@ bots = []
 crates-io = "write"
 crates-io-on-call = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 pr-required = false
 prevent-force-push = false

--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -7,7 +7,7 @@ bots = ["renovate", "rustbot", "heroku-deploy-access"]
 [access.teams]
 crates-io = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = [
     "Backend / Lint",

--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -7,7 +7,7 @@ bots = ["rustbot", "forking-renovate"]
 [access.teams]
 crates-io = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 required-approvals = 0
 pr-required = false

--- a/repos/rust-lang/docs.rs.toml
+++ b/repos/rust-lang/docs.rs.toml
@@ -8,7 +8,7 @@ bots = ["rustbot", "renovate"]
 docs-rs = 'write'
 docs-rs-reviewers = 'write'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'main'
 required-approvals = 0
 require-conversation-resolution = true

--- a/repos/rust-lang/edition-guide.toml
+++ b/repos/rust-lang/edition-guide.toml
@@ -7,7 +7,7 @@ bots = ["rustbot", "rfcbot"]
 [access.teams]
 edition = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["Success gate"]
 required-approvals = 0

--- a/repos/rust-lang/ena.toml
+++ b/repos/rust-lang/ena.toml
@@ -6,5 +6,5 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'master'

--- a/repos/rust-lang/enzyme.toml
+++ b/repos/rust-lang/enzyme.toml
@@ -13,12 +13,12 @@ libs-api = "maintain"
 release = "maintain"
 wg-llvm = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "rustc/*"
 pr-required = false
 prevent-creation = false
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 pr-required = false
 

--- a/repos/rust-lang/flate2-rs.toml
+++ b/repos/rust-lang/flate2-rs.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'main'
 
 [environments.github-pages]

--- a/repos/rust-lang/fls.toml
+++ b/repos/rust-lang/fls.toml
@@ -13,7 +13,7 @@ lang-ops = "write"
 spec = "write"
 spec-contributors = "triage"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["CI finished"]
 merge-queue = { enabled = true, max-entries-to-build = 1, min-entries-to-merge-wait-minutes = 1 }

--- a/repos/rust-lang/futures-rs.toml
+++ b/repos/rust-lang/futures-rs.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 wg-async = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 

--- a/repos/rust-lang/gha-self-hosted.toml
+++ b/repos/rust-lang/gha-self-hosted.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["CI finished"]
 merge-queue = { enabled = true, max-entries-to-build = 1, min-entries-to-merge-wait-minutes = 1, max-entries-to-merge = 1 }

--- a/repos/rust-lang/git2-rs.toml
+++ b/repos/rust-lang/git2-rs.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 cargo = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["Success gate"]
 required-approvals = 0

--- a/repos/rust-lang/gll.toml
+++ b/repos/rust-lang/gll.toml
@@ -5,5 +5,5 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"

--- a/repos/rust-lang/glob.toml
+++ b/repos/rust-lang/glob.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 crate-maintainers = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["success"]
 required-approvals = 0

--- a/repos/rust-lang/hashbrown.toml
+++ b/repos/rust-lang/hashbrown.toml
@@ -8,7 +8,7 @@ bots = []
 libs = "write"
 libs-contributors = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/impl-trait-utils.toml
+++ b/repos/rust-lang/impl-trait-utils.toml
@@ -6,5 +6,5 @@ bots = []
 [access.teams]
 wg-async = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"

--- a/repos/rust-lang/infra-smoke-tests.toml
+++ b/repos/rust-lang/infra-smoke-tests.toml
@@ -6,7 +6,7 @@ bots = ["renovate"]
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 required-approvals = 0
 require-linear-history = true

--- a/repos/rust-lang/josh-sync.toml
+++ b/repos/rust-lang/josh-sync.toml
@@ -7,7 +7,7 @@ bots = []
 compiler = "write"
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["Test"]
 required-approvals = 0

--- a/repos/rust-lang/leadership-council.toml
+++ b/repos/rust-lang/leadership-council.toml
@@ -7,5 +7,5 @@ bots = ["rustbot", "rfcbot"]
 leadership-council = "maintain"
 council-librarians = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"

--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -9,14 +9,14 @@ bots = [
 [access.teams]
 crate-maintainers = 'maintain'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'main'
 ci-checks = ['success']
 required-approvals = 0
 merge-queue = { enabled = true, method = "rebase" }
 require-linear-history = true
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'libc-0.2'
 ci-checks = ['success']
 required-approvals = 0

--- a/repos/rust-lang/llvm-project.toml
+++ b/repos/rust-lang/llvm-project.toml
@@ -6,11 +6,11 @@ bots = []
 [access.teams]
 wg-llvm = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "rustc/*"
 pr-required = false
 prevent-creation = false
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 pr-required = false

--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -12,7 +12,7 @@ devtools = "write"
 # soon, and then this can be removed.
 Dylan-DPC = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["Success gate"]
 required-approvals = 0

--- a/repos/rust-lang/measureme.toml
+++ b/repos/rust-lang/measureme.toml
@@ -6,12 +6,12 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["success"]
 merge-queue = { enabled = true }
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "stable"
 ci-checks = ["success"]
 

--- a/repos/rust-lang/miri-test-libstd.toml
+++ b/repos/rust-lang/miri-test-libstd.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 miri = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["Success"]
 required-approvals = 0

--- a/repos/rust-lang/miri.toml
+++ b/repos/rust-lang/miri.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 compiler = "write"
 miri = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/nomicon.toml
+++ b/repos/rust-lang/nomicon.toml
@@ -8,7 +8,7 @@ bots = []
 lang = "write"
 lang-docs = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["Success gate"]
 merge-queue = { enabled = true }

--- a/repos/rust-lang/odht.toml
+++ b/repos/rust-lang/odht.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["Required Checks Passed"]
 require-up-to-date-branches = true

--- a/repos/rust-lang/portable-simd.toml
+++ b/repos/rust-lang/portable-simd.toml
@@ -6,7 +6,7 @@ bots = ["rustbot"]
 [access.teams]
 project-portable-simd = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 

--- a/repos/rust-lang/project-exploit-mitigations.toml
+++ b/repos/rust-lang/project-exploit-mitigations.toml
@@ -6,6 +6,6 @@ bots = []
 [access.teams]
 project-exploit-mitigations = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 dismiss-stale-review = true

--- a/repos/rust-lang/project-stable-mir.toml
+++ b/repos/rust-lang/project-stable-mir.toml
@@ -6,7 +6,7 @@ bots = ["rustbot"]
 [access.teams]
 project-stable-mir = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 
 [environments.github-pages]

--- a/repos/rust-lang/promote-release.toml
+++ b/repos/rust-lang/promote-release.toml
@@ -7,7 +7,7 @@ bots = []
 infra = "triage"
 infra-admins = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = [
     "Local release (beta)",

--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -10,7 +10,7 @@ lang-docs = "write"
 spec = "write"
 spec-contributors = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["Success gate"]
 merge-queue = { enabled = true }

--- a/repos/rust-lang/relnotes.toml
+++ b/repos/rust-lang/relnotes.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 release = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = [
     "build (macos-latest, beta)",

--- a/repos/rust-lang/renovate.toml
+++ b/repos/rust-lang/renovate.toml
@@ -6,7 +6,7 @@ bots = ["renovate"]
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["Conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/rfcs.toml
+++ b/repos/rust-lang/rfcs.toml
@@ -7,7 +7,7 @@ bots = ["rustbot", "rfcbot", "renovate"]
 [access.teams]
 all = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 

--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -12,7 +12,7 @@ clippy = "triage"
 compiler = "triage"
 triage = "triage"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/rust-bindgen.toml
+++ b/repos/rust-lang/rust-bindgen.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 wg-bindgen = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 required-approvals = 0
 ci-checks = ["success"]

--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -8,7 +8,7 @@ bots = ["rustbot"]
 clippy = "write"
 clippy-contributors = "triage"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = [
     "conclusion",

--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -23,7 +23,7 @@ rustdoc = "maintain"
 triagebot = "maintain"
 rustc-dev-guide = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["test"]
 

--- a/repos/rust-lang/rust-log-analyzer.toml
+++ b/repos/rust-lang/rust-log-analyzer.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["CI"]
 required-approvals = 0

--- a/repos/rust-lang/rust-playground.toml
+++ b/repos/rust-lang/rust-playground.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 infra = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = []
 required-approvals = 0

--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -30,14 +30,14 @@ triage = "write"
 rust-timer = "write"
 
 # Only `bors` can push to `main`
-[[branch-protections]]
+[[rulesets]]
 name = "main"
 pattern = "main"
 allowed-merge-apps = ["bors"]
 prevent-update = true
 
 # No one can force push to main
-[[branch-protections]]
+[[rulesets]]
 name = "main - force-push"
 pattern = "main"
 # `main` already requires users to open PRs.
@@ -45,14 +45,14 @@ pattern = "main"
 pr-required = false
 
 # Only `bors` and `promote-release` can push to `stable`
-[[branch-protections]]
+[[rulesets]]
 name = "stable"
 pattern = "stable"
 allowed-merge-apps = ["bors", "promote-release"]
 prevent-update = true
 
 # Only `promote-release` can force-push to `stable`
-[[branch-protections]]
+[[rulesets]]
 name = "stable - force-push"
 pattern = "stable"
 allowed-merge-apps = ["promote-release"]
@@ -61,21 +61,21 @@ allowed-merge-apps = ["promote-release"]
 pr-required = false
 
 # No one create or delete the stable branch.
-[[branch-protections]]
+[[rulesets]]
 name = "stable - misc"
 pattern = "stable"
 pr-required = false
 prevent-force-push = false
 
 # Only `bors` and `promote-release` can push to `beta`
-[[branch-protections]]
+[[rulesets]]
 name = "beta"
 pattern = "beta"
 allowed-merge-apps = ["bors", "promote-release"]
 prevent-update = true
 
 # Only `promote-release` can force-push to `beta`
-[[branch-protections]]
+[[rulesets]]
 name = "beta - force-push"
 pattern = "beta"
 allowed-merge-apps = ["promote-release"]
@@ -84,24 +84,24 @@ allowed-merge-apps = ["promote-release"]
 pr-required = false
 
 # no one can create or delete the beta branch.
-[[branch-protections]]
+[[rulesets]]
 name = "beta - misc"
 pattern = "beta"
 pr-required = false
 prevent-force-push = false
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "*"
 allowed-merge-apps = ["bors", "promote-release"]
 prevent-update = true
 allowed-merge-teams = ["rust-timer"]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "*/**/*"
 allowed-merge-apps = ["bors", "promote-release"]
 prevent-update = true
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "cargo_update"
 pr-required = false
 prevent-deletion = false
@@ -109,42 +109,42 @@ prevent-force-push = false
 
 # Required for running try builds created by bors.
 # Must support force-pushes.
-[[branch-protections]]
+[[rulesets]]
 pattern = "automation/bors/try"
 allowed-merge-apps = ["bors"]
 prevent-update = true
 
 # Required for running try builds created by bors.
 # Must support force-pushes.
-[[branch-protections]]
+[[rulesets]]
 pattern = "automation/bors/try-merge"
 allowed-merge-apps = ["bors"]
 prevent-update = true
 
 # Required for running auto builds created by bors.
 # Must support force-pushes.
-[[branch-protections]]
+[[rulesets]]
 pattern = "automation/bors/auto"
 allowed-merge-apps = ["bors"]
 prevent-update = true
 
 # Required for running auto builds created by bors.
 # Must support force-pushes.
-[[branch-protections]]
+[[rulesets]]
 pattern = "automation/bors/auto-merge"
 allowed-merge-apps = ["bors"]
 prevent-update = true
 
 # Required for unrolled PR builds created by perfbot.
 # Must support force-pushes.
-[[branch-protections]]
+[[rulesets]]
 pattern = "try-perf"
 allowed-merge-teams = ["rust-timer"]
 prevent-update = true
 
 # Required for unrolled PR builds created by perfbot.
 # Must support force-pushes.
-[[branch-protections]]
+[[rulesets]]
 pattern = "perf-tmp"
 allowed-merge-teams = ["rust-timer"]
 prevent-update = true

--- a/repos/rust-lang/rustc-demangle.toml
+++ b/repos/rust-lang/rustc-demangle.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = [
     "Test (stable)",

--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -18,7 +18,7 @@ rustdoc = "write"
 rustdoc-frontend = "write"
 rustc-dev-guide = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["ci"]
 required-approvals = 0
@@ -26,7 +26,7 @@ required-approvals = 0
 # This branch protection exists for historical reasons
 # We had to force-push the whole commit history of rustc-dev-guide
 # This branch contains the old commit graph, to keep commit references working
-[[branch-protections]]
+[[rulesets]]
 pattern = "master-old"
 prevent-update = true
 

--- a/repos/rust-lang/rustc-hash.toml
+++ b/repos/rust-lang/rustc-hash.toml
@@ -6,5 +6,5 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"

--- a/repos/rust-lang/rustc-perf.toml
+++ b/repos/rust-lang/rustc-perf.toml
@@ -7,7 +7,7 @@ bots = []
 [access.teams]
 wg-compiler-performance = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["conclusion"]
 merge-queue = { enabled = true }

--- a/repos/rust-lang/rustc-stable-hash.toml
+++ b/repos/rust-lang/rustc-stable-hash.toml
@@ -6,5 +6,5 @@ bots = []
 [access.teams]
 compiler = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"

--- a/repos/rust-lang/rustc_codegen_c.toml
+++ b/repos/rust-lang/rustc_codegen_c.toml
@@ -7,7 +7,7 @@ bots = []
 codegen-c-maintainers = "maintain"
 compiler = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ['success']
 require-up-to-date-branches = true

--- a/repos/rust-lang/rustc_codegen_gcc.toml
+++ b/repos/rust-lang/rustc_codegen_gcc.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 compiler = "write"
 wg-gcc-backend = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["success", "success_gcc12", "success_release", "success_failures", "success_m68k", "success_stdarch"]
 required-approvals = 0

--- a/repos/rust-lang/rustfmt.toml
+++ b/repos/rust-lang/rustfmt.toml
@@ -8,7 +8,7 @@ bots = ["rustbot"]
 rustfmt = "write"
 rustfmt-contributors = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 required-approvals = 0
 ci-checks = [
@@ -27,11 +27,11 @@ ci-checks = [
     "rustdoc check",
 ]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "libsyntax"
 required-approvals = 0
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "rust-1.*"
 required-approvals = 0
 

--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -7,12 +7,12 @@ bots = ["rustbot", "renovate"]
 [access.teams]
 rustup = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["conclusion"]
 merge-queue = { enabled = true, method = "rebase" }
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "release/*"
 ci-checks = ["conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/simpleinfra.toml
+++ b/repos/rust-lang/simpleinfra.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 infra = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["Rust projects", "Terraform configuration", "GitHub Actions (JS)"]
 required-approvals = 0

--- a/repos/rust-lang/socket2.toml
+++ b/repos/rust-lang/socket2.toml
@@ -14,7 +14,7 @@ Thomasdezeeuw = 'maintain'
 carllerche = 'maintain'
 Darksonn = 'maintain'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = 'master'
 ci-checks = [
     'Rustfmt',

--- a/repos/rust-lang/staging.crates.io-index.toml
+++ b/repos/rust-lang/staging.crates.io-index.toml
@@ -7,7 +7,7 @@ bots = []
 crates-io = "write"
 crates-io-on-call = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 pr-required = false
 prevent-force-push = false

--- a/repos/rust-lang/std-dev-guide.toml
+++ b/repos/rust-lang/std-dev-guide.toml
@@ -10,7 +10,7 @@ libs-api = "write"
 libs = "maintain"
 rustc-dev-guide = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["book-test"]
 require-up-to-date-branches = true

--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -12,7 +12,7 @@ libs = "write"
 libs-api = "write"
 libs-contributors = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["conclusion"]
 required-approvals = 0

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -8,7 +8,7 @@ mods = "write"
 team-repo-admins = "write"
 infra = "triage"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 ci-checks = ["CI"]
 dismiss-stale-review = true

--- a/repos/rust-lang/this-week-in-rust.toml
+++ b/repos/rust-lang/this-week-in-rust.toml
@@ -8,6 +8,6 @@ bots = []
 twir-reviewers = "write"
 twir = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 required-approvals = 0

--- a/repos/rust-lang/thorin.toml
+++ b/repos/rust-lang/thorin.toml
@@ -6,7 +6,7 @@ bots = ["rustbot"]
 [access.teams]
 compiler = 'maintain'
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 require-conversation-resolution = true
 require-linear-history = true

--- a/repos/rust-lang/triagebot.toml
+++ b/repos/rust-lang/triagebot.toml
@@ -8,7 +8,7 @@ bots = ["rustbot"]
 infra = "maintain"
 triagebot = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["ci"]
 merge-queue = { enabled = true }

--- a/repos/rust-lang/wg-async.toml
+++ b/repos/rust-lang/wg-async.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 wg-async = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 required-approvals = 0
 

--- a/repos/rust-lang/wg-macros.toml
+++ b/repos/rust-lang/wg-macros.toml
@@ -6,7 +6,7 @@ bots = ["rustbot"]
 [access.teams]
 wg-macros = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 
 [environments.github-pages]

--- a/repos/rust-lang/www.rust-lang.org.toml
+++ b/repos/rust-lang/www.rust-lang.org.toml
@@ -7,7 +7,7 @@ bots = ["rustbot"]
 [access.teams]
 website = "write"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "main"
 
 [environments.github-pages]

--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -173,6 +173,8 @@ pub struct Repo {
     pub bots: Vec<Bot>,
     pub teams: Vec<RepoTeam>,
     pub members: Vec<RepoMember>,
+    /// These are rulesets, not branch protections.
+    /// The name is unchanged to keep the API retro-compatible.
     pub branch_protections: Vec<BranchProtection>,
     pub crates: Vec<Crate>,
     pub environments: IndexMap<String, Environment>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -831,7 +831,7 @@ pub(crate) struct Repo {
     pub bots: Vec<Bot>,
     pub access: RepoAccess,
     #[serde(default)]
-    pub branch_protections: Vec<BranchProtection>,
+    pub rulesets: Vec<Ruleset>,
     #[serde(default)]
     pub crates_io: Vec<CratesIoConfiguration>,
     #[serde(default)]
@@ -956,7 +956,7 @@ fn merge_queue_default_check_response_timeout_minutes() -> u32 {
 
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
-pub(crate) struct BranchProtection {
+pub(crate) struct Ruleset {
     pub pattern: String,
     #[serde(default)]
     pub target: ProtectionTarget,

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -50,7 +50,7 @@ impl<'a> Generator<'a> {
 
         for (r, archived) in repo_iter {
             let branch_protections: Vec<_> = r
-                .branch_protections
+                .rulesets
                 .iter()
                 .map(|b| v1::BranchProtection {
                     pattern: b.pattern.clone(),

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -69,7 +69,7 @@ static CHECKS: &[Check<fn(&Data, &mut Vec<String>)>] = checks![
     validate_zulip_stream_extra_people,
     validate_repos,
     validate_archived_repos,
-    validate_branch_protections,
+    validate_rulesets,
     validate_environments,
     validate_trusted_publishing,
     validate_member_roles,
@@ -1193,125 +1193,122 @@ fn validate_environments(data: &Data, errors: &mut Vec<String>) {
     });
 }
 
-/// Validate that branch protections make sense in combination with used bots.
-fn validate_branch_protections(data: &Data, errors: &mut Vec<String>) {
+/// Validate that rulesets make sense in combination with used bots.
+fn validate_rulesets(data: &Data, errors: &mut Vec<String>) {
     let github_teams = data.github_teams();
 
     wrapper(data.repos(), errors, |repo, _| {
         let bors_configured = repo.bots.iter().any(|b| matches!(b, Bot::Bors));
         let mut pattern_counts = HashMap::new();
 
-        for protection in &repo.branch_protections {
+        for ruleset in &repo.rulesets {
             *pattern_counts
-                .entry((protection.target, protection.pattern.as_str()))
+                .entry((ruleset.target, ruleset.pattern.as_str()))
                 .or_insert(0usize) += 1;
         }
 
-        for protection in &repo.branch_protections {
-            let key = (protection.target, protection.pattern.as_str());
+        for ruleset in &repo.rulesets {
+            let key = (ruleset.target, ruleset.pattern.as_str());
             let occurrences = pattern_counts
                 .get(&key)
                 .with_context(|| format!("pattern_counts should contain the key {key:?}"))?;
-            if *occurrences > 1 && protection.name.is_none() {
+            if *occurrences > 1 && ruleset.name.is_none() {
                 bail!(
-                    r#"repo '{}' uses multiple {:?} protections with the pattern `{}`; when multiple protections share the same target and pattern, each protection must specify `name`"#,
+                    r#"repo '{}' uses multiple {:?} rulesets with the pattern `{}`; when multiple rulesets share the same target and pattern, each ruleset must specify `name`"#,
                     repo.name,
-                    protection.target,
-                    protection.pattern,
+                    ruleset.target,
+                    ruleset.pattern,
                 );
             }
 
-            for team in &protection.allowed_merge_teams {
+            for team in &ruleset.allowed_merge_teams {
                 let key = (repo.org.clone(), team.clone());
                 if !github_teams.contains(&key) {
                     bail!(
-                        r#"repo '{}' uses a branch protection for {} that mentions the '{}' github team; but that team does not seem to exist"#,
+                        r#"repo '{}' uses a ruleset for {} that mentions the '{}' github team; but that team does not seem to exist"#,
                         repo.name,
-                        protection.pattern,
+                        ruleset.pattern,
                         team
                     );
                 }
                 if !repo.access.teams.contains_key(team) {
                     bail!(
-                        r#"repo '{}' uses a branch protection for {} that has an allowed merge team '{}', but that team is not mentioned in [access.teams]"#,
+                        r#"repo '{}' uses a ruleset for {} that has an allowed merge team '{}', but that team is not mentioned in [access.teams]"#,
                         repo.name,
-                        protection.pattern,
+                        ruleset.pattern,
                         team
                     );
                 }
             }
 
-            if !protection.pr_required {
+            if !ruleset.pr_required {
                 // It does not make sense to use CI checks when a PR is not required, because with a
                 // CI check, it would not be possible to push into the branch without a PR anyway.
-                if !protection.ci_checks.is_empty() {
+                if !ruleset.ci_checks.is_empty() {
                     bail!(
-                        r#"repo '{}' uses a branch protection for {} that does not require a PR, but has non-empty `ci-checks`"#,
+                        r#"repo '{}' uses a ruleset for {} that does not require a PR, but has non-empty `ci-checks`"#,
                         repo.name,
-                        protection.pattern,
+                        ruleset.pattern,
                     );
                 }
-                if let Some(required_approvals) = protection.required_approvals
+                if let Some(required_approvals) = ruleset.required_approvals
                     && required_approvals > 0
                 {
                     bail!(
-                        r#"repo '{}' uses a branch protection for {} that does not require a PR, but `required-approvals` is greater than 0"#,
+                        r#"repo '{}' uses a ruleset for {} that does not require a PR, but `required-approvals` is greater than 0"#,
                         repo.name,
-                        protection.pattern,
+                        ruleset.pattern,
                     );
                 }
             }
 
-            if protection.require_up_to_date_branches && protection.ci_checks.is_empty() {
+            if ruleset.require_up_to_date_branches && ruleset.ci_checks.is_empty() {
                 bail!(
-                    r#"repo '{}' uses a branch protection for {} that enables `require-up-to-date-branches`, but has empty `ci-checks`"#,
+                    r#"repo '{}' uses a ruleset for {} that enables `require-up-to-date-branches`, but has empty `ci-checks`"#,
                     repo.name,
-                    protection.pattern,
+                    ruleset.pattern,
                 );
             }
 
-            if protection.merge_queue.enabled && protection.pattern.contains('*') {
+            if ruleset.merge_queue.enabled && ruleset.pattern.contains('*') {
                 bail!(
-                    r#"repo '{}' uses a GitHub rule for {} that enables `merge-queue`, but GitHub merge queues only support exact ref names patterns"#,
+                    r#"repo '{}' uses a ruleset for {} that enables `merge-queue`, but GitHub merge queues only support exact ref names patterns"#,
                     repo.name,
-                    protection.pattern,
+                    ruleset.pattern,
                 );
             }
 
-            if protection.require_linear_history
-                && protection.merge_queue.enabled
-                && protection.merge_queue.method == MergeQueueMethod::Merge
+            if ruleset.require_linear_history
+                && ruleset.merge_queue.enabled
+                && ruleset.merge_queue.method == MergeQueueMethod::Merge
             {
                 bail!(
-                    r"repo '{}' uses a branch protection for {} that requires linear commit history, but also requires a merge queue using the default merging method `merge`, which is not compatible",
+                    r"repo '{}' uses a ruleset for {} that requires linear commit history, but also requires a merge queue using the default merging method `merge`, which is not compatible",
                     repo.name,
-                    protection.pattern,
+                    ruleset.pattern,
                 );
             }
 
-            let managed_by_bors = protection
-                .allowed_merge_apps
-                .contains(&AllowedMergeApp::Bors);
+            let managed_by_bors = ruleset.allowed_merge_apps.contains(&AllowedMergeApp::Bors);
             if managed_by_bors {
                 if !bors_configured {
                     bail!(
-                        r#"repo '{}' uses bors to manage a branch protection for '{}', but bors is not enabled. Add "bors" to the `bots` array"#,
+                        r#"repo '{}' uses bors to manage a ruleset for '{}', but bors is not enabled. Add "bors" to the `bots` array"#,
                         repo.name,
-                        protection.pattern,
+                        ruleset.pattern,
                     );
                 }
-                if protection.required_approvals.is_some()
-                    || protection.dismiss_stale_review
-                    || !protection.pr_required
-                    || !protection.allowed_merge_teams.is_empty()
-                        && !protection.pattern.contains('*')
+                if ruleset.required_approvals.is_some()
+                    || ruleset.dismiss_stale_review
+                    || !ruleset.pr_required
+                    || !ruleset.allowed_merge_teams.is_empty() && !ruleset.pattern.contains('*')
                 {
                     bail!(
-                        r#"repo '{}' uses bors, but its branch protection for {} uses invalid
+                        r#"repo '{}' uses bors, but its ruleset for {} uses invalid
 attributes (`required-approvals`, `dismiss-stale-review`, `pr-required` or `allowed-merge-teams`).
 Please remove the attributes when using bors"#,
                         repo.name,
-                        protection.pattern,
+                        ruleset.pattern,
                     );
                 }
             }

--- a/tests/static-api/repos/archive/test-org/archived_repo.toml
+++ b/tests/static-api/repos/archive/test-org/archived_repo.toml
@@ -5,6 +5,6 @@ bots = []
 
 [access.teams]
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["CI"]

--- a/tests/static-api/repos/test-org/some_repo.toml
+++ b/tests/static-api/repos/test-org/some_repo.toml
@@ -6,7 +6,7 @@ bots = []
 [access.teams]
 foo = "maintain"
 
-[[branch-protections]]
+[[rulesets]]
 pattern = "master"
 ci-checks = ["CI"]
 allowed-merge-teams = ["foo"]


### PR DESCRIPTION
rename `branch-protections` to `rulesets` in the repositories toml files.

v1 API is unchanged to be backwards compatible.