### PR TITLE
Require linear history in lang-team repo

### DIFF
--- a/repos/rust-lang/lang-team.toml
+++ b/repos/rust-lang/lang-team.toml
@@ -14,3 +14,6 @@ release = "maintain"
 [environments.github-pages]
 branches = ["gh-pages", "main"]
 
+[[rulesets]]
+pattern = "main"
+require-linear-history = true


### PR DESCRIPTION
We don't use bors, so all three options to merge a pull request appear. Historically PRs have used merge commits, but this was not enforced.

There's not a need for merge commits in a repo as simple as lang-team, and there's not an option to require them for consistency either. For simplicity, let's disallow future merge commits and keep a linear history.