### PR TITLE
Add types team to rust-forge repo

### DIFF
--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -21,6 +21,7 @@ edition = "maintain"
 release = "maintain"
 rustdoc = "maintain"
 triagebot = "maintain"
+types = "maintain"
 rustc-dev-guide = "maintain"
 
 [[rulesets]]


### PR DESCRIPTION
For what it's worth, I have absolutely no authority to make this change and want to underline that I'm only doing this to promote a discussion.

Since rust-lang/rust-forge#1040 was limited to collaborators, but the FCP includes the types team, I noted that the types team is not actually included in the list of people who count as maintainers for that repo. It makes sense to include them even though it's likely all the relevant people are already on at least one of the other teams required to have access. It's just that the PR got heated enough to need to be locked down, and I want to make sure everyone who does have a stake in the discussion can do so.