### PR TITLE
allow publishing rustdoc-types via tags

### DIFF
--- a/repos/rust-lang/rustdoc-types.toml
+++ b/repos/rust-lang/rustdoc-types.toml
@@ -8,9 +8,10 @@ rustdoc = "write"
 
 [environments.publish]
 branches = ["trunk"]
+# Matches the `on:` rule of `release.yml`
+tags = ["v*"]
 
 [[crates-io]]
 crates = ["rustdoc-types"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
-


### PR DESCRIPTION
Publishing failed:
https://github.com/rust-lang/rustdoc-types/actions/runs/27799666854
<img width="2102" height="1522" alt="image" src="https://github.com/user-attachments/assets/2aa9989e-071b-4391-bacb-a70a4af87c9b" />
