### PR TITLE
Add theemathas to T-release

### DIFF
--- a/teams/release.toml
+++ b/teams/release.toml
@@ -9,6 +9,7 @@ members = [
     "Mark-Simulacrum",
     "emilyalbini",
     "BoxyUwU",
+    "theemathas",
 ]
 alumni = [
     "alexcrichton",


### PR DESCRIPTION
@theemathas has been helping for the last few release cycles with Crater triage, adding them to the team to recognize that work. Thanks!

Largely replaces https://github.com/rust-lang/team/pull/2449 (I still think that would make some sense but it removes immediate need/concern for it).