### PR TITLE
stepping back as lang-team lead

### DIFF
--- a/teams/lang.toml
+++ b/teams/lang.toml
@@ -3,7 +3,6 @@ top-level = true
 
 [people]
 leads = [
-    "nikomatsakis",
     "tmandry",
 ]
 members = [


### PR DESCRIPTION
I've decided that the time has come to step back from @rust-lang/lang leadership. @tmandry will continue on as the lang team lead. In my time working with him, I have found that @tmandry consistently brings great insight both on technical matters and (crucially for a lead) on team dynamics. I'm looking forward to seeing what he does as lang team lead going forward!

I've been leading the lang team since it was first created in 2015. Back in those days I honestly never expected Rust to be powering multiple clouds or used in the Linux kernel. It's been so cool to watch and be a part of that journey. It also feels like a good time to hand off the reins to someone else.

I don't plan to disappear entirely, but I do want to shift my focus significantly. My top priority right now is helping to set the org up for success when it comes to scale. I care a lot about how the org connects with our users and shapes our biggest priorities, and I want to see us have a solid funding story for both the Rust project and the many awesome crates that have made Rust such a success. I still expect to drive the occasional lang feature but I am planning to wind down that side of things more and more.

So long, and thanks for all the crabs!