### PR TITLE
Configure merge queue for rustfmt

### DIFF
--- a/repos/rust-lang/rustfmt.toml
+++ b/repos/rust-lang/rustfmt.toml
@@ -17,20 +17,10 @@ rustfmt-contributors = "write"
 pattern = "main"
 required-approvals = 0
 ci-checks = [
-    "(x86_64-unknown-linux-gnu, nightly)",
-    "(x86_64-unknown-linux-gnu, stable)",
-    "(x86_64-apple-darwin, nightly)",
-    "(x86_64-apple-darwin, stable)",
-    "(x86_64-pc-windows-msvc, nightly)",
-    "(i686-pc-windows-msvc, nightly)",
-    "(i686-pc-windows-msvc, stable)",
-    "(i686-pc-windows-gnu, stable)",
-    "(i686-pc-windows-gnu, nightly)",
-    "(x86_64-pc-windows-gnu, nightly)",
-    "(x86_64-pc-windows-msvc, stable)",
-    "(x86_64-pc-windows-gnu, stable)",
+    "test conclusion",
     "rustdoc check",
 ]
+merge-queue = { enabled = true }
 
 [[rulesets]]
 pattern = "libsyntax"


### PR DESCRIPTION
Should be merged in cooperation with https://github.com/rust-lang/rustfmt/pull/6989.