### PR TITLE
add assumptions on binders project & repo

### DIFF
--- a/repos/rust-lang/project-assumptions-on-binders.toml
+++ b/repos/rust-lang/project-assumptions-on-binders.toml
@@ -1,0 +1,12 @@
+org = "rust-lang"
+name = "project-assumptions-on-binders"
+description = ""
+homepage = "https://rust-lang.github.io/project-assumptions-on-binders/"
+bots = ["rustbot"]
+
+[access.teams]
+project-assumptions-on-binders = "maintain"
+all = "write"
+
+[environments.github-pages]
+

--- a/teams/assumptions-on-binders.toml
+++ b/teams/assumptions-on-binders.toml
@@ -1,0 +1,24 @@
+name = "project-assumptions-on-binders"
+kind = "project-group"
+subteam-of = "types"
+
+[people]
+leads = ["BoxyUwU", "lcnr"]
+members = [
+    "BoxyUwU",
+    "lcnr",
+]
+alumni = []
+
+[website]
+name = "Assumptions on Binders Project Group"
+description = "Working to support where clauses on `for<'a>` in the Rust language"
+repo = "https://github.com/rust-lang/project-assumptions-on-binders"
+zulip-stream = "T-types/assumptions-on-binders"
+
+[[github]]
+orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "project-assumptions-on-binders"
+


### PR DESCRIPTION
cc https://rust-lang.github.io/rust-project-goals/2026/assumptions_on_binders.html

I want a repo so I can store design docs/misc thoughts and also track all the high level bits of work and goals that are covered under this work. Not sure who exactly should sign off on this :sparkles: I don't know that actually creating the associated team is useful? I just did so so that if/when other contributors start working on this they can get shoved into a group to recognise that :thinking: 

cc @lcnr