### PR TITLE
Add `staging.crates.io-index-archive` repository

### DIFF
--- a/repos/rust-lang/staging.crates.io-index-archive.toml
+++ b/repos/rust-lang/staging.crates.io-index-archive.toml
@@ -1,0 +1,16 @@
+org = "rust-lang"
+name = "staging.crates.io-index-archive"
+description = "Archive of the staging.crates.io-index commit history after squashes"
+bots = []
+
+[access.teams]
+crates-io = "maintain"
+
+[[rulesets]]
+pattern = "snapshot-*"
+pr-required = false
+prevent-creation = false
+
+[[rulesets]]
+pattern = "main"
+pr-required = false


### PR DESCRIPTION
This is the equivalent of the `crates.io-index-archive` repository, but for the staging environment. This will allow us to smoke test the automatic snapshot branch archival.

As @emilyalbini mentioned on Zulip:

> once the repo is ready one infra-admin will need to tweak https://github.com/organizations/rust-lang/settings/installations/57677614 to install the app in the new repo too