### PR TITLE
Update cargo team leads

### DIFF
--- a/teams/cargo.toml
+++ b/teams/cargo.toml
@@ -2,10 +2,9 @@ name = "cargo"
 subteam-of = "devtools"
 
 [people]
-leads = ["ehuss"]
+leads = ["Eh2406", "weihanglo"]
 members = [
     "Eh2406",
-    "ehuss",
     "joshtriplett",
     "weihanglo",
     "epage",
@@ -23,6 +22,7 @@ alumni = [
     "withoutboats",
     "matklad",
     "carols10cents",
+    "ehuss",
 ]
 
 [permissions]


### PR DESCRIPTION
I'm happy to announce Jacob and Weihang have been selected as the new leads of the Cargo team. I'm stepping down and moving myself to alumni. I wish them well in this next chapter for the team!

cc @rust-lang/cargo
