### PR TITLE
Add branch protection ruleset for crabwatch

### DIFF
--- a/repos/rust-lang/crabwatch.toml
+++ b/repos/rust-lang/crabwatch.toml
@@ -5,3 +5,9 @@ bots = []
 
 [access.teams]
 infra = "write"
+
+[[rulesets]]
+pattern = "main"
+ci-checks = ["CI"]
+required-approvals = 0
+


### PR DESCRIPTION
Added  `[[rulesets]]` block to `crabwatch.toml` to protect the `main` branch.
The ruleset enforces:
- CI job named `CI` must pass before merge.
- At least 1 approving review required.
- Reviews are dismissed when new commits are pushed after approval.
- All PR review threads must be resolved before merge.
closes:  https://github.com/rust-lang/crabwatch/issues/4