### PR TITLE
Configure branches for unrolled perf builds for bors

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -151,5 +151,19 @@ pattern = "perf-tmp"
 allowed-merge-teams = ["rust-timer"]
 prevent-update = true
 
+# Required for running unrolled perf builds created by bors.
+# Must support force-pushes.
+[[rulesets]]
+pattern = "automation/bors/try-perf"
+bypass-apps = ["bors"]
+prevent-update = true
+
+# Required for running unrolled perf builds created by bors.
+# Must support force-pushes.
+[[rulesets]]
+pattern = "automation/bors/try-perf-merge"
+bypass-apps = ["bors"]
+prevent-update = true
+
 [environments.bors]
-branches = ["automation/bors/auto", "automation/bors/try", "try-perf"]
+branches = ["automation/bors/auto", "automation/bors/try", "automation/bors/try-perf", "try-perf"]


### PR DESCRIPTION
Adds new branches that will be used by bors to unroll branches for perf. builds (this functionality will be ported over from rustc-perf).

Historically we had some issues with bors creating these branches, so it would be good if they could be pre-created manually first.

After the functionality is ported and we test that it works fine, I will remove the push access of rust-timer and the old `try-perf` and `try-tmp` branches.
