### PR TITLE
fix rustwide release publish

### DIFF
--- a/repos/rust-lang/rustwide.toml
+++ b/repos/rust-lang/rustwide.toml
@@ -8,7 +8,8 @@ infra = "write"
 docs-rs = "write"
 
 [environments.publish]
-branches = ["main"]
+# Matches the `on:` rule of `release.yml`
+tags = ["*"]
 
 [[crates-io]]
 crates = ["rustwide"]


### PR DESCRIPTION
From what I understand, this is what's needed to fix the failure? 

- https://github.com/rust-lang/rustwide/actions/runs/31682741361 
- https://github.com/rust-lang/rustwide/blob/a3eecbc214a907f04ab4e0bd36708d323f660c8d/.github/workflows/release.yml 