### PR TITLE
Add `rust-lang/std-replacement-data` repo

### DIFF
--- a/repos/rust-lang/std-replacement-data.toml
+++ b/repos/rust-lang/std-replacement-data.toml
@@ -1,0 +1,11 @@
+org = "rust-lang"
+name = "std-replacement-data"
+description = "Curated dataset of standard-library replacements for crates, surfaced on crates.io"
+bots = ["renovate"]
+
+[access.teams]
+crates-io = "write"
+
+[[rulesets]]
+pattern = "main"
+required-approvals = 0


### PR DESCRIPTION
This creates a new `rust-lang/std-replacement-data` repo owned by the crates.io team. It will host the curated standard-library replacement dataset that currently lives inside the crates.io codebase (added in rust-lang/crates.io#13855), so the data can be maintained and contributed to independently of the application. This addresses https://github.com/rust-lang/crates.io/pull/13855#issuecomment-4638182013.

Review setup mirrors `crates.io`: the `crates-io` team has `write` access and the `main` ruleset requires no approvals. No CI checks are configured yet. They'll be added once workflows exist. The only bot is `renovate`.

r? @rust-lang/infra 