### PR TITLE
Rename default branch of futures-rs and pin-utils to main

### DIFF
--- a/repos/rust-lang/futures-rs.toml
+++ b/repos/rust-lang/futures-rs.toml
@@ -13,7 +13,7 @@ path = "/"
 wg-async = "write"
 
 [[rulesets]]
-pattern = "master"
+pattern = "main"
 required-approvals = 0
 
 [environments.github-pages]

--- a/repos/rust-lang/pin-utils.toml
+++ b/repos/rust-lang/pin-utils.toml
@@ -5,3 +5,7 @@ bots = []
 
 [access.teams]
 wg-async = "write"
+
+[[rulesets]]
+pattern = "main"
+required-approvals = 0


### PR DESCRIPTION
Per [#t-infra > Renaming default branches from master to main](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Renaming.20default.20branches.20from.20master.20to.20main/with/542920517), I'd like to rename the default branch name for the repos that I maintain:

- https://github.com/rust-lang/futures-rs/pull/3026
- https://github.com/rust-lang/pin-utils/pull/40

I don't have permission to change the branch name in the settings, so I would appreciate it if someone from the infra-admin could do that when merging this.

