### PR TITLE
Move Muirrum to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -12,7 +12,6 @@ members = [
     "Alexendoo",
     "bstrie",
     "crlf0710",
-    "Muirrum",
     "camelid",
     "alice-i-cecile",
     "pitaj",
@@ -41,6 +40,7 @@ members = [
 ]
 alumni = [
     "jieyouxu",
+    "Muirrum",
 ]
 
 [website]


### PR DESCRIPTION
Move `Muirrum` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`Muirrum` will be moved to alumni in the following team(s):
- triage (CC @Dylan-DPC)

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @Muirrum

If you want to keep being a member of Rust teams, please let us know!