### PR TITLE
Configure merge queue on the lang-team repo

### DIFF
--- a/repos/rust-lang/lang-team.toml
+++ b/repos/rust-lang/lang-team.toml
@@ -16,3 +16,12 @@ release = "maintain"
 
 [environments.github-pages]
 branches = ["gh-pages", "main"]
+
+[[rulesets]]
+pattern = "main"
+merge-queue = {
+  enabled = true,
+  method = "merge",
+  min-entries-to-merge-wait-minutes = 0,
+  check-response-timeout-minutes = 6
+}


### PR DESCRIPTION
This helps prevent breakage on main and helps with consistency of using merge commits.