### PR TITLE
Allow merging my own changes to impl-trait-utils

### DIFF
--- a/repos/rust-lang/impl-trait-utils.toml
+++ b/repos/rust-lang/impl-trait-utils.toml
@@ -8,3 +8,4 @@ wg-async = "maintain"
 
 [[rulesets]]
 pattern = "main"
+required-approvals = 0


### PR DESCRIPTION
This repo is in maintenance mode and there aren't other maintainers. Not being able to self-approve changes requires an awkward dance, and there's no option to enable self-approval, so set the required approvals to 0.

e.g. I have to ask someone else to open https://github.com/rust-lang/impl-trait-utils/pull/41