### PR TITLE
add a Dictionary Passing Project Group

### DIFF
--- a/repos/rust-lang/project-dictionary-passing.toml
+++ b/repos/rust-lang/project-dictionary-passing.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "project-dictionary-passing"
+description = ""
+homepage = "https://rust-lang.github.io/project-dictionary-passing/"
+bots = ["rustbot"]
+
+[access.teams]
+project-dictionary-passing = "maintain"
+all = "write"
+
+[environments.github-pages]

--- a/teams/assumptions-on-binders.toml
+++ b/teams/assumptions-on-binders.toml
@@ -14,7 +14,7 @@ alumni = []
 name = "Assumptions on Binders Project Group"
 description = "Working to support where clauses on `for<'a>` in the Rust language"
 repo = "https://github.com/rust-lang/project-assumptions-on-binders"
-zulip-stream = "T-types/assumptions-on-binders"
+zulip-stream = "t-types/assumptions-on-binders"
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/project-dictionary-passing.toml
+++ b/teams/project-dictionary-passing.toml
@@ -16,7 +16,7 @@ alumni = []
 name = "Meta-language Dictionary Passing Working Group"
 description = "Modelling the trait system and cycle handling via meta-language dictionary passing"
 repo = "https://github.com/rust-lang/project-dictionary-passing"
-zulip-stream = "T-types/dictionary-passing"
+zulip-stream = "t-types/dictionary-passing"
 
 [[github]]
 orgs = ["rust-lang"]

--- a/teams/project-dictionary-passing.toml
+++ b/teams/project-dictionary-passing.toml
@@ -1,0 +1,25 @@
+name = "project-dictionary-passing"
+kind = "project-group"
+subteam-of = "types"
+
+[people]
+leads = ["lcnr"]
+members = [
+    "lcnr",
+    "Nadrieril",
+    "nikomatsakis",
+    "BennoLossin"
+]
+alumni = []
+
+[website]
+name = "Meta-language Dictionary Passing Working Group"
+description = "Modelling the trait system and cycle handling via meta-language dictionary passing"
+repo = "https://github.com/rust-lang/project-dictionary-passing"
+zulip-stream = "T-types/dictionary-passing"
+
+[[github]]
+orgs = ["rust-lang"]
+
+[[zulip-groups]]
+name = "project-dictionary-passing"


### PR DESCRIPTION
Mainly to have a separate zulip stream and to more easily collect the open problems and interesting tests/edge-cases in github issues

cc @rust-lang/types @Nadrieril @nikomatsakis @BennoLossin 