### PR TITLE
Set crabwatch custom property on rust-lang/crates-io-auth-action

### DIFF
--- a/repos/rust-lang/crates-io-auth-action.toml
+++ b/repos/rust-lang/crates-io-auth-action.toml
@@ -13,3 +13,6 @@ pattern = "main"
 ci-checks = ["Conclusion"]
 required-approvals = 0
 merge-queue = { enabled = true }
+
+[custom-properties]
+crabwatch = true


### PR DESCRIPTION
Opts crates-io-auth-action into crabwatch scanning by setting the crabwatch custom property. 