### PR TITLE
gws: add diff for google accounts

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -26,6 +26,15 @@ pub struct Team {
     pub github: Option<TeamGitHub>,
     pub website_data: Option<TeamWebsite>,
     pub roles: Vec<MemberRole>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub google_workspace_saml_group: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GoogleWorkspace {
+    pub first_name: String,
+    pub last_name: String,
+    pub account_handle: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -36,6 +45,8 @@ pub struct TeamMember {
     pub is_lead: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub roles: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub google_workspace: Option<GoogleWorkspace>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,13 @@ mod static_api;
 mod sync;
 mod validate;
 
-const AVAILABLE_SERVICES: &[&str] = &["github", "mailgun", "zulip", "crates-io"];
+const AVAILABLE_SERVICES: &[&str] = &[
+    "github",
+    "google-workspace",
+    "mailgun",
+    "zulip",
+    "crates-io",
+];
 
 const USER_AGENT: &str = "https://github.com/rust-lang/team (infra@rust-lang.org)";
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -76,13 +76,22 @@ pub(crate) struct Funding {
     github_sponsors: bool,
 }
 
-#[allow(dead_code)]
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct GoogleWorkspace {
-    first_name: String,
-    last_name: String,
-    account_handle: String,
+    pub first_name: String,
+    pub last_name: String,
+    pub account_handle: String,
+}
+
+impl From<GoogleWorkspace> for rust_team_data::v1::GoogleWorkspace {
+    fn from(gws: GoogleWorkspace) -> Self {
+        rust_team_data::v1::GoogleWorkspace {
+            first_name: gws.first_name,
+            last_name: gws.last_name,
+            account_handle: gws.account_handle,
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -157,8 +166,8 @@ impl Person {
         &self.permissions
     }
 
-    pub(crate) fn google_workspace(&self) -> &Option<GoogleWorkspace> {
-        &self.google_workspace
+    pub(crate) fn google_workspace(&self) -> Option<&GoogleWorkspace> {
+        self.google_workspace.as_ref()
     }
 
     pub(crate) fn validate(&self) -> Result<(), Error> {
@@ -194,7 +203,6 @@ impl std::fmt::Display for TeamKind {
     }
 }
 
-#[allow(dead_code)]
 #[derive(serde::Deserialize, Debug)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub(crate) struct Team {

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -7,7 +7,9 @@ use anyhow::{Context as _, Error, ensure};
 use indexmap::IndexMap;
 use log::info;
 use rust_team_data::v1;
-use rust_team_data::v1::{BranchProtectionMode, Crate, CrateTeamOwner, RepoMember};
+use rust_team_data::v1::{
+    BranchProtectionMode, Crate, CrateTeamOwner, GoogleWorkspace, RepoMember,
+};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -531,14 +533,18 @@ fn convert_teams<'a>(
 
         let leads = team.leads();
         let mut members = Vec::new();
-        for github_name in &team.members(data)? {
+        for github_name in team.members(data)? {
             if let Some(person) = data.person(github_name) {
                 members.push(v1::TeamMember {
                     name: person.name().into(),
                     github: (*github_name).into(),
                     github_id: person.github_id(),
                     is_lead: leads.contains(github_name),
-                    roles: website_roles.get(*github_name).cloned().unwrap_or_default(),
+                    roles: website_roles.get(github_name).cloned().unwrap_or_default(),
+                    google_workspace: person
+                        .google_workspace()
+                        .cloned()
+                        .map(GoogleWorkspace::from),
                 });
             }
         }
@@ -557,6 +563,10 @@ fn convert_teams<'a>(
                         .get(alum.github.as_str())
                         .cloned()
                         .unwrap_or_default(),
+                    google_workspace: person
+                        .google_workspace()
+                        .cloned()
+                        .map(GoogleWorkspace::from),
                 });
             }
         }
@@ -606,6 +616,7 @@ fn convert_teams<'a>(
                     description: role.description.clone(),
                 })
                 .collect(),
+            google_workspace_saml_group: team.google_workspace_saml_group(),
         };
         team_map.insert(team.name().into(), team_data);
     }

