### PR TITLE
Change default branch of `rust-clippy` to `main`

### DIFF
--- a/repos/rust-lang/rust-clippy.toml
+++ b/repos/rust-lang/rust-clippy.toml
@@ -14,7 +14,7 @@ clippy = "write"
 clippy-contributors = "triage"
 
 [[rulesets]]
-pattern = "master"
+pattern = "main"
 ci-checks = [
     "conclusion",
     "conclusion_dev",


### PR DESCRIPTION
Companion PR: https://github.com/rust-lang/rust-clippy/pull/17556
