### PR TITLE
Move joelpalmer to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -6,7 +6,6 @@ leads = ["Dylan-DPC"]
 members = [
     "Dylan-DPC",
     "JohnTitor",
-    "joelpalmer",
     "JohnCSimon",
     "Alexendoo",
     "bstrie",
@@ -41,6 +40,7 @@ alumni = [
     "KittyBorgX",
     "anden3",
     "edmilsonefs",
+    "joelpalmer",
 ]
 
 [website]


### PR DESCRIPTION
Move `joelpalmer` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`joelpalmer` will be moved to alumni in the following team(s):
- triage (CC @Dylan-DPC)

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @joelpalmer

If you want to keep being a member of Rust teams, please let us know!