### PR TITLE
Give crater permissions to the triage team

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -42,6 +42,9 @@ members = [
 ]
 alumni = []
 
+[permissions]
+crater = true
+
 [website]
 name = "Triage Team"
 description = "Triaging repositories under the rust-lang organisation"


### PR DESCRIPTION
We in the release team have appreciated the triage team's help with beta crater reports, especially @theemathas, and they may do more with the ability to queue crater jobs themselves.

r? @Mark-Simulacrum 