### PR TITLE
Change `lang-team` default branch to `main`

### DIFF
--- a/repos/rust-lang/lang-team.toml
+++ b/repos/rust-lang/lang-team.toml
@@ -12,5 +12,5 @@ types = "maintain"
 release = "maintain"
 
 [environments.github-pages]
-branches = ["gh-pages", "master"]
+branches = ["gh-pages", "main"]
 


### PR DESCRIPTION
Requested in https://github.com/rust-lang/infra-team/issues/270.

Only CI relevant seems to be GH pages environment.

The deploy workflow already hedges against `master` vs `main`, cf. <https://github.com/rust-lang/lang-team/blob/11beedc287edaacb33d77fa18340c0ac097e5ece/.github/workflows/deploy.yml#L35>.

`lang-team` default branch references are updated in https://github.com/rust-lang/lang-team/pull/376.