### PR TITLE
Move anden3 to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -16,7 +16,6 @@ members = [
     "camelid",
     "alice-i-cecile",
     "pitaj",
-    "anden3",
     "Enselic",
     "tranquillity-codes",
     "oskgo",
@@ -41,6 +40,7 @@ members = [
 alumni = [
     "jieyouxu",
     "KittyBorgX",
+    "anden3",
 ]
 
 [website]


### PR DESCRIPTION
Move `anden3` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`anden3` will be moved to alumni in the following team(s):
- triage (CC @Dylan-DPC)

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @anden3

If you want to keep being a member of Rust teams, please let us know!