### PR TITLE
Add Zulip topic for the funding team and MiRs

### DIFF
--- a/teams/funding.toml
+++ b/teams/funding.toml
@@ -31,6 +31,16 @@ name = "T-funding"
 [[zulip-streams]]
 name = "funding/private"
 
+[[zulip-streams]]
+name = "funding/with-mir"
+extra-teams = [
+    "maintainers-in-residence"
+]
+extra-people = [
+    "abibroom",
+    "becrumbul"
+]
+
 [[lists]]
 address = "funding@rust-lang.org"
 extra-teams = ["funding-advisors"]


### PR DESCRIPTION
We will invite maintainers in residence to this stream, so that they can discuss various internal funding and reporting topics with the Funding team.

The channel already exists and the rust lang owner is a member of it.