### PR TITLE
Add first batch of Maintainers in Residence

### DIFF
--- a/teams/maintainers-in-residence.toml
+++ b/teams/maintainers-in-residence.toml
@@ -23,7 +23,7 @@ description = "Part-time Maintainer in Residence"
 
 [[roles]]
 id = "maintainer-grant"
-description = "Mantainer grantee"
+description = "Maintainer grantee"
 
 [permissions]
 dev-desktop = true

--- a/teams/maintainers-in-residence.toml
+++ b/teams/maintainers-in-residence.toml
@@ -3,7 +3,14 @@ kind = "marker-team"
 
 [people]
 leads = []
-members = []
+members = [
+    { github = "rami3l", roles = ["full-time"] },
+    { github = "blyxyas", roles = ["part-time"] },
+    { github = "ChrisDenton", roles = ["part-time"] },
+    { github = "fmease", roles = ["part-time"] },
+    { github = "joboet", roles = ["maintainer-grant"] },
+    { github = "Jarcho", roles = ["maintainer-grant"] },
+]
 alumni = []
 
 [[roles]]
@@ -13,6 +20,10 @@ description = "Full-time Maintainer in Residence"
 [[roles]]
 id = "part-time"
 description = "Part-time Maintainer in Residence"
+
+[[roles]]
+id = "maintainer-grant"
+description = "Mantainer grantee"
 
 [permissions]
 dev-desktop = true

--- a/teams/maintainers-in-residence.toml
+++ b/teams/maintainers-in-residence.toml
@@ -31,9 +31,10 @@ dev-desktop = true
 [[github]]
 orgs = ["rust-lang"]
 
-[website]
-name = "Maintainer in Residence"
-description = "Rust maintainers sponsored by the Rust Foundation Maintainers Fund"
+# Temporarily commented out, before we announce the first MiR batch
+#[website]
+#name = "Maintainer in Residence"
+#description = "Rust maintainers sponsored by the Rust Foundation Maintainers Fund"
 
 [[zulip-groups]]
 name = "T-mir"


### PR DESCRIPTION
It would be useful for the MiRs and the funding team to have a shared Zulip channel for communicating about internal stuff (contracts, reporting, etc.), so I'm opening this PR to add the current MiRs to the team already.

Note that we haven't announced this publicly yet, so please don't share this information outside the Project yet (yes, this PR is public, and they will appear somewhere in the governance section of our website, but that's not really any kind of public announcement).

CC @rami3l @ChrisDenton @blyxyas @Jarcho @fmease @joboet

CC @rust-lang/funding