### PR TITLE
add rustbot to project-const-generics

### DIFF
--- a/repos/rust-lang/project-const-generics.toml
+++ b/repos/rust-lang/project-const-generics.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "project-const-generics"
 description = ""
 homepage = "https://rust-lang.github.io/project-const-generics/"
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 project-const-generics = "maintain"


### PR DESCRIPTION
from [zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/rustbot.20assign.20in.20project-const-generics.20repo):

> Urgau: Triagebot is missing the appropriate permissions to assign people in https://github.com/rust-lang/team/blob/e5be6da8fd5a87f5e8e0d7907a32d596c19dc020/repos/rust-lang/project-const-generics.toml#L5
> Urgau: The bot array should have "rustbot" in it.