### PR TITLE
Automatic synchronization for the new `all/rustacean-connection` channel

### DIFF
--- a/teams/all.toml
+++ b/teams/all.toml
@@ -39,3 +39,11 @@ name = "all/private"
 extra-teams = [
     "foundation-staff",
 ]
+
+# Secondary channel for people sharing vacation plans for better separation from all/private.
+# [Same level of privacy as all/private though.]
+[[zulip-streams]]
+name = "all/rustacean-connection"
+extra-teams = [
+    "foundation-staff",
+]


### PR DESCRIPTION
This should keep the current list of members in sync with future changes to T-all membership. It also adds the foundation staff members to `all/rustacean-connection` (which AFAICT are currently not members yet) for full access parity with `all/private`.

*the people this will add, AFAIK:*
<img width="121" height="156" alt="Bildschirmfoto_20260722_161539" src="https://github.com/user-attachments/assets/2f00cef4-d1e0-4f52-853f-3826dc44dd18" />



cc @apiraino 

---

*Edit:* Actually the diff is slightly larger than this, adding 9 people (10 if you count the owner bot; and including 4 of the 5 people listed above, 1 is already in the new channel) and removing 3.

*Edit2:* Okay… **part** of the discrepancy is from #2615 happening in between, which explains 2 of the 3 removals. 
*Edit3:* Actually, the 3rd removal is also a recent alumni move, namely #2607.

