### PR TITLE
add project directors to funding advisors channel

### DIFF
--- a/teams/funding-advisors.toml
+++ b/teams/funding-advisors.toml
@@ -21,4 +21,7 @@ name = "T-funding-advisors"
 
 [[zulip-streams]]
 name = "funding/with-advisors"
-extra-teams = ["funding"]
+extra-teams = [
+    "funding",
+    "foundation-board-project-directors"
+]


### PR DESCRIPTION
Add the @rust-lang/foundation-board-project-directors to the @rust-lang/funding advisors team.

This will add them into the private funding/advisors channel. We discussed this in our meeting today, it makes sense because we will be doing more coordination with foundation fundraising and PDs are intimately involved in that.