### PR TITLE
wg-allocators: bors try privileges

### DIFF
--- a/teams/wg-allocators.toml
+++ b/teams/wg-allocators.toml
@@ -25,6 +25,7 @@ alumni = [
 orgs = ["rust-lang"]
 
 [permissions]
+bors.rust.try = true
 perf = true
 
 [website]


### PR DESCRIPTION
I had intended to add this in #2658 but didn't notice perf doesn't also imply try ^^ necessary for perf to work.