### PR TITLE
mailgun: enable mangling and syncing with subdomains

### DIFF
--- a/src/sync/mailgun/mod.rs
+++ b/src/sync/mailgun/mod.rs
@@ -15,6 +15,10 @@ const DESCRIPTION: &str = "managed by an automatic script on github";
 // Limit (in bytes) of the size of a Mailgun rule's actions list.
 const ACTIONS_SIZE_LIMIT_BYTES: usize = 4000;
 
+// Helper subdomain to use while we migrate lists from Mailgun
+// See https://github.com/rust-lang/infra-team/issues/297
+const MIGRATION_HELPER_SUBDOMAIN: &str = "legacy-lists";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct List {
     address: String,
@@ -74,17 +78,28 @@ fn mangle_lists(email_private_key: &str, lists: team_data::Lists) -> anyhow::Res
 }
 
 fn mangle_address(addr: &str) -> anyhow::Result<String> {
+    let Some((user, domain)) = addr.split_once('@') else {
+        bail!("the address `{addr}` doesn't have any '@'");
+    };
+
+    // A list defined directly under the legacy subdomain would be matched both
+    // by its own route and by the route of the list with the same name on the
+    // parent domain, delivering every message twice.
+    if domain.starts_with(&format!("{MIGRATION_HELPER_SUBDOMAIN}.")) {
+        bail!("the address `{addr}` is under the legacy migration subdomain");
+    }
+
     // Escape dots since they have a special meaning in Python regexes
-    let mangled = addr.replace('.', "\\.");
+    let user = user.replace('.', "\\.");
+    let domain = domain.replace('.', "\\.");
 
     // Inject (?:\+.+)? before the '@' in the address to support '+' aliases like
-    // infra+botname@rust-lang.org
-    if let Some(at_pos) = mangled.find('@') {
-        let (user, domain) = mangled.split_at(at_pos);
-        Ok(format!("^{user}(?:\\+.+)?{domain}$"))
-    } else {
-        bail!("the address `{}` doesn't have any '@'", addr);
-    }
+    // infra+botname@rust-lang.org, and accept the legacy subdomain so a single
+    // route serves both mail arriving directly at Mailgun and mail relayed by
+    // Google Workspace.
+    Ok(format!(
+        "^{user}(?:\\+.+)?@(?:{MIGRATION_HELPER_SUBDOMAIN}\\.)?{domain}$"
+    ))
 }
 
 pub(crate) async fn run(
@@ -223,11 +238,32 @@ mod tests {
 
     #[test]
     fn test_mangle_address() {
+        assert!(
+            mangle_address(&format!("list@{MIGRATION_HELPER_SUBDOMAIN}.example.com")).is_err(),
+            "a list under the migrated subdomain would be matched twice"
+        );
+
         assert_eq!(
-            r"^list-name(?:\+.+)?@example\.com$",
+            r"^list-name(?:\+.+)?@(?:legacy-lists\.)?example\.com$",
             mangle_address("list-name@example.com").unwrap()
         );
+
         assert!(mangle_address("list-name.example.com").is_err());
+        assert!(mangle_address("list@legacy-mail.example.com").is_ok());
+    }
+
+    #[test]
+    fn test_mangle_address_matching() {
+        let re = regex::Regex::new(&mangle_address("list@example.com").unwrap());
+
+        for addr in [
+            "list@example.com",
+            "list@legacy-lists.example.com",
+            "list+bot@example.com",
+            "list+bot@legacy-lists.example.com",
+        ] {
+            assert!(re.as_ref().unwrap().is_match(addr), "should match {addr}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## AI disclosure

I used Claude Code to get clarifications about these changes and deep search in the wild info on Mailgun's API rate limits.

---

Towards https://github.com/rust-lang/infra-team/issues/297

We tweak the mangling logic to handle a special subdomain we'll introduce to enable the migration (of lists provisioned by `team`) from Mailgun to Google Groups.

`sync` does not support dry-runs for Mailgun in CI, so I had to test these changes manually. 

```shell
echo "Preparing team static api"
cargo run --quiet static-api build
echo

echo "Dry-run changes against Mailgun"

MAILGUN_API_TOKEN=$(op read <path/to/secret>) \
EMAIL_PRIVATE_KEY=$(op read <path/to/secret>) \
  cargo run --quiet -- sync dry-run --services mailgun --src team-api
echo
```

A part of the output looks like this, I won't share it full since it'd disclose encrypted emails:

```
# .
# .
# previous output
#
[INFO  rust_team::sync::mailgun::api] deleting route with ID 5c5b479fa4764a000139448d
[INFO  rust_team::sync::mailgun::api] deleting route with ID 6321fe4584c515511ba78994
[INFO  rust_team::sync::mailgun::api] deleting route with ID 6321fe4565c9ab17d6be343e
[INFO  rust_team::sync::mailgun] creating list ^leah(?:\+.+)?@(?:legacy-lists\.)?rustconf\.com$
[INFO  rust_team::sync::mailgun] creating list ^infra-team(?:\+.+)?@(?:legacy-lists\.)?rust-lang\.org$
[INFO  rust_team::sync::mailgun] creating list ^community(?:\+.+)?@(?:legacy-lists\.)?rust-lang\.org$
[INFO  rust_team::sync::mailgun] creating list ^project-vision-doc-2025(?:\+.+)?@(?:legacy-lists\.)?rust-lang\.org$
#
# more output
# .
# .
```

This approach will delete and (re)create all 96 lists we currently have, rather than updating them in-place. This should be fine from the rate-limiting perspective for a single deploy (no official numbers, but 300 rpm mentioned on [issues like this](https://github.com/phillbaker/terraform-provider-mailgunv3/issues/15)). 

After lots of pain, I think this path worths compared with trying to update existing rules in-place and keeping guardrail checks to ensure consistency between the current and the new state (that was my first attempt). 

Happy to get input in case I missed something.