### PR TITLE
Configure trusted publishing for `rustc-hash`

### DIFF
--- a/repos/rust-lang/rustc-hash.toml
+++ b/repos/rust-lang/rustc-hash.toml
@@ -8,3 +8,12 @@ compiler = "write"
 
 [[rulesets]]
 pattern = "main"
+
+[environments.publish]
+branches = ["main"]
+
+[[crates-io]]
+crates = ["rustc-hash"]
+publish-workflow = "publish.yml"
+publish-environment = "publish"
+teams = ["compiler"]


### PR DESCRIPTION
So that we can auto publish it from CI via release-plz.
