### PR TITLE
Move edmilsonefs to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -8,7 +8,6 @@ members = [
     "JohnTitor",
     "joelpalmer",
     "JohnCSimon",
-    "edmilsonefs",
     "Alexendoo",
     "bstrie",
     "crlf0710",
@@ -41,6 +40,7 @@ alumni = [
     "jieyouxu",
     "KittyBorgX",
     "anden3",
+    "edmilsonefs",
 ]
 
 [website]


### PR DESCRIPTION
Move `edmilsonefs` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`edmilsonefs` will be moved to alumni in the following team(s):
- triage (CC @Dylan-DPC)

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @edmilsonefs

If you want to keep being a member of Rust teams, please let us know!

@rustbot label +alumni