### PR TITLE
Add `senekor` as Rustlings maintainer

### DIFF
--- a/teams/rustlings.toml
+++ b/teams/rustlings.toml
@@ -6,14 +6,17 @@ leads = ["mo8it", "manyinsects"]
 members = [
     "manyinsects",
     "mo8it",
+    "senekor",
 ]
-alumni = []
+alumni = [
+    "carols10cents",
+]
 
 [[github]]
 orgs = ["rust-lang"]
 
 [website]
 name = "Rustlings team"
-description = "Maintaining and updating the Rustlings course"
-repo = "https://github.com/rust-lang/rustlings/"
+description = "Maintaining the Rustlings course"
+repo = "https://github.com/rust-lang/rustlings"
 zulip-stream = "t-lang/rustlings"


### PR DESCRIPTION
I would like to make @senekor as a maintainer. He contributes a lot to Rustlings :)

I also added @carols10cents as an alumni. I don't know why she isn't on that list yet :D