### PR TITLE
Remove typo-ed member of the mentees team

### DIFF
--- a/teams/mentees.toml
+++ b/teams/mentees.toml
@@ -6,7 +6,6 @@ kind = "marker-team"
 leads = []
 members = [
     # GSoC
-    { github = "Zoxc", roles = ["gsoc"] },
     { github = "Sa4dUs", roles = ["gsoc"] },
     { github = "lapla-cogito", roles = ["gsoc"] },
     { github = "Shourya742", roles = ["gsoc"] },


### PR DESCRIPTION
Zoxc isn't a part of GSoC, I probably copy-pasted this line from somewhere by accident when restructuring the team, sorry.
