### PR TITLE
Move inactive t-triage members to alumni

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -23,7 +23,6 @@ members = [
     "Darksonn",
     "cyrgani",
     "nuzzles",
-    "shard77",
     "xizheyin",
     "karolzwolak",
     "probablytaylors",
@@ -41,6 +40,7 @@ alumni = [
     "edmilsonefs",
     "joelpalmer",
     "JohnCSimon",
+    "shard77",
 ]
 
 [website]

--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -14,7 +14,6 @@ members = [
     "alice-i-cecile",
     "pitaj",
     "Enselic",
-    "tranquillity-codes",
     "oskgo",
     "lolbinarycat",
     "alex-semenyuk",
@@ -41,6 +40,7 @@ alumni = [
     "joelpalmer",
     "JohnCSimon",
     "shard77",
+    "tranquillity-codes",
 ]
 
 [website]

--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -9,7 +9,6 @@ members = [
     "Alexendoo",
     "bstrie",
     "crlf0710",
-    "Muirrum",
     "camelid",
     "alice-i-cecile",
     "pitaj",
@@ -41,6 +40,7 @@ alumni = [
     "JohnCSimon",
     "shard77",
     "tranquillity-codes",
+    "Muirrum",
 ]
 
 [website]

--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -6,7 +6,6 @@ leads = ["Dylan-DPC"]
 members = [
     "Dylan-DPC",
     "JohnTitor",
-    "JohnCSimon",
     "Alexendoo",
     "bstrie",
     "crlf0710",
@@ -41,6 +40,7 @@ alumni = [
     "anden3",
     "edmilsonefs",
     "joelpalmer",
+    "JohnCSimon",
 ]
 
 [website]


### PR DESCRIPTION
This PR combines:
- https://github.com/rust-lang/team/pull/2609
- https://github.com/rust-lang/team/pull/2608
- https://github.com/rust-lang/team/pull/2603
- https://github.com/rust-lang/team/pull/2598

Together to avoid multiple rebases.