### PR TITLE
Give the program team write access to the blog

### DIFF
--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -11,6 +11,7 @@ build-type = "workflow"
 foundation-board-project-directors = "write"
 leadership-council = "write"
 leads = "write"
+program = "write"
 project-group-leads = "write"
 website = "maintain"
 # For Rust release blog posts


### PR DESCRIPTION
Our program managers regularly need to post to the blog. We would like to give them access so that they can merge posts themselves.

cc @rust-lang/program 