### PR TITLE
use crabwatch in infra team repositories

### DIFF
--- a/repos/rust-lang/aws-runners-test.toml
+++ b/repos/rust-lang/aws-runners-test.toml
@@ -6,3 +6,6 @@ bots = []
 [access.teams]
 infra = "write"
 infra-admins = "maintain"
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -22,3 +22,6 @@ branches = ["main"]
 
 [environments.staging]
 branches = ["main"]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/calendar-generation.toml
+++ b/repos/rust-lang/calendar-generation.toml
@@ -17,3 +17,6 @@ wg-async = "write"
 
 [[rulesets]]
 pattern = "main"
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -25,3 +25,6 @@ pr-required = false
 
 [environments.github-pages]
 branches = ["main"]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/ci-mirrors.toml
+++ b/repos/rust-lang/ci-mirrors.toml
@@ -14,3 +14,6 @@ dismiss-stale-review = true
 merge-queue = { enabled = true, max-entries-to-build = 1, min-entries-to-merge-wait-minutes = 1, max-entries-to-merge = 15 }
 
 [environments.upload]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/crater.toml
+++ b/repos/rust-lang/crater.toml
@@ -12,3 +12,6 @@ pattern = "master"
 ci-checks = ["conclusion"]
 required-approvals = 0
 merge-queue = { enabled = true }
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/crates-build-env.toml
+++ b/repos/rust-lang/crates-build-env.toml
@@ -10,3 +10,6 @@ infra = "write"
 [[rulesets]]
 pattern = 'master'
 required-approvals = 0
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/crates-io-heroku-metrics.toml
+++ b/repos/rust-lang/crates-io-heroku-metrics.toml
@@ -5,3 +5,6 @@ bots = []
 
 [access.teams]
 infra = "write"
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/gha-self-hosted.toml
+++ b/repos/rust-lang/gha-self-hosted.toml
@@ -12,3 +12,6 @@ ci-checks = ["CI finished"]
 merge-queue = { enabled = true, max-entries-to-build = 1, min-entries-to-merge-wait-minutes = 1, max-entries-to-merge = 1 }
 
 [environments.upload]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/infra-smoke-tests.toml
+++ b/repos/rust-lang/infra-smoke-tests.toml
@@ -20,3 +20,6 @@ ci-checks = [
     "Lint YAML files",
     "Run tests",
 ]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/infra-team.toml
+++ b/repos/rust-lang/infra-team.toml
@@ -6,3 +6,6 @@ bots = []
 
 [access.teams]
 infra = "write"
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/josh-sync.toml
+++ b/repos/rust-lang/josh-sync.toml
@@ -11,3 +11,6 @@ infra = "write"
 pattern = "main"
 ci-checks = ["Test"]
 required-approvals = 0
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/monitorbot.toml
+++ b/repos/rust-lang/monitorbot.toml
@@ -5,3 +5,6 @@ bots = []
 
 [access.teams]
 infra = "write"
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/pontoon.toml
+++ b/repos/rust-lang/pontoon.toml
@@ -8,3 +8,5 @@ infra = "write"
 
 [environments.rust-pontoon]
 
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/promote-release.toml
+++ b/repos/rust-lang/promote-release.toml
@@ -18,3 +18,6 @@ ci-checks = [
 ]
 required-approvals = 0
 require-conversation-resolution = true
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/renovate.toml
+++ b/repos/rust-lang/renovate.toml
@@ -11,3 +11,6 @@ pattern = "main"
 ci-checks = ["Conclusion"]
 required-approvals = 0
 merge-queue = { enabled = true }
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -33,3 +33,6 @@ ci-checks = ["test"]
 
 [environments.github-pages]
 branches = ["main"]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/rust-log-analyzer.toml
+++ b/repos/rust-lang/rust-log-analyzer.toml
@@ -13,3 +13,5 @@ required-approvals = 0
 
 [environments.github-pages]
 
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/rust-playground.toml
+++ b/repos/rust-lang/rust-playground.toml
@@ -11,3 +11,6 @@ infra = "maintain"
 pattern = "main"
 ci-checks = []
 required-approvals = 0
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/rust-repos.toml
+++ b/repos/rust-lang/rust-repos.toml
@@ -5,3 +5,6 @@ bots = ["highfive"]
 
 [access.teams]
 infra = "write"
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -34,3 +34,6 @@ pattern = "master-old"
 prevent-update = true
 
 [environments.github-pages]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/rustup-components-history.toml
+++ b/repos/rust-lang/rustup-components-history.toml
@@ -13,3 +13,6 @@ path = "/"
 infra = "write"
 
 [environments.github-pages]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/rustwide.toml
+++ b/repos/rust-lang/rustwide.toml
@@ -15,3 +15,6 @@ tags = ["*"]
 crates = ["rustwide"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/simpleinfra.toml
+++ b/repos/rust-lang/simpleinfra.toml
@@ -10,3 +10,6 @@ infra = "write"
 pattern = "master"
 ci-checks = ["CI"]
 required-approvals = 0
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/thanks.toml
+++ b/repos/rust-lang/thanks.toml
@@ -18,3 +18,6 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["main"]
+
+[custom-properties]
+crabwatch = true

--- a/repos/rust-lang/triagebot.toml
+++ b/repos/rust-lang/triagebot.toml
@@ -12,3 +12,6 @@ triagebot = "maintain"
 pattern = "main"
 ci-checks = ["ci"]
 merge-queue = { enabled = true }
+
+[custom-properties]
+crabwatch = true


### PR DESCRIPTION
As asked in [#t-infra > crabwatch on infra repos @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/crabwatch.20on.20infra.20repos/near/616106850).
Let's run https://github.com/rust-lang/crabwatch/blob/main/.github/workflows/crabwatch.yml in all these repositories.