### PR TITLE
Add Jonathan Brouwer to wg-compiler-performance

### DIFF
--- a/teams/wg-compiler-performance.toml
+++ b/teams/wg-compiler-performance.toml
@@ -12,6 +12,7 @@ members = [
     "Zoxc",
     "panstromek",
     "Jamesbarford",
+    "JonathanBrouwer"
 ]
 alumni = [
     "michaelwoerister",


### PR DESCRIPTION
Jonathan has been helping us a lot with triaging rollups and benchmark regressions, so I'd like to nominate Jonathan to become a member of the compiler performance working area.

CC @rust-lang/wg-compiler-performance