### PR TITLE
Move JakobDegen to alumni

### DIFF
--- a/teams/lang-advisors.toml
+++ b/teams/lang-advisors.toml
@@ -11,13 +11,14 @@ members = [
     "dianne",
     "ehuss",
     "jackh726",
-    "JakobDegen",
     "RalfJung",
     "Mark-Simulacrum",
     "Nadrieril",
     "wesleywiser",
 ]
-alumni = []
+alumni = [
+    "JakobDegen",
+]
 
 # Granting these permissions because an advisor can use these to help when
 # reviewing a proposed change.


### PR DESCRIPTION
Move `JakobDegen` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`JakobDegen` will be moved to alumni in the following team(s):
- lang-advisors

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @JakobDegen

If you want to keep being a member of Rust teams, please let us know!