### PR TITLE
create crabwatch repository

### DIFF
--- a/repos/rust-lang/crabwatch.toml
+++ b/repos/rust-lang/crabwatch.toml
@@ -1,0 +1,7 @@
+org = "rust-lang"
+name = "crabwatch"
+description = "Analyze Rust project repositories CI and best practices"
+bots = []
+
+[access.teams]
+infra = "write"


### PR DESCRIPTION
Tool to address https://github.com/rust-lang/infra-team/issues/260

Initially it will run zizmor locally on all rust repositories.
The infra team will use it to discover what zizmor lints fail in what repositories.

Maybe the infra team will also use this tool to also enforce that the zizmor lints don't fail again after they have been fixed.