### PR TITLE
Create `maintainers-in-residence` marker team

### DIFF
--- a/teams/maintainers-in-residence.toml
+++ b/teams/maintainers-in-residence.toml
@@ -1,0 +1,28 @@
+name = "maintainers-in-residence"
+kind = "marker-team"
+
+[people]
+leads = []
+members = []
+alumni = []
+
+[[roles]]
+id = "full-time"
+description = "Full-time Maintainer in Residence"
+
+[[roles]]
+id = "part-time"
+description = "Part-time Maintainer in Residence"
+
+[permissions]
+dev-desktop = true
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "Maintainer in Residence"
+description = "Rust maintainers sponsored by the Rust Foundation Maintainers Fund"
+
+[[zulip-groups]]
+name = "T-mir"


### PR DESCRIPTION
Creating this in advance (we don't yet have any MiRs, but hopefully soon we will have!) to prepare some new content on our website.
