### PR TITLE
Move lukas-code to alumni

### DIFF
--- a/teams/compiler.toml
+++ b/teams/compiler.toml
@@ -43,7 +43,6 @@ members = [
     "Kobzol",
     { github = "lcnr", roles = ["compiler-maintainer"] },
     { github = "lqd", roles = ["compiler-maintainer"] },
-    "lukas-code",
     "m-ou-se",
     "madsmtm",
     "mati865",
@@ -101,7 +100,8 @@ alumni = [
     { github = "varkor", roles = ["compiler-maintainer"] },
     "Xanewok",
     "zackmdavis",
-    { github = "Zoxc", roles = ["compiler-maintainer"] }
+    { github = "Zoxc", roles = ["compiler-maintainer"] },
+    "lukas-code",
 ]
 
 [[roles]]


### PR DESCRIPTION
Move `lukas-code` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`lukas-code` will be moved to alumni in the following team(s):
- compiler (CC @BoxyUwU @davidtwco)

This pull request should be left open at least for 10 days to allow the contributor to respond.

CC @lukas-code

If you want to keep being a member of Rust teams, please let us know!
