### PR TITLE
Sync t-rustfmt/private with membership

### DIFF
--- a/teams/rustfmt.toml
+++ b/teams/rustfmt.toml
@@ -27,3 +27,7 @@ repo = "https://github.com/rust-lang/rustfmt"
 
 [[zulip-groups]]
 name = "T-rustfmt"
+
+[[zulip-streams]]
+name = "t-rustfmt/private"
+extra-teams = ["rustfmt-contributors"]


### PR DESCRIPTION
The stream already exists, and Rust Owner Account has been added.

cc @jieyouxu 