### PR TITLE
simpleinfra: Enable forking-renovate bot

### DIFF
--- a/repos/rust-lang/simpleinfra.toml
+++ b/repos/rust-lang/simpleinfra.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "simpleinfra"
 description = "Rust Infrastructure automation"
-bots = []
+bots = ["forking-renovate"]
 
 [access.teams]
 infra = "write"


### PR DESCRIPTION
The repo has no renovate.json yet, so enabling the bot will open an onboarding PR with a suggested config. This surfaces outdated dependencies, such as those in the Fastly Compute@Edge code for static.crates.io.

r? @rust-lang/infra 