### PR TITLE
feat: add `wg-build-script` working group

### DIFF
--- a/teams/wg-build-script.toml
+++ b/teams/wg-build-script.toml
@@ -1,0 +1,27 @@
+name = "wg-build-script"
+subteam-of = "cargo"
+kind = "working-group"
+
+[people]
+leads = ["celinval", "weihanglo"]
+members = [
+    "LawnGnome",
+    "NobodyXu",
+    "celinval",
+    "epage",
+    "joshtriplett",
+    "ranger-ross",
+    "weihanglo",
+]
+alumni = []
+
+[[github]]
+orgs = ["rust-lang"]
+
+[website]
+name = "Build Script Working Group"
+description = "Improving the security, determinism, and performance of Cargo build scripts"
+zulip-stream = "t-cargo/build-script"
+
+[[zulip-groups]]
+name = "WG-build-script"


### PR DESCRIPTION
We've discussed this on Zulip DMs and t-cargo meemting (see [note](https://github.com/rust-lang/cargo-team/blob/bfc106cb25acca505d6183634b90423f350e839b/meetings/sync-meeting/2026-08-11.md?plain=1#L113-L119) and we'd like to form a new working group to discuss about the issues and evolutions around Cargo's build scripts.

Initially we expect to focus on topics like security, build determinism, and build script performance (supply chain security being of particular interest to me). The scope of this working group can be expanded, shrunk, or split when needed.

The way of working is not yet decided. It will be the first topic on the new Zulip channel (expect on `#t-cargo/wg-build-script`)

cc @rust-lang/cargo @LawnGnome @NobodyXu @celinval 