### PR TITLE
Allow deploying the blog from the merge queue

### DIFF
--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -20,8 +20,7 @@ release = "write"
 [[rulesets]]
 pattern = "main"
 ci-checks = [
-    "lint",
-    "build",
+    "CI"
 ]
 require-conversation-resolution = true
 # Allow promote release to push without PRs

--- a/repos/rust-lang/blog.rust-lang.org.toml
+++ b/repos/rust-lang/blog.rust-lang.org.toml
@@ -29,4 +29,4 @@ allowed-merge-apps = ["promote-release"]
 merge-queue = { enabled = true }
 
 [environments.github-pages]
-branches = ["main"]
+branches = ["gh-readonly-queue/main/*"]


### PR DESCRIPTION
Needed to unblock https://github.com/rust-lang/blog.rust-lang.org/pull/1893. Copied the branch wildcard from the `fls` repository.
