### PR TITLE
Add folkertdev to crate-maintainers

### DIFF
--- a/teams/crate-maintainers.toml
+++ b/teams/crate-maintainers.toml
@@ -19,6 +19,7 @@ members = [
     "Kobzol",
     "NobodyXu",
     "madsmtm",
+    "folkertdev",
 ]
 alumni = []
 


### PR DESCRIPTION
Folkert has been doing great work in the ecosystem on
zlib-rs, flate2, libz-sys, and libz-ng-sys.

Proposal being discussed in libs, waiting for confirmation by @Amanieu.
