### PR TITLE
Require github-pages environment for workflow Pages

### DIFF
--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -384,7 +384,7 @@ build-type = "workflow"
 ```
 
 For `legacy`, `branch` is required and `path` must be either `/` or `/docs`.
-For `workflow`, `branch` and `path` must not be set, and the repository must
+For the `workflow` build type, `branch` and `path` must not be set, and the repository must
 define the `github-pages` environment (GitHub automatically creates this
 environment for Pages deployments, and sync-team would delete it if it is not
 defined in the repo TOML file).

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -379,10 +379,15 @@ path = "/docs"
 # Build Pages from a GitHub Actions workflow.
 [pages]
 build-type = "workflow"
+
+[environments.github-pages]
 ```
 
 For `legacy`, `branch` is required and `path` must be either `/` or `/docs`.
-For `workflow`, `branch` and `path` must not be set.
+For `workflow`, `branch` and `path` must not be set, and the repository must
+define the `github-pages` environment (GitHub automatically creates this
+environment for Pages deployments, and sync-team would delete it if it is not
+defined in the repo TOML file).
 
 ### Repository access
 

--- a/repos/rust-lang/funding.toml
+++ b/repos/rust-lang/funding.toml
@@ -8,3 +8,5 @@ build-type = "workflow"
 
 [access.teams]
 funding = "write"
+
+[environments.github-pages]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -2,7 +2,7 @@ use crate::api::github::GitHubApi;
 use crate::api::zulip::ZulipApi;
 use crate::data::Data;
 use crate::schema::{
-    AllowedMergeApp, Bot, Email, MergeQueueMethod, Permissions, Repo, RepoPermission, Team,
+    AllowedMergeApp, Bot, Email, MergeQueueMethod, Pages, Permissions, Repo, RepoPermission, Team,
     TeamKind, TeamPeople, ZulipMember,
 };
 use anyhow::{Context as _, Error, bail};
@@ -1196,7 +1196,15 @@ fn validate_environments(data: &Data, errors: &mut Vec<String>) {
 
 fn validate_pages(data: &Data, errors: &mut Vec<String>) {
     wrapper(data.all_repos(), errors, |repo, _| {
-        repo.normalized_pages()?;
+        let pages = repo.normalized_pages()?;
+        if matches!(pages, Some(Pages::Workflow)) && !repo.environments.contains_key("github-pages")
+        {
+            bail!(
+                "repo {}/{} configures workflow GitHub Pages without a `github-pages` environment; add `[environments.github-pages]`",
+                repo.org,
+                repo.name
+            );
+        }
         Ok(())
     });
 }


### PR DESCRIPTION
Related to #2543

Should notice 2 things.

1. I used a LLM to double-check the existing repo TOML files for configs that already violate this requirement. It found `repos/rust-lang/funding.toml`, so I added `[environments.github-pages]` there in this PR. If that is premature, let me know I can remove it.
2. `static_api.rs` still does not take this new validation into account (as I understand #2543 requires `validate.rs` only). If that is expected, just omit it.