### PR TITLE
remove unused ruleset in rust repo

### DIFF
--- a/repos/rust-lang/rust.toml
+++ b/repos/rust-lang/rust.toml
@@ -103,12 +103,6 @@ pattern = "*/**/*"
 bypass-apps = ["bors", "promote-release"]
 prevent-update = true
 
-[[rulesets]]
-pattern = "cargo_update"
-pr-required = false
-prevent-deletion = false
-prevent-force-push = false
-
 # Required for running try builds created by bors.
 # Must support force-pushes.
 [[rulesets]]


### PR DESCRIPTION
We don't need this ruleset anymore because we replaced the old update mechanism that used it with Renovate. See https://github.com/rust-lang/infra-team/issues/293 