### PR TITLE
Add self to wg-secure-code

### DIFF
--- a/teams/wg-secure-code.toml
+++ b/teams/wg-secure-code.toml
@@ -10,6 +10,7 @@ members = [
     "alex",
     "amousset",
     "djc",
+    "LawnGnome",
 ]
 alumni = [
     "danielhenrymantilla",


### PR DESCRIPTION
@djc didn't scream *too* loudly when I asked about this at the All Hands, but ping @Shnatsel and/or @tarcieri for their thoughts. Just felt a little weird to be talking about RustSec things as a new contributor while not actually being a member of the associated working group.