### PR TITLE
@JayanAXHF is the new point of contact for manually-drop-attr goal

### DIFF
--- a/teams/goal-owners.toml
+++ b/teams/goal-owners.toml
@@ -24,6 +24,7 @@ members = [
     "icmccorm",
     "jackh726",
     "jakos-sec",
+    "JayanAXHF",
     "jchlanda",
     "JoelMarcey",
     "JohnTitor",


### PR DESCRIPTION
https://github.com/rust-lang/rust-project-goals/pull/661 makes @JayanAXHF the new Point of Contact for the manually-drop-attr goal.

Adding him to goal-owners so he can post updates there.