### PR TITLE
Register rfcbot for Forge

### DIFF
--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -2,7 +2,7 @@ org = 'rust-lang'
 name = 'rust-forge'
 description = 'Information useful to people contributing to Rust'
 homepage = "https://forge.rust-lang.org/"
-bots = ["rustbot"]
+bots = ["rustbot", "rfcbot"]
 
 [access.teams]
 community = "maintain"


### PR DESCRIPTION
Since we do have a few FCPs going on there, and it'd be nice for the FCP labels to be  used.