### PR TITLE
Remove renamed allowed_merge_apps

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -384,9 +384,6 @@ pub struct BranchProtection {
     pub mode: BranchProtectionMode,
     pub allowed_merge_teams: Vec<String>,
     pub merge_bots: Vec<MergeBot>,
-    /// Deprecated name for `bypass_apps`, kept for backwards compatibility.
-    #[serde(default)]
-    pub allowed_merge_apps: Vec<MergeBot>,
     #[serde(default)]
     pub bypass_apps: Vec<MergeBot>,
     pub require_up_to_date_branches: bool,

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -71,9 +71,6 @@ impl<'a> Generator<'a> {
                         BranchProtectionMode::PrNotRequired
                     },
                     allowed_merge_teams: b.allowed_merge_teams.clone(),
-                    // Temporarily support the old allowed_merge_apps to avoid
-                    // deserialization errors in triagebot.
-                    allowed_merge_apps: Self::convert_bypass_apps(&b.bypass_apps),
                     bypass_apps: Self::convert_bypass_apps(&b.bypass_apps),
                     require_up_to_date_branches: b.require_up_to_date_branches,
                     merge_queue: b.merge_queue.enabled,

--- a/src/sync/github/tests/test_utils.rs
+++ b/src/sync/github/tests/test_utils.rs
@@ -563,7 +563,6 @@ impl BranchProtectionBuilder {
             require_linear_history,
             mode,
             allowed_merge_teams,
-            allowed_merge_apps: bypass_apps.clone(),
             bypass_apps,
             require_up_to_date_branches,
             merge_queue,

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -24,26 +24,6 @@ fn static_api() -> Result<(), Error> {
         .dir(dir_valid())
         .assert_success()?;
 
-    // The old and new names must contain the same data while v1 consumers migrate.
-    let repos: rust_team_data::v1::Repos =
-        serde_json::from_str(&std::fs::read_to_string(dir_output.join("v1/repos.json"))?)?;
-    let mut found_bypass_app = false;
-    for branch_protection in repos
-        .repos
-        .values()
-        .flatten()
-        .flat_map(|repo| &repo.branch_protections)
-    {
-        assert_eq!(
-            branch_protection.allowed_merge_apps,
-            branch_protection.bypass_apps
-        );
-        if !branch_protection.bypass_apps.is_empty() {
-            found_bypass_app = true;
-        }
-    }
-    assert!(found_bypass_app, "the fixture must contain a bypass app");
-
     step("checking whether the output matched the expected one");
 
     // Collect all the files present in either the output or expected dirs

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -24,7 +24,6 @@
           },
           "allowed_merge_teams": [],
           "merge_bots": [],
-          "allowed_merge_apps": [],
           "bypass_apps": [],
           "require_up_to_date_branches": false,
           "merge_queue": false,
@@ -76,9 +75,6 @@
             "foo"
           ],
           "merge_bots": [],
-          "allowed_merge_apps": [
-            "promote_release"
-          ],
           "bypass_apps": [
             "promote_release"
           ],

--- a/tests/static-api/_expected/v1/repos/archived_repo.json
+++ b/tests/static-api/_expected/v1/repos/archived_repo.json
@@ -22,7 +22,6 @@
       },
       "allowed_merge_teams": [],
       "merge_bots": [],
-      "allowed_merge_apps": [],
       "bypass_apps": [],
       "require_up_to_date_branches": false,
       "merge_queue": false,

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -33,9 +33,6 @@
         "foo"
       ],
       "merge_bots": [],
-      "allowed_merge_apps": [
-        "promote_release"
-      ],
       "bypass_apps": [
         "promote_release"
       ],


### PR DESCRIPTION
Closes #2394 

Since allowed_merge_apps was renamed in https://github.com/rust-lang/team/pull/2586 and triagebot was updated in https://github.com/rust-lang/triagebot/pull/2464 it can be removed.