### PR TITLE
rust-lang/rust: Enable `forking-renovate` bot

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "rust"
 description = "Empowering everyone to build reliable and efficient software."
 homepage = "https://www.rust-lang.org"
-bots = ["bors", "craterbot", "glacierbot", "log-analyzer", "rustbot", "rfcbot", "rust-timer", "datadog"]
+bots = ["bors", "craterbot", "forking-renovate", "glacierbot", "log-analyzer", "rustbot", "rfcbot", "rust-timer", "datadog"]
 
 [access.teams]
 bootstrap = "write"


### PR DESCRIPTION
This enables Renovate to pin GitHub Actions to SHAs and keep them up-to-date.

See https://github.com/rust-lang/rust/pull/155089#issuecomment-4262931121

r? @marcoieni 