### PR TITLE
Add teor to cloud-compute team

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -25,6 +25,7 @@ members = [
     "reddevilmidzy",
     "ShoyuVanilla",
     "addiesh",
+    "teor2345",
 ]
 
 alumni = [


### PR DESCRIPTION
I am currently working on the [splat compiler experiment](https://github.com/rust-lang/rust/issues/153629), and I am a C++ interop contractor for the Rust Foundation.

Usually I use my Mac laptop or home Linux server for development. But it would be great to have an alternative when I'm travelling, or those machines are otherwise not working for a specific task.

For example, splat needs to change codegen and maybe debugging, but I haven't been able to get the debug symbols tests to run on my current devices.