### PR TITLE
Move KittyBorgX to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -17,7 +17,6 @@ members = [
     "alice-i-cecile",
     "pitaj",
     "anden3",
-    "KittyBorgX",
     "Enselic",
     "tranquillity-codes",
     "oskgo",
@@ -41,6 +40,7 @@ members = [
 ]
 alumni = [
     "jieyouxu",
+    "KittyBorgX",
 ]
 
 [website]


### PR DESCRIPTION
Move `KittyBorgX` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`KittyBorgX` will be moved to alumni in the following team(s):
- triage (CC @Dylan-DPC)

This pull request should be left open at least for 10 days (until `29.07.2026`) to allow the contributor to respond.

CC @KittyBorgX

If you want to keep being a member of Rust teams, please let us know!