### PR TITLE
Sync t-cargo/private with membership

### DIFF
--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -49,3 +49,6 @@ address = "cargo@rust-lang.org"
 
 [[zulip-groups]]
 name = "T-cargo"
+
+[[zulip-streams]]
+name = "t-cargo/private"


### PR DESCRIPTION
This adds the #t-cargo/private Zulip stream so that it tracks the team membership. This stream already exists, and I have added Rust Owner Account.