### PR TITLE
fix: exclude parents rulesets

### DIFF
--- a/src/sync/github/api/read.rs
+++ b/src/sync/github/api/read.rs
@@ -726,6 +726,13 @@ impl GithubRead for GitHubApiRead {
 
         let mut ruleset_ids = vec![];
 
+        // Exclude inherited organization/enterprise rulesets, as we only manage
+        // repository rulesets.
+        // Note that parent rulesets can contain parent-only rule types, such as `workflows`,
+        // so if you enable this, make sure the deserialization of the ruleset can handle all
+        // organization/enterprise rule types, too.
+        let includes_parents = "includes_parents=false";
+
         // REST API endpoint for rulesets
         // https://docs.github.com/en/rest/repos/rules#get-all-repository-rulesets
         // The API returns only a subset of data for each ruleset :/
@@ -733,7 +740,7 @@ impl GithubRead for GitHubApiRead {
         self.client
             .rest_paginated(
                 &Method::GET,
-                &GitHubUrl::repos(org, repo, "rulesets")?,
+                &GitHubUrl::repos(org, repo, &format!("rulesets?{includes_parents}"))?,
                 |resp: Vec<RulesetInfo>| {
                     ruleset_ids.extend(resp.into_iter().map(|info| info.id));
                     Ok(())


### PR DESCRIPTION
I defined an organization ruleset for the repositories with the `crabwatch = true` custom properties.
Unfortunately, now CI fails because when retrieving repository rulesets, it doesn't recognize the "workflows" type.


This PR unblocks CI.


Here is the error I saw when applying https://github.com/rust-lang/team/pull/2572:

```
**Error:** rust_team] failed: Cannot deserialize type `rust_team::sync::github::api::Ruleset` from the following response body:
    {
      "_links": {
        "html": {
          "href": "[https://github.com/rust-lang/crabwatch/rules/18624409](https://github.com/rust-lang/crabwatch/rules/18624409)"
        },
        "self": {
          "href": "[https://api.github.com/repos/rust-lang/crabwatch/rulesets/18624409](https://api.github.com/repos/rust-lang/crabwatch/rulesets/18624409)"
        }
      },
      "bypass_actors": [],
      "conditions": {
        "ref_name": {
          "exclude": [],
          "include": [
            "~DEFAULT_BRANCH"
          ]
        }
      },
      "created_at": "2026-07-07T16:08:44.564+02:00",
      "current_user_can_bypass": "never",
      "enforcement": "active",
      "id": 18624409,
      "name": "crabwatch",
      "node_id": "RRS_lACkVXNlcs4AUt55zgEcL5k",
      "rules": [
        {
          "parameters": {
            "do_not_enforce_on_create": false,
            "workflows": [
              {
                "path": ".github/workflows/crabwatch.yml",
                "ref": "refs/heads/main",
                "repository_id": 1256932671
              }
            ]
          },
          "type": "workflows"
        }
      ],
      "source": "rust-lang",
      "source_type": "Organization",
      "target": "branch",
      "updated_at": "2026-07-09T16:53:19.260+02:00"
    }
**Error:** rust_team] caused by: unknown variant `workflows`, expected one of `creation`, `update`, `deletion`, `required_linear_history`, `merge_queue`, `required_deployments`, `required_signatures`, `pull_request`, `required_status_checks`, `non_fast_forward` at line 1 column 224
**Error:** Process completed with exit code 1.
```

## AI disclosure

I used GPT5.6 with the codex harness to generate this change. I reviewed its output and changed it where necessary.