### PR TITLE
Add missing `rustbot` to the `log` repository

### DIFF
--- a/repos/rust-lang/log.toml
+++ b/repos/rust-lang/log.toml
@@ -2,7 +2,7 @@ org = 'rust-lang'
 name = 'log'
 description = 'Logging implementation for Rust'
 homepage = "https://docs.rs/log"
-bots = []
+bots = ["rustbot"]
 
 [access.teams]
 crate-maintainers = 'maintain'


### PR DESCRIPTION
The `log` repo has had a [`triagebot.toml`](https://github.com/rust-lang/log/blob/master/triagebot.toml) for quite some time now, but never gave the permissions to rustbot/triagebot.

This is starting to cause some issues for triagebot as we have been trying to update some review comments for a few days. Let's fix the inconsistency by giving `rustbot` the permissions.