### PR TITLE
Archive hiring marker team and add their email to the funding team

### DIFF
--- a/teams/archive/hiring.toml
+++ b/teams/archive/hiring.toml
@@ -3,7 +3,8 @@ kind = "marker-team"
 
 [people]
 leads = []
-members = [
+members = []
+alumni = [
     "JoelMarcey",
     "ehuss",
     "nikomatsakis",

--- a/teams/funding.toml
+++ b/teams/funding.toml
@@ -38,6 +38,9 @@ extra-teams = ["funding-advisors"]
 [[lists]]
 address = "funding-private@rust-lang.org"
 
+[[lists]]
+address = "hiring@rust-lang.org"
+
 [rfcbot]
 label = "T-funding"
 name = "Funding"


### PR DESCRIPTION
A left over cleanup forgotten in https://github.com/rust-lang/team/pull/2468

cc @rust-lang/funding 