### PR TITLE
create funding advisors team

### DIFF
--- a/people/erikjee.toml
+++ b/people/erikjee.toml
@@ -1,0 +1,5 @@
+name = 'Erik Jonkers'
+github = 'erikjee'
+github-id = 6603364
+zulip-id = 607646
+email = "erik@tweedegolf.com"

--- a/people/jlizen.toml
+++ b/people/jlizen.toml
@@ -2,4 +2,4 @@ name = "Jess Izen"
 github = "jlizen"
 github-id = 44884346
 zulip-id = 783853
-email = "jlizen@amazon.com"
+email = "rust@jessizen.com"

--- a/people/jlizen.toml
+++ b/people/jlizen.toml
@@ -1,0 +1,3 @@
+name = "Jess Izen"
+github = "jlizen"
+github-id = 44884346

--- a/people/jlizen.toml
+++ b/people/jlizen.toml
@@ -1,3 +1,5 @@
 name = "Jess Izen"
 github = "jlizen"
 github-id = 44884346
+zulip-id = 783853
+email = "jlizen@amazon.com"

--- a/teams/funding-advisors.toml
+++ b/teams/funding-advisors.toml
@@ -19,5 +19,5 @@ description = "People coordinating closely with the Funding team"
 name = "T-funding-advisors"
 
 [[zulip-streams]]
-name = "t-funding/with-advisors"
+name = "funding/with-advisors"
 extra-teams = ["funding"]

--- a/teams/funding-advisors.toml
+++ b/teams/funding-advisors.toml
@@ -1,0 +1,21 @@
+name = "funding-advisors"
+subteam-of = "funding"
+
+[people]
+leads = []
+members = [
+    "jlizen",
+    "becrumbul",
+]
+alumni = []
+
+[website]
+name = "Funding advisors team"
+description = "People coordinating closely with the Funding team"
+
+[[zulip-groups]]
+name = "T-funding-advisors"
+
+[[zulip-streams]]
+name = "t-funding/with-advisors"
+extra-teams = ["funding"]

--- a/teams/funding-advisors.toml
+++ b/teams/funding-advisors.toml
@@ -6,6 +6,8 @@ leads = []
 members = [
     "jlizen",
     "becrumbul",
+    "m-ou-se",
+    "erikjee",
 ]
 alumni = []
 

--- a/teams/funding-advisors.toml
+++ b/teams/funding-advisors.toml
@@ -8,6 +8,7 @@ members = [
     "becrumbul",
     "m-ou-se",
     "erikjee",
+    "obi1kenobi",
 ]
 alumni = []
 

--- a/teams/funding.toml
+++ b/teams/funding.toml
@@ -33,6 +33,10 @@ name = "funding/private"
 
 [[lists]]
 address = "funding@rust-lang.org"
+extra-teams = ["funding-advisors"]
+
+[[lists]]
+address = "funding-private@rust-lang.org"
 
 [rfcbot]
 label = "T-funding"


### PR DESCRIPTION
Create a private `funding/with-advisors` stream and modify the `funding@` email alias to include the advisors; `funding-private@` can be used if we want narrow-cast.

To be discussed in our @rust-lang/funding meeting this morning.