### PR TITLE
Move rbtcollins to alumni

### DIFF
--- a/teams/devtools.toml
+++ b/teams/devtools.toml
@@ -3,7 +3,7 @@ top-level = true
 
 [people]
 leads = ["Manishearth"]
-members = ["Manishearth", "GuillaumeGomez", "rbtcollins", "ehuss", "calebcartwright"]
+members = ["Manishearth", "GuillaumeGomez", "ehuss", "calebcartwright"]
 alumni = [
     "alexcrichton",
     "brson",
@@ -22,6 +22,7 @@ alumni = [
     "withoutboats",
     "wycats",
     "Xanewok",
+    "rbtcollins",
 ]
 
 [rfcbot]


### PR DESCRIPTION
Move `rbtcollins` to alumni, as they have been inactive on GitHub and Zulip for some time. This is in accordance with https://github.com/rust-lang/leadership-council/blob/main/policies/membership/auto-alumni.md.

`rbtcollins` will be moved to alumni in the following team(s):
- devtools (CC @Manishearth)

This pull request should be left open at least for 10 days (until `29.07.2026`) to allow the contributor to respond.

CC @rbtcollins

If you want to keep being a member of Rust teams, please let us know!