### PR TITLE
Add crates to the v1 API

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -441,6 +441,19 @@ pub struct People {
     pub people: IndexMap<String, Person>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Krate {
+    pub name: String,
+    /// Teams that have access to this crate.
+    pub teams: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Crates {
+    /// Crate name as key.
+    pub crates: IndexMap<String, Krate>,
+}
+
 fn is_branch_target(target: &ProtectionTarget) -> bool {
     matches!(target, ProtectionTarget::Branch)
 }

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 use log::info;
 use rust_team_data::v1;
 use rust_team_data::v1::{
-    BranchProtectionMode, Crate, CrateTeamOwner, GoogleWorkspace, RepoMember,
+    BranchProtectionMode, Crate, CrateTeamOwner, GoogleWorkspace, Krate, RepoMember,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -36,6 +36,7 @@ impl<'a> Generator<'a> {
         self.generate_rfcbot()?;
         self.generate_zulip_map()?;
         self.generate_people()?;
+        self.generate_crates()?;
         self.generate_index_html()?;
         Ok(())
     }
@@ -473,6 +474,31 @@ impl<'a> Generator<'a> {
         people.sort_keys();
 
         self.add("v1/people.json", &v1::People { people })?;
+
+        Ok(())
+    }
+
+    fn generate_crates(&self) -> Result<(), Error> {
+        let mut crates = IndexMap::new();
+
+        for repo in self.data.repos() {
+            for crates_io_conf in &repo.crates_io {
+                // Note: validation should check that crates are unique
+                for krate in &crates_io_conf.crates {
+                    crates.insert(
+                        krate.clone(),
+                        Krate {
+                            name: krate.clone(),
+                            teams: crates_io_conf.teams.clone(),
+                        },
+                    );
+                }
+            }
+        }
+
+        crates.sort_by(|k1, _, k2, _| k1.cmp(k2));
+
+        self.add("v1/crates.json", &v1::Crates { crates })?;
 
         Ok(())
     }

--- a/tests/static-api/_expected/v1/crates.json
+++ b/tests/static-api/_expected/v1/crates.json
@@ -1,0 +1,16 @@
+{
+  "crates": {
+    "my-crate": {
+      "name": "my-crate",
+      "teams": [
+        "foo"
+      ]
+    },
+    "my-crate-2": {
+      "name": "my-crate-2",
+      "teams": [
+        "foo"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I'm working on implementing yanking/unyanking via triagebot on Zulip. For that, it needs to have access to which teams own what crates.

This could probably be made more forward-compatible, but we don't yet know which information about crates we will need, and the only consumer for now should be triagebot, so should be fine.
