### PR TITLE
Rename `rust-project-goals` to `goals`

### DIFF
--- a/repos/rust-lang/goals.toml
+++ b/repos/rust-lang/goals.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
-name = "rust-project-goals"
+name = "goals"
 description = "Rust Project Goals tracker"
-homepage = "https://rust-lang.github.io/rust-project-goals/"
+homepage = "https://rust-lang.github.io/goals/"
 bots = ["rustbot", "rfcbot"]
 
 [pages]

--- a/repos/rust-lang/project-goal-reference-expansion.toml
+++ b/repos/rust-lang/project-goal-reference-expansion.toml
@@ -1,7 +1,7 @@
 org = "rust-lang"
 name = "project-goal-reference-expansion"
 description = "Project Goal coordination repository for expansion of the Rust Reference"
-homepage = "https://github.com/rust-lang/rust-project-goals/blob/main/src/2025h2/reference-expansion.md"
+homepage = "https://github.com/rust-lang/goals/blob/main/src/2025h2/reference-expansion.md"
 bots = []
 
 [pages]

--- a/teams/goal-owners.toml
+++ b/teams/goal-owners.toml
@@ -1,4 +1,4 @@
-# Auto-generated from the rust-project-goals repository
+# Auto-generated from the goals repository
 name = "goal-owners"
 kind = "marker-team"
 

--- a/teams/goals.toml
+++ b/teams/goals.toml
@@ -28,10 +28,10 @@ ping = "rust-lang/goals"
 
 [website]
 name = "Goals team"
-description = "Administering the Rust goal setting program"
+description = "Administering the Rust Project Goals"
 email = "goals@rust-lang.org"
-zulip-stream = "project goals"
-repo = "https://github.com/rust-lang/rust-project-goals"
+zulip-stream = "goals"
+repo = "https://github.com/rust-lang/goals"
 
 [[zulip-groups]]
 name = "T-goals"


### PR DESCRIPTION
We'd like to rename `rust-project-goals` to just `goals`, and also the related Zulip channels. Context: [#project-goals/meta > Renaming repo/channels](https://rust-lang.zulipchat.com/#narrow/channel/478266-project-goals.2Fmeta/topic/Renaming.20repo.2Fchannels/with/615051083)

A previous rename (#2522) suggests that stuff needs to be renamed manually. @marcoieni could you help?

cc @nikomatsakis @lcnr 