### PR TITLE
configure trusted publishing for libc

### DIFF
--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -28,5 +28,14 @@ required-approvals = 0
 merge-queue = { enabled = true, method = "rebase" }
 require-linear-history = true
 
+[[crates-io]]
+crates = ["libc", "ctest"]
+publish-workflow = "release.yaml"
+publish-environment = "release"
+teams = ["libs"]
+
 [environments.github-pages]
 branches = ["gh-pages", "main", "master"]
+
+[environments.release]
+branches = ["main", "libc-0.2"]


### PR DESCRIPTION
Related to https://github.com/rust-lang/libc/pull/5317
When merging this, rust-lang-owner should remove individual access and undeclared teams