### PR TITLE
Add `theemathas` to cloud compute team

### DIFF
--- a/teams/cloud-compute.toml
+++ b/teams/cloud-compute.toml
@@ -28,6 +28,7 @@ members = [
     "teor2345",
     "Human9000-bit",
     "aDotInTheVoid",
+    "theemathas",
 ]
 
 alumni = [


### PR DESCRIPTION
The dev desktops would be helpful for, among other things, running `cargo-bisect-rustc` (which, when ran locally, often runs into some fastly issue that's geographically local)