### PR TITLE
Configure `std-replacement-data` GitHub Pages environment

### DIFF
--- a/repos/rust-lang/std-replacement-data.toml
+++ b/repos/rust-lang/std-replacement-data.toml
@@ -9,3 +9,5 @@ crates-io = "write"
 [[rulesets]]
 pattern = "main"
 required-approvals = 0
+
+[environments.github-pages]


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/team/pull/2541#issuecomment-4845830088

I *think* this is enough since `std-replacement-data` seems to build and deploy GH pages for pushes to the default branch?