### PR TITLE
Create configs when untracked repos found

### DIFF
--- a/.github/workflows/check-untracked-repos.yml
+++ b/.github/workflows/check-untracked-repos.yml
@@ -38,42 +38,34 @@ jobs:
 
       - name: Check untracked repositories
         id: check
-        # exit code 2 means that configurations were created, so do not exit immediately
-        shell: bash {0}
         run: |
           cargo build --release
-          CARGO_BUILD_EXIT_CODE=$?
 
-          if [[ "$CARGO_BUILD_EXIT_CODE" -ne 0 ]]; then
-            exit "$CARGO_BUILD_EXIT_CODE"
-          fi
+          CHECK_UNTRACKED_REPOS_EXIT_CODE=0
+          # Capture the status without failing because
+          # exit code 2 means that configurations were created.
+          ./target/release/rust-team ci check-untracked-repos --create-missing \
+            || CHECK_UNTRACKED_REPOS_EXIT_CODE=$?
 
-          ./target/release/rust-team ci check-untracked-repos --create-missing
-          CHECK_UNTRACKED_REPOS_EXIT_CODE=$?
+          case "$CHECK_UNTRACKED_REPOS_EXIT_CODE" in
+            0) configurations_created=false ;;
+            2) configurations_created=true ;;
+            *) exit "$CHECK_UNTRACKED_REPOS_EXIT_CODE" ;;
+          esac
 
-          if [[ "$CHECK_UNTRACKED_REPOS_EXIT_CODE" -eq 0 ]]; then
-            echo "configurations_created=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "$CHECK_UNTRACKED_REPOS_EXIT_CODE" -eq 2 ]]; then
-            echo "configurations_created=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          exit "$CHECK_UNTRACKED_REPOS_EXIT_CODE"
+          echo "configurations_created=$configurations_created" >> "$GITHUB_OUTPUT"
 
       - name: Check for an existing pull request
         id: pull_request
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           PULL_REQUEST_EXISTS=$(
             gh pr list \
               --head "$AUTOMATION_BRANCH" \
               --state open \
-              --json number \
-              --jq 'length > 0'
+              --json isCrossRepository \
+              --jq 'map(select(.isCrossRepository == false)) | length > 0'
           )
 
           echo "Pull request exists: $PULL_REQUEST_EXISTS"
