### PR TITLE
Adds support for deleting GitHub Pages settings

### DIFF
--- a/repos/rust-analyzer/metrics.toml
+++ b/repos/rust-analyzer/metrics.toml
@@ -4,8 +4,12 @@ description = ""
 homepage = "https://rust-analyzer.github.io/metrics/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 rust-analyzer = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-analyzer/rust-analyzer.github.io.toml
+++ b/repos/rust-analyzer/rust-analyzer.github.io.toml
@@ -4,8 +4,12 @@ description = ""
 homepage = "https://rust-analyzer.github.io/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "master"
+path = "/"
+
 [access.teams]
 rust-analyzer = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang-nursery/lazy-static.rs.toml
+++ b/repos/rust-lang-nursery/lazy-static.rs.toml
@@ -3,8 +3,12 @@ name = "lazy-static.rs"
 description = "A small macro for defining lazy evaluated static variables in Rust."
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 libs = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang-nursery/rust-cookbook.toml
+++ b/repos/rust-lang-nursery/rust-cookbook.toml
@@ -3,10 +3,14 @@ name = "rust-cookbook"
 description = "https://rust-lang-nursery.github.io/rust-cookbook"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 cookbook = "write"
 lang-docs = "write"
 
 [environments.github-pages]
 branches = ["gh-pages"]
-

--- a/repos/rust-lang-nursery/rust-lang-nursery.github.io.toml
+++ b/repos/rust-lang-nursery/rust-lang-nursery.github.io.toml
@@ -3,8 +3,12 @@ name = "rust-lang-nursery.github.io"
 description = "GitHub pages redirects"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "master"
+path = "/"
+
 [access.teams]
 infra = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang-nursery/rust-toolstate.toml
+++ b/repos/rust-lang-nursery/rust-toolstate.toml
@@ -4,6 +4,11 @@ description = "Records build and test status of external tools bundled with the 
 homepage = "https://rust-lang-nursery.github.io/rust-toolstate/"
 bots = ["highfive"]
 
+[pages]
+build-type = "legacy"
+branch = "master"
+path = "/"
+
 [access.teams]
 infra = "write"
 
@@ -12,4 +17,3 @@ pattern = "master"
 pr-required = false
 
 [environments.github-pages]
-

--- a/repos/rust-lang/a-mir-formality.toml
+++ b/repos/rust-lang/a-mir-formality.toml
@@ -3,6 +3,9 @@ name = "a-mir-formality"
 description = "a model of MIR and the Rust type/trait system"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 lang = "maintain"
 lang-ops = "maintain"

--- a/repos/rust-lang/api-guidelines.toml
+++ b/repos/rust-lang/api-guidelines.toml
@@ -4,9 +4,13 @@ description = "Rust API guidelines"
 homepage = "https://rust-lang.github.io/api-guidelines/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 libs-api = "write"
 libs = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/areweasyncyet.rs.toml
+++ b/repos/rust-lang/areweasyncyet.rs.toml
@@ -4,6 +4,9 @@ description = "Are we async yet?"
 homepage = "https://areweasyncyet.rs"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 wg-async = "write"
 
@@ -12,4 +15,3 @@ upsuper = "write"
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/arewewebyet.toml
+++ b/repos/rust-lang/arewewebyet.toml
@@ -4,6 +4,11 @@ description = "Are we web yet? A simple reckoning of Rust's readiness for Web-re
 homepage = "https://www.arewewebyet.org/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "zola-build"
+path = "/"
+
 [access.teams]
 arewewebyet = "maintain"
 
@@ -11,4 +16,3 @@ arewewebyet = "maintain"
 pattern = 'master'
 
 [environments.github-pages]
-

