### PR TITLE
Archive the `rustc-rayon` repository

### DIFF
--- a/repos/archive/rust-lang/rustc-rayon.toml
+++ b/repos/archive/rust-lang/rustc-rayon.toml
@@ -4,4 +4,3 @@ description = "Rayon: A data parallelism library for Rust"
 bots = []
 
 [access.teams]
-compiler = "write"


### PR DESCRIPTION
If I understand it correctly, it is no longer used.

CC @cuviper