### PR TITLE
Replace Caleb with Yacin as rustfmt lead

### DIFF
--- a/teams/rustfmt.toml
+++ b/teams/rustfmt.toml
@@ -2,7 +2,7 @@ name = "rustfmt"
 subteam-of = "devtools"
 
 [people]
-leads = ["calebcartwright"]
+leads = ["ytmimi"]
 members = [
     "calebcartwright",
     "ytmimi",


### PR DESCRIPTION
(This has @calebcartwright's approval, but not yet from @ytmimi)

Caleb has been busy and harder to reach consistently. He's still planning on being around, but it seems prudent to have a more active lead.

We have some plans to grow the team too, but don't want to block this on that
