### PR TITLE
Move vertexclique to alumni

### DIFF
--- a/teams/community-localization.toml
+++ b/teams/community-localization.toml
@@ -2,15 +2,15 @@ name = "community-localization"
 subteam-of = "community"
 
 [people]
-leads = ["vertexclique", "Manishearth"]
+leads = ["Manishearth"]
 members = [
     "Manishearth",
     "JohnTitor",
-    "vertexclique",
 ]
 alumni = [
     "sebasmagri",
     "XAMPPRocky",
+    "vertexclique",
 ]
 
 [rfcbot]


### PR DESCRIPTION
Move `vertexclique` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`vertexclique` will be moved to alumni in the following team(s):
- community-localization (CC @Manishearth)

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @vertexclique

If you want to keep being a member of Rust teams, please let us know!