### PR TITLE
Fix integration source links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ from all the supported services.
 
 [perf]: https://perf.rust-lang.org
 
-[perf-src]: https://github.com/rust-lang/rustc-perf/blob/master/site/src/server.rs
+[perf-src]: https://github.com/rust-lang/rustc-perf/blob/main/site/src/server.rs
 
 [rfcbot]: https://rfcbot.rs
 
-[rfcbot-src]: https://github.com/rust-lang/rfcbot-rs/blob/main/src/teams.rs
+[rfcbot-src]: https://github.com/rust-lang/rfcbot-rs/blob/master/src/teams.rs
 
 [sync-team-src]: src/sync
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ from all the supported services.
 
 [rfcbot]: https://rfcbot.rs
 
-[rfcbot-src]: https://github.com/rust-lang/rfcbot-rs/blob/master/src/teams.rs
+[rfcbot-src]: https://github.com/rust-lang/rfcbot-rs/blob/main/src/teams.rs
 
-[sync-team-src]: sync-team
+[sync-team-src]: src/sync
 
 [crates-io-admin-src]: https://github.com/rust-lang/crates.io/blob/main/src/worker/jobs/sync_admins.rs
 


### PR DESCRIPTION
This PR updates README.md to fix two broken/moved links:
- sync-team was renamed to src/sync (I think)
- ~~rfcbot's~~ perf's master branch was renamed to main

[Rendered README](https://github.com/teor2345/team/blob/patch-4/README.md)