### PR TITLE
Add Tyler Mandry to funding advisors

### DIFF
--- a/teams/funding-advisors.toml
+++ b/teams/funding-advisors.toml
@@ -9,7 +9,8 @@ members = [
     "m-ou-se",
     "erikjee",
     "obi1kenobi",
-    "abibroom"
+    "abibroom",
+    "tmandry",
 ]
 alumni = []
 


### PR DESCRIPTION
Tyler represents Google as a funding partner, and wants to provide input for the funding team.

CC @tmandry

CC @rust-lang/funding