### PR TITLE
fix(repos/rustup): update homepage URL

### DIFF
--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "rustup"
 description = "The Rust toolchain installer"
-homepage = "https://rust-lang.github.io/rustup/"
+homepage = "https://rustup.rs/"
 bots = ["rustbot", "renovate"]
 
 [access.teams]


### PR DESCRIPTION
When editing the config file I realized that the homepage URL still points to the user guide (possibly a leftover from the ancient times).

Given that rustup already has a proper homepage https://rustup.rs along with the links to the user guide in the README, I think the homepage URL should be replaced with https://rustup.rs/ instead.

cc @rust-lang/rustup 