### PR TITLE
Move alibektas to alumni

### DIFF
--- a/teams/rust-analyzer-contributors.toml
+++ b/teams/rust-analyzer-contributors.toml
@@ -4,7 +4,6 @@ subteam-of = "rust-analyzer"
 [people]
 leads = []
 members = [
-    "alibektas",
     "dfireBird",
     "DropDemBits",
     "Nadrieril",
@@ -12,7 +11,9 @@ members = [
     "Shourya742",
     "Young-Flash",
 ]
-alumni = []
+alumni = [
+    "alibektas",
+]
 
 [website]
 name = "rust-analyzer team contributors"


### PR DESCRIPTION
Move `alibektas` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`alibektas` will be moved to alumni in the following team(s):
- rust-analyzer-contributors

This pull request should be left open at least for 10 days (until `29.07.2026`) to allow the contributor to respond.

CC @alibektas

If you want to keep being a member of Rust teams, please let us know!