### PR TITLE
add fallible to dev guide team

### DIFF
--- a/people/fallible-algebra.toml
+++ b/people/fallible-algebra.toml
@@ -1,0 +1,4 @@
+name = "Fallible Algebra"
+github = "fallible-algebra"
+github-id = 118682743
+zulip-id = 1082493

--- a/people/fallible-algebra.toml
+++ b/people/fallible-algebra.toml
@@ -1,4 +1,5 @@
 name = "Fallible Algebra"
 github = "fallible-algebra"
 github-id = 118682743
+email = "fallible.algebra@proton.me"
 zulip-id = 1082493

--- a/teams/rustc-dev-guide.toml
+++ b/teams/rustc-dev-guide.toml
@@ -14,6 +14,7 @@ members = [
     "Noratrieb",
     "Kobzol",
     "reddevilmidzy",
+    "fallible-algebra",
 ]
 alumni = [
     "LeSeulArtichaut",


### PR DESCRIPTION
cc @tshepang @fallible-algebra

Fallible has been working quite closely with me on type system docs in the dev guide for the last month or so (and intends to continue doing so). She's written the wellformedness section most recently: https://rustc-dev-guide.rust-lang.org/analysis/well-formed.html