### PR TITLE
Add teor to triage

### DIFF
--- a/teams/triage.toml
+++ b/teams/triage.toml
@@ -31,6 +31,7 @@ members = [
     "JayanAXHF",
     "cijiugechu",
     "JohnCSimon",
+    "teor2345",
 ]
 alumni = [
     "jieyouxu",


### PR DESCRIPTION
I'm a contractor for the Rust Foundation, and people have given my work a bunch of review time. So I'd like to give back by doing some triage.

I'm following the instructions in the [Onboarding section of Rust Forge](https://forge.rust-lang.org/onboarding.html#joining-wg-triage):
- I've DM'd @Dylan-DPC and they're fine with it
- This is the PR to add me to triage
- I've also read the [triage procedure](https://forge.rust-lang.org/release/triage-procedure.html)