### PR TITLE
Rename mdbook publish workflow name and fix trusted publishing diff

### DIFF
--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -34,7 +34,7 @@ crates = [
     "mdbook-renderer",
     "mdbook-summary",
 ]
-publish-workflow = "deploy.yml"
+publish-workflow = "publish-crates-io.yml"
 publish-environment = "publish"
 
 [environments.github-pages]

--- a/src/sync/crates_io/mod.rs
+++ b/src/sync/crates_io/mod.rs
@@ -172,8 +172,10 @@ impl SyncCratesIo {
                     config_diffs.push(ConfigDiff::Create(desired.clone()));
                 }
 
-                // Non-matching configs should be deleted
-                config_diffs.extend(configs.iter_mut().map(|c| ConfigDiff::Delete(c.clone())));
+                // Non-matching configs should be deleted.
+                // Drain them from `tp_configs` so the final leftover-config cleanup below doesn't queue
+                // the same configs for deletion a second time.
+                config_diffs.extend(configs.drain(..).map(ConfigDiff::Delete));
             }
 
             // Sync "trusted publishing only" crate option


### PR DESCRIPTION
I've needed to change the name of the workflow name used with trusted publishing in mdbook.