### PR TITLE
repos/crates.io: enable Datadog GitHub App

### DIFF
--- a/repos/rust-lang/crates.io.toml
+++ b/repos/rust-lang/crates.io.toml
@@ -2,7 +2,7 @@ org = "rust-lang"
 name = "crates.io"
 description = "The Rust package registry"
 homepage = "https://crates.io"
-bots = ["renovate", "rustbot", "heroku-deploy-access"]
+bots = ["renovate", "rustbot", "heroku-deploy-access", "datadog"]
 
 [access.teams]
 crates-io = "write"


### PR DESCRIPTION
Adds the `datadog` bot to the crates.io repo so the org-level Datadog GitHub App is scoped to it.

Context: https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/datadog.20bot.20in.20team.20repo/with/604916992