### PR TITLE
Add T-all members to rfcbot data

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -202,6 +202,7 @@ pub struct PermissionPerson {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Rfcbot {
     pub teams: IndexMap<String, RfcbotTeam>,
+    pub all_members: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -421,7 +421,16 @@ impl<'a> Generator<'a> {
         }
 
         teams.sort_keys();
-        self.add("v1/rfcbot.json", &v1::Rfcbot { teams })?;
+
+        let mut all_members = self
+            .data
+            .active_members()?
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        all_members.sort();
+
+        self.add("v1/rfcbot.json", &v1::Rfcbot { teams, all_members })?;
         Ok(())
     }
 

--- a/tests/static-api/_expected/v1/rfcbot.json
+++ b/tests/static-api/_expected/v1/rfcbot.json
@@ -7,5 +7,14 @@
         "user-0"
       ]
     }
-  }
+  },
+  "all_members": [
+    "test-admin",
+    "user-0",
+    "user-1",
+    "user-2",
+    "user-3",
+    "user-4",
+    "user-6"
+  ]
 }


### PR DESCRIPTION
Note: to be paired with rust-lang/rustbot-rs#360

Designed in such a way that the PRs can be merged independently without issue, although it's probably better to merge this one first so that the data can be used for testing.