### PR TITLE
ignore github-app zizmor lint

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,6 @@
 rules:
+  github-app:
+    disable: true
   dangerous-triggers:
     ignore:
       - dry-run.yml


### PR DESCRIPTION
This allows to update the zizmor github action.

Test this locally by running: `zizmor . --persona=pedantic`