### PR TITLE
Use main in rustc-hash

### DIFF
--- a/repos/rust-lang/rustc-hash.toml
+++ b/repos/rust-lang/rustc-hash.toml
@@ -7,4 +7,4 @@ bots = []
 compiler = "write"
 
 [[rulesets]]
-pattern = "master"
+pattern = "main"


### PR DESCRIPTION
An infra-admin will need to actually change it on the repo.