### PR TITLE
Configure `T-bootstrap` to use FCP

### DIFF
--- a/teams/bootstrap.toml
+++ b/teams/bootstrap.toml
@@ -21,6 +21,11 @@ perf = true
 dev-desktop = true
 bors.rust.review = true
 
+[rfcbot]
+label = "T-bootstrap"
+name = "Bootstrap"
+ping = "rust-lang/bootstrap"
+
 [[github]]
 orgs = ["rust-lang"]
 


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/rust-forge/pull/1040#issuecomment-4438100535.

(I'm not actually sure if this is sufficient to allow T-bootstrap to use FCP?)

cc @Mark-Simulacrum (bootstrap lead)
FYI @rust-lang/bootstrap 