--- a/src/sync/github/tests/test_utils.rs
+++ b/src/sync/github/tests/test_utils.rs
@@ -287,6 +287,7 @@ impl From<TeamData> for v1::Team {
             github: (!gh_teams.is_empty()).then_some(TeamGitHub { teams: gh_teams }),
             website_data: None,
             roles: vec![],
+            google_workspace_saml_group: None,
         }
     }
 }

--- a/src/sync/gws/api.rs
+++ b/src/sync/gws/api.rs
@@ -1,0 +1,41 @@
+use crate::sync::gws::RUST_LANG_GWS_DOMAIN;
+use async_trait::async_trait;
+use rust_team_data::v1::GoogleWorkspace;
+
+/// https://developers.google.com/workspace/admin/directory/reference/rest/v1/groups
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Group {
+    pub name: String,
+    pub email: String,
+}
+
+/// https://developers.google.com/workspace/admin/directory/reference/rest/v1/users#UserName
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct UserName {
+    pub given_name: String,
+    pub family_name: String,
+}
+
+/// https://developers.google.com/workspace/admin/directory/reference/rest/v1/users
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct User {
+    pub name: UserName,
+    pub primary_email: String,
+}
+
+impl From<&GoogleWorkspace> for User {
+    fn from(gws: &GoogleWorkspace) -> Self {
+        Self {
+            primary_email: format!("{}@{}", gws.account_handle, RUST_LANG_GWS_DOMAIN),
+            name: UserName {
+                given_name: gws.first_name.to_string(),
+                family_name: gws.last_name.to_string(),
+            },
+        }
+    }
+}
+
+#[async_trait]
+pub(crate) trait GoogleWorkspaceApiClient {
+    async fn get_users(&self) -> anyhow::Result<Vec<User>>;
+}

