### PR TITLE
add yocto ping group

### DIFF
--- a/teams/yocto.toml
+++ b/teams/yocto.toml
@@ -1,0 +1,14 @@
+name = "yocto"
+kind = "marker-team"
+
+# This marker team is for Rust project members that are interested in helping with issues related
+# to Yocto's distribution of Rust
+
+[people]
+leads = []
+members = [
+  "davidtwco"
+]
+
+[[github]]
+orgs = ["rust-lang"]


### PR DESCRIPTION
I've been working with developers from [the Yocto project](https://www.yoctoproject.org/) to help them resolve some issues they have in distributing Rust - see [#yocto](https://rust-lang.zulipchat.com/#narrow/channel/557100-yocto) on Zulip. I want to add a ping group so that when they report issues, they can do `@rustbot ping yocto` and I'll get notified (as well as anyone else who'd like to help).