### PR TITLE
Enable branch protection for 0.N branches of futures-rs

### DIFF
--- a/repos/rust-lang/futures-rs.toml
+++ b/repos/rust-lang/futures-rs.toml
@@ -16,4 +16,8 @@ wg-async = "write"
 pattern = "main"
 required-approvals = 0
 
+[[rulesets]]
+pattern = "0.[1-9]"
+required-approvals = 0
+
 [environments.github-pages]


### PR DESCRIPTION
futures-rs has 0.N branches (https://github.com/rust-lang/futures-rs/branches), and releases to crates-io are currently made from these branches.