### PR TITLE
Rename the default branch of `triagebot` to `main`

### DIFF
--- a/repos/rust-lang/triagebot.toml
+++ b/repos/rust-lang/triagebot.toml
@@ -9,6 +9,6 @@ infra = "maintain"
 triagebot = "maintain"
 
 [[rulesets]]
-pattern = "master"
+pattern = "main"
 ci-checks = ["ci"]
 merge-queue = { enabled = true }


### PR DESCRIPTION
Related PR: https://github.com/rust-lang/triagebot/pull/2484
