### PR TITLE
Move manyinsects to alumni

### DIFF
--- a/teams/rustlings.toml
+++ b/teams/rustlings.toml
@@ -2,14 +2,14 @@ name = "rustlings"
 subteam-of = "lang-docs"
 
 [people]
-leads = ["mo8it", "manyinsects"]
+leads = ["mo8it"]
 members = [
-    "manyinsects",
     "mo8it",
     "senekor",
 ]
 alumni = [
     "carols10cents",
+    "manyinsects",
 ]
 
 [[github]]


### PR DESCRIPTION
Move `manyinsects` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`manyinsects` will be moved to alumni in the following team(s):
- rustlings (CC @mo8it)

This pull request should be left open at least for 10 days (until `29.07.2026`) to allow the contributor to respond.

CC @manyinsects

If you want to keep being a member of Rust teams, please let us know!