### PR TITLE
Exclude users from all/rustaceans-connections

### DIFF
--- a/teams/all.toml
+++ b/teams/all.toml
@@ -47,3 +47,6 @@ name = "all/rustacean-connection"
 extra-teams = [
     "foundation-staff",
 ]
+excluded-people = [
+    "ChayimFriedman2",
+]


### PR DESCRIPTION
this way we can prevent people from being auto-readded to a Zulip stream when they don't want

r? @Kobzol

(let's see if someone else wants to be added)