### PR TITLE
Move cdmistman to alumni

### DIFF
--- a/teams/twir.toml
+++ b/teams/twir.toml
@@ -6,13 +6,13 @@ leads = ["nellshamrell"]
 members = [
     "nellshamrell",
     "llogiq",
-    "cdmistman",
     "extrawurst",
     "andrewpollack",
     "JoelMarcey",
 ]
 alumni = [
     "nasa42",
+    "cdmistman",
 ]
 
 [[github]]


### PR DESCRIPTION
Move `cdmistman` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`cdmistman` will be moved to alumni in the following team(s):
- twir (CC @nellshamrell)

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @cdmistman

If you want to keep being a member of Rust teams, please let us know!