--- a/repos/rust-lang/async-book.toml
+++ b/repos/rust-lang/async-book.toml
@@ -4,9 +4,11 @@ description = "Asynchronous Programming in Rust"
 homepage = "https://rust-lang.github.io/async-book/index.html"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 wg-async = "write"
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/async-crashdump-debugging-initiative.toml
+++ b/repos/rust-lang/async-crashdump-debugging-initiative.toml
@@ -3,8 +3,12 @@ name = "async-crashdump-debugging-initiative"
 description = ""
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 project-async-crashdump-debugging = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/async-fundamentals-initiative.toml
+++ b/repos/rust-lang/async-fundamentals-initiative.toml
@@ -4,6 +4,9 @@ description = ""
 homepage = "https://rust-lang.github.io/async-fundamentals-initiative/"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 wg-async = "maintain"
 
@@ -13,4 +16,3 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/beyond-refs.toml
+++ b/repos/rust-lang/beyond-refs.toml
@@ -4,6 +4,9 @@ description = "Wiki for design work going beyond Rust's current reference types"
 homepage = "https://rust-lang.github.io/beyond-refs/"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 beyond-refs-editors = "maintain"
 goal-owners = "maintain"

--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -4,6 +4,9 @@ description = "Home of the Rust and Inside Rust blogs"
 homepage = "https://blog.rust-lang.org"
 bots = ["rustbot", "renovate"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 inside-rust-reviewers = "write"
 website = "maintain"

--- a/repos/rust-lang/book.toml
+++ b/repos/rust-lang/book.toml
@@ -4,6 +4,11 @@ description = "The Rust Programming Language"
 homepage = "https://doc.rust-lang.org/book/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 book = "maintain"
 
@@ -14,4 +19,3 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["gh-pages"]
-

--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -3,6 +3,9 @@ name = "calendar"
 description = "Calendars for Rust project teams"
 bots = ["rustbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 cargo = "maintain"
 compiler = "maintain"
@@ -22,4 +25,3 @@ pr-required = false
 
 [environments.github-pages]
 branches = ["main"]
-

--- a/repos/rust-lang/cargo-bisect-rustc.toml
+++ b/repos/rust-lang/cargo-bisect-rustc.toml
@@ -4,6 +4,9 @@ description = "Bisects rustc, either nightlies or CI artifacts"
 homepage = "https://rust-lang.github.io/cargo-bisect-rustc/"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 compiler = "write"
 
@@ -16,4 +19,3 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["gh-pages", "master"]
-

--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -4,6 +4,9 @@ description = "The Rust package manager"
 homepage = "https://doc.rust-lang.org/cargo"
 bots = ["rustbot", "rfcbot", "renovate"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 cargo = "write"
 

--- a/repos/rust-lang/cfg-if.toml
+++ b/repos/rust-lang/cfg-if.toml
@@ -3,8 +3,12 @@ name = 'cfg-if'
 description = 'A if/elif-like macro for Rust #[cfg] statements'
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 crate-maintainers = 'maintain'
 
 [environments.github-pages]
-

--- a/repos/rust-lang/chalk.toml
+++ b/repos/rust-lang/chalk.toml
@@ -4,8 +4,12 @@ description = "An implementation and definition of the Rust trait system using a
 homepage = "https://rust-lang.github.io/chalk/book/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 types = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/cmake-rs.toml
+++ b/repos/rust-lang/cmake-rs.toml
@@ -4,6 +4,11 @@ description = 'Rust build dependency for running cmake'
 homepage = "https://docs.rs/cmake"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 crate-maintainers = 'maintain'
 

--- a/repos/rust-lang/compiler-team.toml
+++ b/repos/rust-lang/compiler-team.toml
@@ -4,6 +4,11 @@ description = "A home for compiler team planning documents, meeting minutes, and
 homepage = "https://rust-lang.github.io/compiler-team/"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 compiler = "write"
 compiler-ops = "write"
@@ -14,4 +19,3 @@ pattern = "master"
 required-approvals = 0
 
 [environments.github-pages]
-

--- a/repos/rust-lang/const-eval.toml
+++ b/repos/rust-lang/const-eval.toml
@@ -3,8 +3,12 @@ name = "const-eval"
 description = "home for proposals in and around compile-time function evaluation"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 wg-const-eval = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/dyn-upcasting-coercion-initiative.toml
+++ b/repos/rust-lang/dyn-upcasting-coercion-initiative.toml
@@ -3,8 +3,12 @@ name = "dyn-upcasting-coercion-initiative"
 description = "Initiative to support upcasting dyn Trait values to supertraits"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 project-dyn-upcasting = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/edition-guide.toml
+++ b/repos/rust-lang/edition-guide.toml
@@ -4,6 +4,11 @@ description = "A guide to changes between various editions of Rust"
 homepage = "https://doc.rust-lang.org/nightly/edition-guide/"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 edition = "maintain"
 

--- a/repos/rust-lang/effects-initiative.toml
+++ b/repos/rust-lang/effects-initiative.toml
@@ -4,6 +4,11 @@ description = "Public repository for the Rust effects initiative"
 homepage = "https://rust-lang.github.io/effects-initiative/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 project-keyword-generics = "write"
 

--- a/repos/rust-lang/fls.toml
+++ b/repos/rust-lang/fls.toml
@@ -4,6 +4,9 @@ description = "The FLS"
 homepage = "https://rust-lang.github.io/fls"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 fls = "write"
 fls-contributors = "triage"

--- a/repos/rust-lang/funding.toml
+++ b/repos/rust-lang/funding.toml
@@ -3,5 +3,8 @@ name = "funding"
 description = "Discussions about funding Rust maintainers"
 bots = ["rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 funding = "write"

--- a/repos/rust-lang/futures-rs.toml
+++ b/repos/rust-lang/futures-rs.toml
@@ -4,6 +4,11 @@ description = "Zero-cost asynchronous programming in Rust"
 homepage = "https://rust-lang.github.io/futures-rs/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 wg-async = "write"
 
@@ -12,4 +17,3 @@ pattern = "master"
 required-approvals = 0
 
 [environments.github-pages]
-

--- a/repos/rust-lang/getopts.toml
+++ b/repos/rust-lang/getopts.toml
@@ -4,8 +4,12 @@ description = 'The getopts repo maintained by the rust-lang project'
 homepage = "https://docs.rs/getopts"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 crate-maintainers = 'maintain'
 
 [environments.github-pages]
-

--- a/repos/rust-lang/glob.toml
+++ b/repos/rust-lang/glob.toml
@@ -4,6 +4,11 @@ description = "Support for matching file paths against Unix shell style patterns
 homepage = "https://doc.rust-lang.org/glob"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 crate-maintainers = "maintain"
 
@@ -13,4 +18,3 @@ ci-checks = ["success"]
 required-approvals = 0
 
 [environments.github-pages]
-

--- a/repos/rust-lang/hashbrown.toml
+++ b/repos/rust-lang/hashbrown.toml
@@ -4,6 +4,11 @@ description = "Rust port of Google's SwissTable hash map"
 homepage = "https://rust-lang.github.io/hashbrown"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 libs = "write"
 libs-contributors = "write"

--- a/repos/rust-lang/impl-trait-initiative.toml
+++ b/repos/rust-lang/impl-trait-initiative.toml
@@ -4,8 +4,12 @@ description = "Impl trait lang team initiative"
 homepage = "https://rust-lang.github.io/impl-trait-initiative/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 project-impl-trait = "maintain"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/initiative-template.toml
+++ b/repos/rust-lang/initiative-template.toml
@@ -4,8 +4,12 @@ description = "A template for lang-team initiatives"
 homepage = "https://nikomatsakis.github.io/initiative-template/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 lang = "maintain"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/jobserver-rs.toml
+++ b/repos/rust-lang/jobserver-rs.toml
@@ -3,9 +3,13 @@ name = "jobserver-rs"
 description = ""
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 cargo = "write"
 compiler = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/lang-team.toml
+++ b/repos/rust-lang/lang-team.toml
@@ -4,6 +4,9 @@ description = "Home of the Rust lang team"
 homepage = "http://lang-team.rust-lang.org/"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 lang = "maintain"
 lang-ops = "maintain"
@@ -13,4 +16,3 @@ release = "maintain"
 
 [environments.github-pages]
 branches = ["gh-pages", "main"]
-

--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -6,6 +6,11 @@ bots = [
     'rustbot',
 ]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 crate-maintainers = 'maintain'
 

--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -4,6 +4,11 @@ description = "Create book from markdown files. Like Gitbook but implemented in 
 homepage = "https://rust-lang.github.io/mdBook/"
 bots = ["rustbot", "renovate"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 devtools = "write"
 

--- a/repos/rust-lang/negative-impls-initiative.toml
+++ b/repos/rust-lang/negative-impls-initiative.toml
@@ -3,8 +3,12 @@ name = "negative-impls-initiative"
 description = "Lang team negative impls initiative"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 project-negative-impls = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/packed_simd.toml
+++ b/repos/rust-lang/packed_simd.toml
@@ -4,6 +4,11 @@ description = "Portable Packed SIMD Vectors for Rust standard library"
 homepage = "https://rust-lang.github.io/packed_simd/packed_simd_2/"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 libs-contributors = "write"
 libs-api = "write"
@@ -11,4 +16,3 @@ libs = "write"
 project-portable-simd = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/perspectives-on-llms.toml
+++ b/repos/rust-lang/perspectives-on-llms.toml
@@ -4,6 +4,9 @@ description = "Rust project perspectives on LLMs"
 homepage = "https://rust-lang.github.io/perspectives-on-llms/index.html"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 perspectives-on-llms-editors = "write"
 

--- a/repos/rust-lang/pkg-config-rs.toml
+++ b/repos/rust-lang/pkg-config-rs.toml
@@ -4,6 +4,11 @@ description = "Build library for invoking pkg-config for Rust"
 homepage = "https://docs.rs/pkg-config"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 crate-maintainers = "maintain"
 
@@ -11,4 +16,3 @@ crate-maintainers = "maintain"
 sdroege = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/polonius.toml
+++ b/repos/rust-lang/polonius.toml
@@ -3,9 +3,11 @@ name = "polonius"
 description = "Defines the Rust borrow checker."
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 wg-polonius = "write"
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/portable-simd.toml
+++ b/repos/rust-lang/portable-simd.toml
@@ -3,6 +3,11 @@ name = "portable-simd"
 description = "The testing ground for the future of portable SIMD in Rust"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 project-portable-simd = "write"
 
@@ -11,4 +16,3 @@ pattern = "master"
 required-approvals = 0
 
 [environments.github-pages]
-

--- a/repos/rust-lang/project-assumptions-on-binders.toml
+++ b/repos/rust-lang/project-assumptions-on-binders.toml
@@ -4,9 +4,11 @@ description = ""
 homepage = "https://rust-lang.github.io/project-assumptions-on-binders/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 project-assumptions-on-binders = "maintain"
 all = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/project-const-generics.toml
+++ b/repos/rust-lang/project-const-generics.toml
@@ -4,10 +4,12 @@ description = ""
 homepage = "https://rust-lang.github.io/project-const-generics/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 project-const-generics = "maintain"
 project-const-generics-triage = "write"
 all = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/project-goal-reference-expansion.toml
+++ b/repos/rust-lang/project-goal-reference-expansion.toml
@@ -4,8 +4,10 @@ description = "Project Goal coordination repository for expansion of the Rust Re
 homepage = "https://github.com/rust-lang/rust-project-goals/blob/main/src/2025h2/reference-expansion.md"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 project-goal-reference-expansion = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/project-group-template.toml
+++ b/repos/rust-lang/project-group-template.toml
@@ -3,8 +3,12 @@ name = "project-group-template"
 description = "Template for creating Project Groups"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 leadership-council = "maintain"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/reference.toml
+++ b/repos/rust-lang/reference.toml
@@ -4,6 +4,9 @@ description = "The Rust Reference"
 homepage = "https://doc.rust-lang.org/nightly/reference/"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 lang = "write"
 lang-docs = "write"

--- a/repos/rust-lang/rfcs.toml
+++ b/repos/rust-lang/rfcs.toml
@@ -4,6 +4,9 @@ description = "RFCs for changes to Rust"
 homepage = "https://rust-lang.github.io/rfcs/"
 bots = ["rustbot", "rfcbot", "renovate"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 all = "write"
 
@@ -13,4 +16,3 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/rust-analyzer.toml
+++ b/repos/rust-lang/rust-analyzer.toml
@@ -4,6 +4,11 @@ description = "A Rust compiler front-end for IDEs"
 homepage = "https://rust-analyzer.github.io/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 rust-analyzer = "write"
 rust-analyzer-contributors = "triage"

--- a/repos/rust-lang/rust-bindgen.toml
+++ b/repos/rust-lang/rust-bindgen.toml
@@ -4,6 +4,11 @@ description = "Automatically generates Rust FFI bindings to C (and some C++) lib
 homepage = "https://rust-lang.github.io/rust-bindgen/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 wg-bindgen = "write"
 

--- a/repos/rust-lang/rust-by-example.toml
+++ b/repos/rust-lang/rust-by-example.toml
@@ -4,8 +4,12 @@ description = "Learn Rust with examples (Live code editor included)"
 homepage = "https://doc.rust-lang.org/stable/rust-by-example/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 rust-by-example = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -4,6 +4,11 @@ description = "A bunch of lints to catch common mistakes and improve your Rust c
 homepage = "https://rust-lang.github.io/rust-clippy/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 clippy = "write"
 clippy-contributors = "triage"

--- a/repos/rust-lang/rust-enhanced.toml
+++ b/repos/rust-lang/rust-enhanced.toml
@@ -3,8 +3,12 @@ name = "rust-enhanced"
 description = "The official Sublime Text 4 package for the Rust Programming Language"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 devtools = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -4,6 +4,9 @@ description = 'Information useful to people contributing to Rust'
 homepage = "https://forge.rust-lang.org/"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 community = "maintain"
 compiler = "maintain"
@@ -31,4 +34,3 @@ ci-checks = ["test"]
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/rust-lang.github.io.toml
+++ b/repos/rust-lang/rust-lang.github.io.toml
@@ -3,8 +3,12 @@ name = "rust-lang.github.io"
 description = "GitHub Pages redirects"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "master"
+path = "/"
+
 [access.teams]
 infra = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/rust-project-goals.toml
+++ b/repos/rust-lang/rust-project-goals.toml
@@ -4,6 +4,9 @@ description = "Rust Project Goals tracker"
 homepage = "https://rust-lang.github.io/rust-project-goals/"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 lang = "maintain"
 lang-ops = "maintain"
@@ -19,4 +22,3 @@ goal-owners = "maintain"
 
 [environments.github-pages]
 branches = ["main"]
-

--- a/repos/rust-lang/rustc-demangle.toml
+++ b/repos/rust-lang/rustc-demangle.toml
@@ -3,6 +3,11 @@ name = "rustc-demangle"
 description = "Rust symbol demangling"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 compiler = "write"
 

--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -4,6 +4,11 @@ description = "A guide to how rustc works and how to contribute to it."
 homepage = "https://rustc-dev-guide.rust-lang.org"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 bootstrap = "write"
 compiler = "write"

--- a/repos/rust-lang/rustc-pr-tracking.toml
+++ b/repos/rust-lang/rustc-pr-tracking.toml
@@ -4,8 +4,12 @@ description = "Statistics about PRs on the rustc repository."
 homepage = "https://rust-lang.github.io/rustc-pr-tracking/"
 bots = ["highfive"]
 
+[pages]
+build-type = "legacy"
+branch = "master"
+path = "/"
+
 [access.teams]
 release = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/rustc-reading-club.toml
+++ b/repos/rust-lang/rustc-reading-club.toml
@@ -3,7 +3,11 @@ name = "rustc-reading-club"
 description = "Rust Code Reading Clubs"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 
 [environments.github-pages]
-

--- a/repos/rust-lang/rustc_public.toml
+++ b/repos/rust-lang/rustc_public.toml
@@ -3,6 +3,11 @@ name = "rustc_public"
 description = "Define compiler intermediate representation usable by external tools"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 project-rustc-public = "write"
 

--- a/repos/rust-lang/rustfmt.toml
+++ b/repos/rust-lang/rustfmt.toml
@@ -4,6 +4,11 @@ description = "Format Rust code"
 homepage = "https://rust-lang.github.io/rustfmt/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "main"
+path = "/docs"
+
 [access.teams]
 rustfmt = "write"
 rustfmt-contributors = "write"

--- a/repos/rust-lang/rustlings.toml
+++ b/repos/rust-lang/rustlings.toml
@@ -4,9 +4,11 @@ description = ":crab: Small exercises to get you used to reading and writing Rus
 homepage = "https://rustlings.rust-lang.org"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 rustlings = "maintain"
 
 [environments.github-pages]
 branches = ["gh-pages", "main"]
-

--- a/repos/rust-lang/rustup-components-history.toml
+++ b/repos/rust-lang/rustup-components-history.toml
@@ -4,8 +4,12 @@ description = "Rustup package status history"
 homepage = "https://rust-lang.github.io/rustup-components-history"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 infra = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/rustup.toml
+++ b/repos/rust-lang/rustup.toml
@@ -4,6 +4,11 @@ description = "The Rust toolchain installer"
 homepage = "https://rustup.rs/"
 bots = ["rustbot", "renovate"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 rustup = "maintain"
 

--- a/repos/rust-lang/std-dev-guide.toml
+++ b/repos/rust-lang/std-dev-guide.toml
@@ -4,6 +4,11 @@ description = "Guide for standard library developers"
 homepage = "https://std-dev-guide.rust-lang.org"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 libs-contributors = "write"
 libs-api = "write"

--- a/repos/rust-lang/std-replacement-data.toml
+++ b/repos/rust-lang/std-replacement-data.toml
@@ -3,6 +3,9 @@ name = "std-replacement-data"
 description = "Curated dataset of standard-library replacements for crates, surfaced on crates.io"
 bots = ["renovate"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 crates-io = "write"
 

--- a/repos/rust-lang/stdarch.toml
+++ b/repos/rust-lang/stdarch.toml
@@ -4,6 +4,11 @@ description = "Rust's standard library vendor-specific APIs and run-time feature
 homepage = "https://doc.rust-lang.org/stable/core/arch/"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 compiler = "write"
 lang = "write"

--- a/repos/rust-lang/team.toml
+++ b/repos/rust-lang/team.toml
@@ -3,6 +3,9 @@ name = "team"
 description = "Rust teams structure"
 bots = ["forking-renovate"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 mods = "write"
 team-repo-admins = "write"

--- a/repos/rust-lang/thanks.toml
+++ b/repos/rust-lang/thanks.toml
@@ -4,10 +4,12 @@ description = "Celebrate Rust contributors."
 homepage = "https://thanks.rust-lang.org"
 bots = []
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 website = "write"
 infra = "write"
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/types-team.toml
+++ b/repos/rust-lang/types-team.toml
@@ -4,8 +4,12 @@ description = "Home of the \"types team\", affiliated with the compiler and lang
 homepage = "https://rust-lang.github.io/types-team/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 types = "write"
 
 [environments.github-pages]
-

--- a/repos/rust-lang/unsafe-code-guidelines.toml
+++ b/repos/rust-lang/unsafe-code-guidelines.toml
@@ -4,9 +4,11 @@ description = "Forum for discussion about what unsafe code can and can't do"
 homepage = "https://rust-lang.github.io/unsafe-code-guidelines"
 bots = ["rustbot", "rfcbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 opsem = 'maintain'
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/wg-async.toml
+++ b/repos/rust-lang/wg-async.toml
@@ -4,6 +4,9 @@ description = "Working group dedicated to improving the foundations of Async I/O
 homepage = "https://rust-lang.github.io/wg-async/"
 bots = ["rustbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 wg-async = "write"
 
@@ -13,4 +16,3 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["master"]
-

--- a/repos/rust-lang/wg-macros.toml
+++ b/repos/rust-lang/wg-macros.toml
@@ -3,6 +3,9 @@ name = "wg-macros"
 description = "Home of the Rust Macros Working Gruop"
 bots = ["rustbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 wg-macros = "maintain"
 
@@ -11,4 +14,3 @@ pattern = "main"
 
 [environments.github-pages]
 branches = ["main"]
-

--- a/repos/rust-lang/www.rust-lang.org.toml
+++ b/repos/rust-lang/www.rust-lang.org.toml
@@ -4,6 +4,9 @@ description = "The home of the Rust website"
 homepage = "https://www.rust-lang.org"
 bots = ["rustbot"]
 
+[pages]
+build-type = "workflow"
+
 [access.teams]
 website = "write"
 
@@ -18,4 +21,3 @@ branches = ["main"]
 [environments.rust-www-staging]
 
 [environments.rust-www-try]
-

--- a/repos/rust-lang/zulip_archive.toml
+++ b/repos/rust-lang/zulip_archive.toml
@@ -4,8 +4,12 @@ description = "A tool for archiving and displaying Zulip chat channels."
 homepage = "https://zulip-archive.rust-lang.org"
 bots = []
 
+[pages]
+build-type = "legacy"
+branch = "gh-pages"
+path = "/"
+
 [access.teams]
 infra = "write"
 
 [environments.github-pages]
-

--- a/src/sync/github/api/write.rs
+++ b/src/sync/github/api/write.rs
@@ -261,6 +261,17 @@ impl GitHubWrite {
         Ok(())
     }
 
+    pub(crate) async fn delete_pages(&self, org: &str, repo: &str) -> anyhow::Result<()> {
+        debug!("Deleting GitHub Pages settings for {org}/{repo}");
+        if !self.dry_run {
+            let method = Method::DELETE;
+            let url = GitHubUrl::repos(org, repo, "pages")?;
+            let resp = self.client.req(method.clone(), &url)?.send().await?;
+            allow_not_found(resp, method, url.url()).await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn add_repo_to_app_installation(
         &self,
         installation_id: u64,

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -779,13 +779,13 @@ impl SyncGitHub {
             (None, None) => Ok(None),
             (None, Some(actual_pages)) => Ok(Some(PagesDiff::Delete(actual_pages))),
             (Some(expected_pages), None) => Ok(Some(PagesDiff::Create(expected_pages.clone()))),
-            (Some(expected_pages), Some(actual_pages)) if actual_pages == *expected_pages => {
-                Ok(None)
+            (Some(expected_pages), Some(actual_pages)) => {
+                let diff = (actual_pages != *expected_pages).then(|| PagesDiff::Update {
+                    old: actual_pages,
+                    new: expected_pages.clone(),
+                });
+                Ok(diff)
             }
-            (Some(expected_pages), Some(actual_pages)) => Ok(Some(PagesDiff::Update {
-                old: actual_pages,
-                new: expected_pages.clone(),
-            })),
         }
     }
 

--- a/src/sync/github/mod.rs
+++ b/src/sync/github/mod.rs
@@ -770,31 +770,23 @@ impl SyncGitHub {
         &self,
         expected_repo: &rust_team_data::v1::Repo,
     ) -> anyhow::Result<Option<PagesDiff>> {
-        let Some(expected_pages) = &expected_repo.pages else {
-            return Ok(None);
-        };
-
         let actual_pages = self
             .github
             .repo_pages(&expected_repo.org, &expected_repo.name)
             .await?;
 
-        // GitHub Pages could be configured for an existing repo
-        // since the GitHub API provides us with POST and PUT endpoints
-        // we need to distinguish such cases, otherwise calling POST on existing Pages
-        // might return 409
-        let Some(actual_pages) = actual_pages else {
-            return Ok(Some(PagesDiff::Create(expected_pages.clone())));
-        };
-
-        if actual_pages == *expected_pages {
-            return Ok(None);
+        match (&expected_repo.pages, actual_pages) {
+            (None, None) => Ok(None),
+            (None, Some(actual_pages)) => Ok(Some(PagesDiff::Delete(actual_pages))),
+            (Some(expected_pages), None) => Ok(Some(PagesDiff::Create(expected_pages.clone()))),
+            (Some(expected_pages), Some(actual_pages)) if actual_pages == *expected_pages => {
+                Ok(None)
+            }
+            (Some(expected_pages), Some(actual_pages)) => Ok(Some(PagesDiff::Update {
+                old: actual_pages,
+                new: expected_pages.clone(),
+            })),
         }
-
-        Ok(Some(PagesDiff::Update {
-            old: actual_pages,
-            new: expected_pages.clone(),
-        }))
     }
 
     async fn diff_rulesets(
@@ -1517,6 +1509,7 @@ enum EnvironmentDiff {
 enum PagesDiff {
     Create(Pages),
     Update { old: Pages, new: Pages },
+    Delete(Pages),
 }
 
 impl PagesDiff {
@@ -1524,6 +1517,7 @@ impl PagesDiff {
         match self {
             Self::Create(pages) => sync.create_pages(org, repo, pages).await?,
             Self::Update { new, .. } => sync.update_pages(org, repo, new).await?,
+            Self::Delete(_) => sync.delete_pages(org, repo).await?,
         }
         Ok(())
     }
@@ -1538,6 +1532,7 @@ impl std::fmt::Display for PagesDiff {
                 writeln!(f, "        Old: {}", format_pages(old))?;
                 writeln!(f, "        New: {}", format_pages(new))
             }
+            Self::Delete(pages) => writeln!(f, "    ❌ Delete: {}", format_pages(pages)),
         }
     }
 }

--- a/src/sync/github/tests/mod.rs
+++ b/src/sync/github/tests/mod.rs
@@ -392,14 +392,51 @@ async fn repo_create() {
 }
 
 #[tokio::test]
-async fn repo_pages_unmanaged_noop() {
+async fn repo_pages_delete() {
     let mut model = DataModel::default();
     model.create_repo(RepoData::new("repo1"));
     let mut gh = model.gh_model();
     gh.set_repo_pages(DEFAULT_ORG, "repo1", workflow_pages());
 
     let diff = model.diff_repos(gh).await;
-    assert!(diff.is_empty());
+    insta::assert_debug_snapshot!(diff, @r#"
+    [
+        Update(
+            UpdateRepoDiff {
+                org: "rust-lang",
+                name: "repo1",
+                repo_id: 0,
+                settings_diff: (
+                    RepoSettings {
+                        description: "",
+                        homepage: None,
+                        archived: false,
+                        auto_merge_enabled: false,
+                    },
+                    RepoSettings {
+                        description: "",
+                        homepage: None,
+                        archived: false,
+                        auto_merge_enabled: false,
+                    },
+                ),
+                permission_diffs: [],
+                branch_protection_diffs: [],
+                ruleset_diffs: [],
+                environment_diffs: [],
+                pages_diff: Some(
+                    Delete(
+                        Pages {
+                            build_type: Workflow,
+                            source: None,
+                        },
+                    ),
+                ),
+                app_installation_diffs: [],
+            },
+        ),
+    ]
+    "#);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Related to #2518 

Shouldn't be merged until all existing Github Pages Settings imported into repos/*.toml, otherwise sync may delete Pages settings that are still only configured on GitHub.