### PR TITLE
Add mdbook team

### DIFF
--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -5,17 +5,12 @@ homepage = "https://rust-lang.github.io/mdBook/"
 bots = ["rustbot", "renovate"]
 
 [access.teams]
-devtools = "write"
-
-[access.individuals]
-# Dylan-DPC is maintaining mdbook along with ehuss. Planning to add a team
-# soon, and then this can be removed.
-Dylan-DPC = "write"
+mdbook = "write"
 
 [[branch-protections]]
 pattern = "master"
 ci-checks = ["Success gate"]
-required-approvals = 0
+required-approvals = 1
 merge-queue = { enabled = true, min-entries-to-merge-wait-minutes = 1 }
 
 [[crates-io]]

--- a/teams/mdbook.toml
+++ b/teams/mdbook.toml
@@ -1,0 +1,27 @@
+name = "mdbook"
+subteam-of = "devtools"
+
+[people]
+leads = ["GuillaumeGomez"]
+members = [
+    "camelid",
+    "notriddle",
+    "GuillaumeGomez",
+]
+
+alumni = [
+    "ehuss",
+    "Dylan-DPC",
+]
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "mdBook team"
+description = "Maintaining mdBook"
+zulip-stream = "t-mdbook"
+repo = "https://github.com/rust-lang/mdBook"
+
+[[zulip-groups]]
+name = "T-mdbook"


### PR DESCRIPTION
Follow-up of the [zulip discussion](https://rust-lang.zulipchat.com/#narrow/channel/507422-t-mdbook/topic/Creating.20an.20mdbook.20team).

Now pinging all dev-tools teams (in no particular order) so everyone is aware of this new team joining dev-tools. :)

cc @rust-lang/devtools @rust-lang/clippy @rust-lang/clippy-contributors @rust-lang/cargo @rust-lang/crates-io @rust-lang/docs-rs @rust-lang/rustdoc @rust-lang/rustfmt @rust-lang/rustfmt-contributors @rust-lang/rustup @rust-lang/testing-devex @rust-lang/wg-bindgen 