### PR TITLE
crates-build-env repo, remove required approvals

### DIFF
--- a/repos/rust-lang/crates-build-env.toml
+++ b/repos/rust-lang/crates-build-env.toml
@@ -9,3 +9,4 @@ infra = "write"
 
 [[rulesets]]
 pattern = 'master'
+required-approvals = 0


### PR DESCRIPTION
so maintainers could just merge things if it fits. 