### PR TITLE
Move tranquillity-codes to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -19,7 +19,6 @@ members = [
     "anden3",
     "KittyBorgX",
     "Enselic",
-    "tranquillity-codes",
     "oskgo",
     "lolbinarycat",
     "alex-semenyuk",
@@ -41,6 +40,7 @@ members = [
 ]
 alumni = [
     "jieyouxu",
+    "tranquillity-codes",
 ]
 
 [website]


### PR DESCRIPTION
Move `tranquillity-codes` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`tranquillity-codes` will be moved to alumni in the following team(s):
- triage (CC @Dylan-DPC)

This pull request should be left open at least for 10 days (until `28.07.2026`) to allow the contributor to respond.

CC @tranquillity-codes

If you want to keep being a member of Rust teams, please let us know!