### PR TITLE
feat(repos/rustup): add protection rule for `release/*` branches

### DIFF
--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -12,6 +12,12 @@ pattern = "main"
 ci-checks = ["conclusion"]
 merge-queue = { enabled = true, method = "rebase" }
 
+[[branch-protections]]
+pattern = "release/*"
+ci-checks = ["conclusion"]
+required-approvals = 0
+prevent-creation = false
+
 [environments.github-pages]
 
 [environments.www-deploy]


### PR DESCRIPTION
Part of https://github.com/rust-lang/rustup/issues/4738; replaces #2372.

As discussed with @Kobzol in https://github.com/rust-lang/rustup/issues/4738#issuecomment-4276417728, given that the GitHub Merge Queue cannot be enabled for globs, the second best would be to have the following on those branches:

- "Require status checks" set to "true", to allow proper auto-merge (seems to be enabled already).
- ~~"Require a PR" and~~ "Require review" set to "false", to prevent spamming the repo for trivial fixes.
- ~~"Bypass actors" set to "t-rustup", to provide enough flexibility to the team regarding the release by reducing wait time when necessary. Combined with the previous point, this also seems to allow the team to push directly onto the backport branches as per https://github.com/rust-lang/rustup/issues/4738#issuecomment-4276417728.~~
- "Prevent creation" set to "false" since obviously `t-rustup` will have to create those branches from time to time.

Please feel free to point out if I have introduced anything wrong/redundant, many thanks in advance 🙏 