@@ -82,7 +74,7 @@ jobs:
       - name: Close previous pull request
         if: ${{ steps.check.outputs.configurations_created == 'false' && steps.pull_request.outputs.exists == 'true' }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: gh pr close "$AUTOMATION_BRANCH"
 
       - name: Commit and push generated configurations
@@ -114,7 +106,7 @@ jobs:
       - name: Create pull request
         if: ${{ steps.check.outputs.configurations_created == 'true' && steps.pull_request.outputs.exists == 'false' }}
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_BASE_BRANCH: ${{ github.event.repository.default_branch }}
           PULL_REQUEST_BODY: >-
             This pull request was created automatically because untracked repositories were found.

--- a/.github/workflows/check-untracked-repos.yml
+++ b/.github/workflows/check-untracked-repos.yml
@@ -1,3 +1,6 @@
+# This workflow checks the default branch every six hours for repositories that do not have a corresponding repos/*/*.toml file.
+# If missing configurations are generated, it force-pushes them to a fixed automation branch and creates a pull request if needed.
+# If no configurations are needed, it closes any open pull request from the automation branch.
 name: Check Untracked Repositories
 
 on:
@@ -6,24 +9,118 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: check-untracked-repositories
+  cancel-in-progress: false
+
 permissions: {}
+
+env:
+  AUTOMATION_BRANCH: automation/import-untracked-repositories
+  AUTOMATION_PR_TITLE: "Automation: automatically import untracked repositories"
 
 jobs:
   check-untracked-repos:
     name: Check untracked repositories
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write       # Needed to push the automation branch
+      pull-requests: write  # Needed to find and close an existing pull request
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check out the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Install Rust stable
         uses: ./.github/actions/setup-rust
 
-      - name: Check for untracked repositories
-        shell: bash
+      - name: Check untracked repositories
+        id: check
+        # exit code 2 means that configurations were created, so do not exit immediately
+        shell: bash {0}
         run: |
           cargo build --release
-          ./target/release/rust-team ci check-untracked-repos
+          CARGO_BUILD_EXIT_CODE=$?
+
+          if [[ "$CARGO_BUILD_EXIT_CODE" -ne 0 ]]; then
+            exit "$CARGO_BUILD_EXIT_CODE"
+          fi
+
+          ./target/release/rust-team ci check-untracked-repos --create-missing
+          CHECK_UNTRACKED_REPOS_EXIT_CODE=$?
+
+          if [[ "$CHECK_UNTRACKED_REPOS_EXIT_CODE" -eq 0 ]]; then
+            echo "configurations_created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$CHECK_UNTRACKED_REPOS_EXIT_CODE" -eq 2 ]]; then
+            echo "configurations_created=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          exit "$CHECK_UNTRACKED_REPOS_EXIT_CODE"
+
+      - name: Check for an existing pull request
+        id: pull_request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          PULL_REQUEST_EXISTS=$(
+            gh pr list \
+              --head "$AUTOMATION_BRANCH" \
+              --state open \
+              --json number \
+              --jq 'length > 0'
+          )
+
+          echo "Pull request exists: $PULL_REQUEST_EXISTS"
+          echo "exists=$PULL_REQUEST_EXISTS" >> "$GITHUB_OUTPUT"
+
+      - name: Close previous pull request
+        if: ${{ steps.check.outputs.configurations_created == 'false' && steps.pull_request.outputs.exists == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: gh pr close "$AUTOMATION_BRANCH"
+
+      - name: Commit and push generated configurations
+        if: ${{ steps.check.outputs.configurations_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git switch --create "$AUTOMATION_BRANCH"
+          gh auth setup-git
+
+          git config user.name "rust-lang-team automation"
+          git config user.email "github-actions@github.com"
+
+          git add repos/
+          git commit -m "Automatically add configurations for untracked repositories"
+
+          git push --force --set-upstream origin "$AUTOMATION_BRANCH"
+
+      # a PR created with the built-in GITHUB_TOKEN may not run CI automatically.
+      # use a GitHub App token so that the pull request triggers CI normally.
+      - name: Generate GitHub App token
+        if: ${{ steps.check.outputs.configurations_created == 'true' && steps.pull_request.outputs.exists == 'false' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.SYNC_TEAM_GH_APP_ID }}
+          private-key: ${{ secrets.SYNC_TEAM_GH_APP_PRIVATE_KEY }}
+
+      - name: Create pull request
+        if: ${{ steps.check.outputs.configurations_created == 'true' && steps.pull_request.outputs.exists == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PULL_REQUEST_BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          PULL_REQUEST_BODY: >-
+            This pull request was created automatically because untracked repositories were found.
+        run: |
+          gh pr create \
+            --base "$PULL_REQUEST_BASE_BRANCH" \
+            --head "$AUTOMATION_BRANCH" \
+            --title "$AUTOMATION_PR_TITLE" \
+            --body "$PULL_REQUEST_BODY"

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -2,7 +2,9 @@ use crate::data::Data;
 use crate::schema::RepoPermission;
 use anyhow::{Context, bail};
 use log::{debug, info, warn};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Generates the contents of `.github/CODEOWNERS`, based on
@@ -176,17 +178,31 @@ fn codeowners_path() -> PathBuf {
 #[derive(Debug, serde::Deserialize)]
 struct GitHubRepo {
     name: String,
+    description: Option<String>,
+    homepage: Option<String>,
     fork: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct UntrackedRepo {
     org: String,
     name: String,
+    description: String,
+    homepage: Option<String>,
 }
 
-/// Check for untracked repositories and fail if any are found
-pub async fn check_untracked_repos(data: &Data) -> anyhow::Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckUntrackedReposResult {
+    AllTracked,
+    MissingRepositoryConfigsCreated,
+}
+
+/// Check for untracked repositories and create missing configuration files
+pub async fn check_untracked_repos(
+    data: &Data,
+    data_dir: &Path,
+    create_missing: bool,
+) -> anyhow::Result<CheckUntrackedReposResult> {
     let github = crate::api::github::GitHubApi::new();
 
     // Get allowed GitHub organizations from config instead of hardcoding
@@ -228,12 +244,20 @@ pub async fn check_untracked_repos(data: &Data) -> anyhow::Result<()> {
 
     if untracked.is_empty() {
         info!("✅ All repositories are tracked!");
-        return Ok(());
+        return Ok(CheckUntrackedReposResult::AllTracked);
     }
 
     warn!("❌ Found {} untracked repositories:", untracked.len());
     for repo in &untracked {
         warn!("  - {}/{}", repo.org, repo.name);
+    }
+
+    if create_missing {
+        let created = create_missing_repo_configs(data_dir, &untracked)?;
+        for path in created {
+            info!("Created {}", path.display());
+        }
+        return Ok(CheckUntrackedReposResult::MissingRepositoryConfigsCreated);
     }
 
     bail!(
@@ -300,6 +324,189 @@ fn find_untracked_repos(
         .map(|(org, repo)| UntrackedRepo {
             org: org.clone(),
             name: repo.name.clone(),
+            description: repo.description.clone().unwrap_or_default(),
+            homepage: repo
+                .homepage
+                .clone()
+                .filter(|homepage| !homepage.is_empty()),
         })
         .collect()
+}
+
+#[derive(serde::Serialize)]
+struct GeneratedRepoConfig<'a> {
+    org: &'a str,
+    name: &'a str,
+    description: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    homepage: Option<&'a str>,
+    // schema::Repo has no Serde defaults for bots and access,
+    // omitting them would make Data::load fail.
+    bots: Vec<&'static str>,
+    access: GeneratedRepoAccess,
+}
+
+#[derive(serde::Serialize)]
+struct GeneratedRepoAccess {
+    teams: BTreeMap<String, String>,
+}
+
+fn create_missing_repo_configs(
+    data_dir: &Path,
+    repos: &[UntrackedRepo],
+) -> anyhow::Result<Vec<PathBuf>> {
+    let mut created = Vec::with_capacity(repos.len());
+    for repo in repos {
+        let contents = toml::to_string_pretty(&GeneratedRepoConfig {
+            org: &repo.org,
+            name: &repo.name,
+            description: &repo.description,
+            homepage: repo.homepage.as_deref(),
+            bots: Vec::new(),
+            access: GeneratedRepoAccess {
+                teams: BTreeMap::new(),
+            },
+        })
+        .with_context(|| {
+            format!(
+                "failed to serialize configuration for {}/{}",
+                repo.org, repo.name
+            )
+        })?;
+
+        let repo_dir = data_dir.join("repos").join(&repo.org);
+        std::fs::create_dir_all(&repo_dir)
+            .with_context(|| format!("failed to create directory {}", repo_dir.display()))?;
+
+        let missing_repo_config_toml = repo_dir.join(format!("{}.toml", repo.name));
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&missing_repo_config_toml)
+            .with_context(|| format!("failed to create {}", missing_repo_config_toml.display()))?;
+
+        file.write_all(contents.as_bytes())
+            .with_context(|| format!("failed to write {}", missing_repo_config_toml.display()))?;
+
+        created.push(missing_repo_config_toml);
+    }
+
+    Ok(created)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GitHubRepo, UntrackedRepo, create_missing_repo_configs, find_untracked_repos};
+    use crate::schema::Repo;
+    use std::collections::HashSet;
+
+    #[test]
+    fn finds_only_untracked_non_fork_repositories() {
+        let github_repos = vec![
+            (
+                "rust-lang".into(),
+                GitHubRepo {
+                    name: "tracked".into(),
+                    description: Some("Tracked repository".into()),
+                    homepage: None,
+                    fork: false,
+                },
+            ),
+            (
+                "rust-lang".into(),
+                GitHubRepo {
+                    name: "fork".into(),
+                    description: None,
+                    homepage: None,
+                    fork: true,
+                },
+            ),
+            (
+                "rust-lang".into(),
+                GitHubRepo {
+                    name: "missing".into(),
+                    description: Some("Missing repository".into()),
+                    homepage: Some("https://example.com".into()),
+                    fork: false,
+                },
+            ),
+        ];
+        let tracked = HashSet::from([("rust-lang".into(), "tracked".into())]);
+
+        let untracked = find_untracked_repos(&github_repos, &tracked);
+
+        assert_eq!(
+            untracked,
+            vec![UntrackedRepo {
+                org: "rust-lang".into(),
+                name: "missing".into(),
+                description: "Missing repository".into(),
+                homepage: Some("https://example.com".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn creates_parseable_repository_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = UntrackedRepo {
+            org: "rust-lang".into(),
+            name: "example".into(),
+            description: "An \"example\" repository\nwith two lines".into(),
+            homepage: Some("https://example.com".into()),
+        };
+
+        let created = create_missing_repo_configs(dir.path(), &[repo]).unwrap();
+
+        assert_eq!(
+            created,
+            vec![dir.path().join("repos/rust-lang/example.toml")]
+        );
+        let contents = std::fs::read_to_string(&created[0]).unwrap();
+        let parsed: Repo = toml::from_str(&contents).unwrap();
+        assert_eq!(parsed.org, "rust-lang");
+        assert_eq!(parsed.name, "example");
+        assert_eq!(
+            parsed.description,
+            "An \"example\" repository\nwith two lines"
+        );
+        assert_eq!(parsed.homepage.as_deref(), Some("https://example.com"));
+        assert!(parsed.bots.is_empty());
+        assert!(parsed.access.teams.is_empty());
+    }
+
+    #[test]
+    fn omits_empty_homepage() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = UntrackedRepo {
+            org: "rust-lang".into(),
+            name: "example".into(),
+            description: String::new(),
+            homepage: None,
+        };
+
+        let created = create_missing_repo_configs(dir.path(), &[repo]).unwrap();
+        let contents = std::fs::read_to_string(&created[0]).unwrap();
+
+        assert!(!contents.contains("homepage"));
+    }
+
+    #[test]
+    fn does_not_overwrite_existing_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("repos/rust-lang/example.toml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "existing contents").unwrap();
+        let repo = UntrackedRepo {
+            org: "rust-lang".into(),
+            name: "example".into(),
+            description: "new contents".into(),
+            homepage: None,
+        };
+
+        create_missing_repo_configs(dir.path(), &[repo]).unwrap_err();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "existing contents");
+    }
 }

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -3,7 +3,6 @@ use crate::schema::RepoPermission;
 use anyhow::{Context, bail};
 use log::{debug, info, warn};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -253,10 +252,7 @@ pub async fn check_untracked_repos(
     }
 
     if create_missing {
-        let created = create_missing_repo_configs(data_dir, &untracked)?;
-        for path in created {
-            info!("Created {}", path.display());
-        }
+        create_missing_repo_configs(data_dir, &untracked)?;
         return Ok(CheckUntrackedReposResult::MissingRepositoryConfigsCreated);
     }
 
@@ -351,13 +347,9 @@ struct GeneratedRepoAccess {
     teams: BTreeMap<String, String>,
 }
 
-fn create_missing_repo_configs(
-    data_dir: &Path,
-    repos: &[UntrackedRepo],
-) -> anyhow::Result<Vec<PathBuf>> {
-    let mut created = Vec::with_capacity(repos.len());
-    for repo in repos {
-        let contents = toml::to_string_pretty(&GeneratedRepoConfig {
+impl<'a> From<&'a UntrackedRepo> for GeneratedRepoConfig<'a> {
+    fn from(repo: &'a UntrackedRepo) -> Self {
+        Self {
             org: &repo.org,
             name: &repo.name,
             description: &repo.description,
@@ -366,33 +358,34 @@ fn create_missing_repo_configs(
             access: GeneratedRepoAccess {
                 teams: BTreeMap::new(),
             },
-        })
-        .with_context(|| {
-            format!(
-                "failed to serialize configuration for {}/{}",
-                repo.org, repo.name
-            )
-        })?;
+        }
+    }
+}
 
-        let repo_dir = data_dir.join("repos").join(&repo.org);
-        std::fs::create_dir_all(&repo_dir)
-            .with_context(|| format!("failed to create directory {}", repo_dir.display()))?;
+fn create_missing_repo_configs(data_dir: &Path, repos: &[UntrackedRepo]) -> anyhow::Result<()> {
+    for repo in repos {
+        let contents =
+            toml::to_string_pretty(&GeneratedRepoConfig::from(repo)).with_context(|| {
+                format!(
+                    "failed to serialize configuration for {}/{}",
+                    repo.org, repo.name
+                )
+            })?;
 
-        let missing_repo_config_toml = repo_dir.join(format!("{}.toml", repo.name));
+        let missing_repo_config_toml = data_dir
+            .join("repos")
+            .join(&repo.org)
+            .join(format!("{}.toml", repo.name));
 
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&missing_repo_config_toml)
-            .with_context(|| format!("failed to create {}", missing_repo_config_toml.display()))?;
+        std::fs::File::create_new(&missing_repo_config_toml)
+            .with_context(|| format!("failed to create {missing_repo_config_toml:?}"))?
+            .write_all(contents.as_bytes())
+            .with_context(|| format!("failed to write {missing_repo_config_toml:?}"))?;
 
-        file.write_all(contents.as_bytes())
-            .with_context(|| format!("failed to write {}", missing_repo_config_toml.display()))?;
-
-        created.push(missing_repo_config_toml);
+        info!("Created {}", missing_repo_config_toml.display());
     }
 
-    Ok(created)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -450,6 +443,10 @@ mod tests {
     #[test]
     fn creates_parseable_repository_config() {
         let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("repos/rust-lang/example.toml");
+
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
         let repo = UntrackedRepo {
             org: "rust-lang".into(),
             name: "example".into(),
@@ -457,14 +454,13 @@ mod tests {
             homepage: Some("https://example.com".into()),
         };
 
-        let created = create_missing_repo_configs(dir.path(), &[repo]).unwrap();
+        create_missing_repo_configs(dir.path(), &[repo]).unwrap();
 
-        assert_eq!(
-            created,
-            vec![dir.path().join("repos/rust-lang/example.toml")]
-        );
-        let contents = std::fs::read_to_string(&created[0]).unwrap();
+        assert!(path.exists());
+
+        let contents = std::fs::read_to_string(path).unwrap();
         let parsed: Repo = toml::from_str(&contents).unwrap();
+
         assert_eq!(parsed.org, "rust-lang");
         assert_eq!(parsed.name, "example");
         assert_eq!(
@@ -479,6 +475,10 @@ mod tests {
     #[test]
     fn omits_empty_homepage() {
         let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("repos/rust-lang/example.toml");
+
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
         let repo = UntrackedRepo {
             org: "rust-lang".into(),
             name: "example".into(),
@@ -486,8 +486,8 @@ mod tests {
             homepage: None,
         };
 
-        let created = create_missing_repo_configs(dir.path(), &[repo]).unwrap();
-        let contents = std::fs::read_to_string(&created[0]).unwrap();
+        create_missing_repo_configs(dir.path(), &[repo]).unwrap();
+        let contents = std::fs::read_to_string(path).unwrap();
 
         assert!(!contents.contains("homepage"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,11 @@ enum CiOpts {
     /// Check if the .github/CODEOWNERS file is up-to-date
     CheckCodeowners,
     /// Check for untracked repositories in GitHub organizations
-    CheckUntrackedRepos,
+    CheckUntrackedRepos {
+        /// Create a TOML configuration file for each untracked repository and exit with code 2
+        #[arg(long)]
+        create_missing: bool,
+    },
 }
 
 #[derive(clap::Parser, Clone, Debug)]
@@ -756,7 +760,13 @@ If you want to keep being a member of Rust teams, please let us know!
         RootOpts::Ci(opts) => match opts {
             CiOpts::GenerateCodeowners => generate_codeowners_file(data)?,
             CiOpts::CheckCodeowners => check_codeowners(data)?,
-            CiOpts::CheckUntrackedRepos => ci::check_untracked_repos(&data).await?,
+            CiOpts::CheckUntrackedRepos { create_missing } => {
+                let result =
+                    ci::check_untracked_repos(&data, &cli.data_dir, create_missing).await?;
+                if result == ci::CheckUntrackedReposResult::MissingRepositoryConfigsCreated {
+                    std::process::exit(2);
+                }
+            }
         },
         RootOpts::Sync(opts) => {
             if let Err(err) = perform_sync(opts, data).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,8 @@ enum CiOpts {
     CheckCodeowners,
     /// Check for untracked repositories in GitHub organizations
     CheckUntrackedRepos {
-        /// Create a TOML configuration file for each untracked repository and exit with code 2
+        /// Create a TOML configuration file for each untracked repository.
+        /// If at least one repository was missing and the file was created, exit with code 2.
         #[arg(long)]
         create_missing: bool,
     },


### PR DESCRIPTION
Related to #2582

According to the discussion in the previous https://github.com/rust-lang/team/pull/2611 it creates missing toml files. I added an exit code 2 to signal that untracked repos are found and configs are created, because this is the simplest way for the workflow to handle it. This still keeps code 1 for unexpected errors.