### PR TITLE
Manage and update preexisting foundation staff group on Zulip through team repo

### DIFF
--- a/teams/foundation-staff.toml
+++ b/teams/foundation-staff.toml
@@ -19,3 +19,6 @@ members = [
     "tinakrauss",
 ]
 alumni = []
+
+[[zulip-groups]]
+name = "foundation"


### PR DESCRIPTION
I just noticed there already is a Zulip group self-describing as containing the foundation staff.

<img width="601" height="259" alt="Bildschirmfoto_20260731_000711" src="https://github.com/user-attachments/assets/5b02ba76-bbff-4ee9-ac48-b354acab413d" />

*(Group created on Sep 25, 2024.)*

Let's keep that up-to-date with this the marker-team here! Does that sound reasonable?
(This also adds several missing members who were never added over the years).

This would be useful for my current setup for the llm-policy discussion channel as well, as a way to keep up to date who gets the "Who can subscribe to this channel" permission.