--- a/src/sync/gws/mod.rs
+++ b/src/sync/gws/mod.rs
@@ -1,0 +1,275 @@
+mod api;
+
+use crate::sync::gws::api::{GoogleWorkspaceApiClient, Group, User};
+use std::collections::BTreeSet;
+use std::fmt::Debug;
+
+pub(crate) const RUST_LANG_GWS_DOMAIN: &str = "rust-lang.org";
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub(crate) enum GoogleGroupDiff {
+    Create(Group),
+    Delete(Group),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub(crate) enum GoogleUserDiff {
+    Create(User),
+    Delete(User),
+}
+
+/// A diff between the team repo and the state on Google Workspace
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct GoogleWorkspaceDiff {
+    google_groups: Vec<GoogleGroupDiff>,
+    google_users: Vec<GoogleUserDiff>,
+}
+
+/// The engine that evaluates diffs between our current configuration and
+/// the actual state in Google Workspace
+#[allow(dead_code)]
+pub(crate) struct SyncGoogleWorkspace {
+    actual_users: Vec<User>,
+    configured_teams: Vec<rust_team_data::v1::Team>,
+}
+
+#[allow(dead_code)]
+impl SyncGoogleWorkspace {
+    pub async fn new(
+        teams: Vec<rust_team_data::v1::Team>,
+        gws_api_client: Box<dyn GoogleWorkspaceApiClient>,
+    ) -> anyhow::Result<Self> {
+        let gws_users = gws_api_client.get_users().await?;
+        let sync = Self {
+            actual_users: gws_users,
+            configured_teams: teams,
+        };
+        Ok(sync)
+    }
+
+    pub(crate) fn diff_all(&self) -> anyhow::Result<GoogleWorkspaceDiff> {
+        let google_groups_diff = self.diff_groups()?;
+        let google_accounts_diff = self.diff_users()?;
+
+        let diff = GoogleWorkspaceDiff {
+            google_groups: google_groups_diff,
+            google_users: google_accounts_diff,
+        };
+        Ok(diff)
+    }
+
+    fn diff_groups(&self) -> anyhow::Result<Vec<GoogleGroupDiff>> {
+        Ok(vec![])
+    }
+
+    fn diff_users(&self) -> anyhow::Result<Vec<GoogleUserDiff>> {
+        let declared_users = self
+            .configured_teams
+            .iter()
+            .filter(|team| team.google_workspace_saml_group.unwrap_or_default())
+            .flat_map(|team| team.members.iter())
+            .filter_map(|member| member.google_workspace.as_ref().map(User::from))
+            .collect::<BTreeSet<_>>();
+
+        let declared_emails = declared_users
+            .iter()
+            .map(|user| user.primary_email.as_str())
+            .collect::<BTreeSet<_>>();
+
+        let actual_emails = self
+            .actual_users
+            .iter()
+            .map(|user| user.primary_email.as_str())
+            .collect::<BTreeSet<_>>();
+
+        let diffs = declared_users
+            .iter()
+            .filter(|u| !actual_emails.contains(u.primary_email.as_str()))
+            .map(|u| GoogleUserDiff::Create(u.clone()))
+            .chain(
+                self.actual_users
+                    .iter()
+                    .filter(|u| !declared_emails.contains(u.primary_email.as_str()))
+                    .map(|u| GoogleUserDiff::Delete(u.clone())),
+            )
+            .collect();
+
+        Ok(diffs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    pub mod rust_team_data_fakes {
+        use rust_team_data::v1::{GoogleWorkspace, Team, TeamKind, TeamMember};
+
+        pub fn normal_member(name: &str) -> TeamMember {
+            TeamMember {
+                name: name.into(),
+                github: name.into(),
+                github_id: 1234567,
+                is_lead: false,
+                roles: vec![],
+                google_workspace: None,
+            }
+        }
+
+        pub fn privileged_member(name: &str, surname: &str) -> TeamMember {
+            TeamMember {
+                google_workspace: Some(GoogleWorkspace {
+                    first_name: name.into(),
+                    last_name: surname.into(),
+                    account_handle: format!("{name}.{surname}"),
+                }),
+                ..normal_member(name)
+            }
+        }
+
+        pub fn normal_team(name: &str, members: Vec<TeamMember>) -> Team {
+            Team {
+                kind: TeamKind::Team,
+                name: name.to_string(),
+                github: None,
+                website_data: None,
+                subteam_of: None,
+                top_level: Some(true),
+                alumni: vec![],
+                roles: vec![],
+                google_workspace_saml_group: None,
+                members,
+            }
+        }
+
+        pub fn privileged_team(name: &str, members: Vec<TeamMember>) -> Team {
+            Team {
+                google_workspace_saml_group: Some(true),
+                ..normal_team(name, members)
+            }
+        }
+    }
+
+    use crate::sync::gws::api::{GoogleWorkspaceApiClient, User, UserName};
+    use crate::sync::gws::tests::rust_team_data_fakes::{privileged_member, privileged_team};
+    use crate::sync::gws::{
+        GoogleUserDiff, GoogleWorkspaceDiff, RUST_LANG_GWS_DOMAIN, SyncGoogleWorkspace,
+    };
+    use async_trait::async_trait;
+    use rust_team_data::v1::Team;
+
+    struct FakeGoogleWorkspace {
+        users: Vec<User>,
+    }
+
+    #[async_trait]
+    impl GoogleWorkspaceApiClient for FakeGoogleWorkspace {
+        async fn get_users(&self) -> anyhow::Result<Vec<User>> {
+            Ok(self.users.clone())
+        }
+    }
+
+    fn google_user(name: &str, surname: &str) -> User {
+        User {
+            name: UserName {
+                given_name: name.into(),
+                family_name: surname.into(),
+            },
+            primary_email: format!("{name}.{surname}@{RUST_LANG_GWS_DOMAIN}"),
+        }
+    }
+
+    async fn run_sync(
+        gws_api_client: Box<dyn GoogleWorkspaceApiClient>,
+        teams: Vec<Team>,
+    ) -> GoogleWorkspaceDiff {
+        let sync = SyncGoogleWorkspace::new(teams, gws_api_client)
+            .await
+            .expect("cannot create sync");
+
+        let google_users_diff = sync.diff_users().expect("cannot diff accounts");
+        let google_groups_diff = sync.diff_groups().expect("cannot diff groups");
+        GoogleWorkspaceDiff {
+            google_users: google_users_diff,
+            google_groups: google_groups_diff,
+        }
+    }
+
+    fn fake_gws_client(users: Vec<User>) -> Box<dyn GoogleWorkspaceApiClient> {
+        let fake_gws = FakeGoogleWorkspace { users };
+        Box::new(fake_gws)
+    }
+
+    #[tokio::test]
+    async fn diff_spots_nothing() {
+        let google_users = vec![
+            google_user("ubiratan", "soares"),
+            google_user("marco", "ieni"),
+        ];
+
+        let teams = vec![privileged_team(
+            "infra-admins",
+            vec![
+                privileged_member("ubiratan", "soares"),
+                privileged_member("marco", "ieni"),
+            ],
+        )];
+
+        let gws_api_client = fake_gws_client(google_users);
+
+        let diff = run_sync(gws_api_client, teams).await;
+        assert!(diff.google_users.is_empty());
+        assert!(diff.google_groups.is_empty());
+    }
+
+    #[tokio::test]
+    async fn diff_spots_user_creation() {
+        let google_users = vec![
+            google_user("ubiratan", "soares"),
+            google_user("marco", "ieni"),
+        ];
+
+        let teams = vec![privileged_team(
+            "infra-admins",
+            vec![
+                privileged_member("ubiratan", "soares"),
+                privileged_member("marco", "ieni"),
+                privileged_member("emily", "albini"),
+            ],
+        )];
+
+        let gws_api_client = fake_gws_client(google_users);
+
+        let diff = run_sync(gws_api_client, teams).await;
+        let expected = vec![GoogleUserDiff::Create(google_user("emily", "albini"))];
+
+        assert_eq!(diff.google_users, expected);
+        assert!(diff.google_groups.is_empty());
+    }
+
+    #[tokio::test]
+    async fn diff_spots_user_deletion() {
+        let google_users = vec![
+            google_user("ubiratan", "soares"),
+            google_user("marco", "ieni"),
+            google_user("emily", "albini"),
+        ];
+
+        let teams = vec![privileged_team(
+            "infra-admins",
+            vec![privileged_member("emily", "albini")],
+        )];
+
+        let gws_api_client = fake_gws_client(google_users);
+
+        let diff = run_sync(gws_api_client, teams).await;
+        let expected = vec![
+            GoogleUserDiff::Delete(google_user("ubiratan", "soares")),
+            GoogleUserDiff::Delete(google_user("marco", "ieni")),
+        ];
+
+        assert_eq!(diff.google_users, expected);
+        assert!(diff.google_groups.is_empty());
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,5 +1,6 @@
 mod crates_io;
 mod github;
+mod gws;
 mod mailgun;
 pub mod team_api;
 pub mod utils;
@@ -77,6 +78,9 @@ pub async fn run_sync_team(
                 if !only_print_plan {
                     diff.apply(&sync).await?;
                 }
+            }
+            "google-workspace" => {
+                println!("google-workspace: nothing to diff");
             }
             _ => panic!("unknown service: {service}"),
         }


### PR DESCRIPTION
First PR to enable diffs betwen our configuration and Google Workspace state. 

The whole feature would be a much bigger PR, so I decided to split it. This PR looks big but it brings a non negletable amount of boilterplate, so hopefully it is not hard to read. I hope the code style is familiar enough compared with other services we also diff and sync.

For now, this PR adds support for diffing google workspace **_users_**, supporting `creation` and `deletion` operations. Everything is still detached from the app entrypoint, and integration will come after we are able to run live dry-runs in CI (which requires further configuration on Github Actions).

To make it sure we can define and safely test some rules we want to encode as part of the diff logic, I added a fake GWS API similar approach similar to what we use in `github`. 

Towards #2363 