### PR TITLE
Configure trusted publishing for jobserver-rs

### DIFF
--- a/repos/rust-lang/jobserver-rs.toml
+++ b/repos/rust-lang/jobserver-rs.toml
@@ -13,3 +13,12 @@ cargo = "write"
 compiler = "write"
 
 [environments.github-pages]
+
+[environments.publish]
+tags = ["*"]
+
+[[crates-io]]
+crates = ["jobserver"]
+publish-workflow = "publish.yml"
+publish-environment = "publish"
+teams = ["cargo", "compiler"]


### PR DESCRIPTION
As per https://github.com/rust-lang/infra-team/issues/204#issuecomment-5011797741.
