### PR TITLE
add sandijigs to cloud-compute

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -27,6 +27,7 @@ members = [
     "addiesh",
     "teor2345",
     "Human9000-bit",
+    "Sandijigs",
 ]
 
 alumni = [


### PR DESCRIPTION
Adding myself to the cloud-compute team for dev desktop access. I'm an Outreachy intern working on crabwatch (CI security analysis tooling for rust-lang repos).The dev desktop would help me build and test the tool more easily.