### PR TITLE
Move shard77 to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -28,7 +28,6 @@ members = [
     "Darksonn",
     "cyrgani",
     "nuzzles",
-    "shard77",
     "xizheyin",
     "karolzwolak",
     "probablytaylors",
@@ -41,6 +40,7 @@ members = [
 ]
 alumni = [
     "jieyouxu",
+    "shard77",
 ]
 
 [website]


### PR DESCRIPTION
Move `shard77` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`shard77` will be moved to alumni in the following team(s):
- triage (CC @Dylan-DPC)

This pull request should be left open at least for 10 days (until `29.07.2026`) to allow the contributor to respond.

CC @shard77

If you want to keep being a member of Rust teams, please let us know!