### PR TITLE
update const generics stuff

### DIFF
--- a/people/LaneAsade.toml
+++ b/people/LaneAsade.toml
@@ -1,0 +1,4 @@
+name = "LaneAsade"
+github = "LaneAsade"
+github-id = 195121679
+zulip-id = 983842

--- a/people/khyperia.toml
+++ b/people/khyperia.toml
@@ -1,0 +1,4 @@
+name = "Ashley Hauck"
+github = "khyperia"
+github-id = 953151
+zulip-id = 330900

--- a/repos/rust-lang/project-const-generics.toml
+++ b/repos/rust-lang/project-const-generics.toml
@@ -6,6 +6,7 @@ bots = ["rustbot"]
 
 [access.teams]
 project-const-generics = "maintain"
+all = "write"
 
 [environments.github-pages]
 

--- a/teams/project-const-generics-triage.toml
+++ b/teams/project-const-generics-triage.toml
@@ -1,0 +1,23 @@
+name = "project-const-generics-triage"
+kind = "project-group"
+subteam-of = "project-const-generics"
+
+[people]
+leads = ["BoxyUwU"]
+members = [
+    "BoxyUwU",
+    "khyperia",
+    "zedddie",
+    "LaneAsade",
+    "reddevilmidzy",
+]
+alumni = []
+
+[website]
+name = "Const Generics Project Group Triage"
+description = "People working on const generics who need triage access to the const generics repo"
+repo = "https://github.com/rust-lang/project-const-generics"
+zulip-stream = "project-const-generics"
+
+[[github]]
+orgs = ["rust-lang"]

--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -26,3 +26,19 @@ zulip-stream = "project-const-generics"
 
 [[github]]
 orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "project-const-generics"
+
+[[zulip-groups]]
+name = "project-const-generics/talkies"
+include-team-members = false
+extra-people = [
+    "BoxyUwU",
+    "camelid",
+    "khyperia",
+    "zedddie",
+    "LaneAsade",
+    "redddy",
+]
+

--- a/teams/project-const-generics.toml
+++ b/teams/project-const-generics.toml
@@ -39,6 +39,6 @@ extra-people = [
     "khyperia",
     "zedddie",
     "LaneAsade",
-    "redddy",
+    "reddevilmidzy",
 ]
 


### PR DESCRIPTION
adds a const generics triage team so that I can give rights to people to edit issues and whatnot in the project-const-generics repo without them being on compiler/other teams. also loosens the restrictions on the project-const-generics repo to be more permissive to the org as a whole not just people on the project group

cc @lcnr