### PR TITLE
Fix `funding` repo URL and give `funding` team write access instead of LC

### DIFF
--- a/repos/rust-lang/funding.toml
+++ b/repos/rust-lang/funding.toml
@@ -4,4 +4,4 @@ description = "Discussions about funding Rust maintainers"
 bots = ["rfcbot"]
 
 [access.teams]
-leadership-council = "write"
+funding = "write"

--- a/teams/funding.toml
+++ b/teams/funding.toml
@@ -6,7 +6,7 @@ name = "Funding team"
 description = "Helping to get Rust maintainers funded"
 email = "funding@rust-lang.org"
 zulip-stream = "funding"
-repo = "https://github.com/rust-lang/rust-project-goals"
+repo = "https://github.com/rust-lang/funding/"
 
 [people]
 leads = [


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/team/pull/2468#pullrequestreview-4320324997