### PR TITLE
Move celaus to alumni

### DIFF
--- a/teams/community-events.toml
+++ b/teams/community-events.toml
@@ -5,7 +5,6 @@ subteam-of = "community"
 leads = []
 members = [
     "mattgathu",
-    "celaus",
     "flaki",
     "badboy",
     "Manishearth",
@@ -13,6 +12,7 @@ members = [
 ]
 alumni = [
     "skade",
+    "celaus",
 ]
 
 [website]


### PR DESCRIPTION
Move `celaus` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`celaus` will be moved to alumni in the following team(s):
- community-events

This pull request should be left open at least for 10 days (until `29.07.2026`) to allow the contributor to respond.

CC @celaus

If you want to keep being a member of Rust teams, please let us know!