### PR TITLE
Track Cargo crates

### DIFF
--- a/repos/rust-lang/cargo.toml
+++ b/repos/rust-lang/cargo.toml
@@ -28,6 +28,29 @@ pr-required = false
 bypass-apps = ["promote-release"]
 prevent-update = true
 
+[[crates-io]]
+crates = [
+    "build-rs",
+    "cargo",
+    "cargo-credential",
+    "cargo-credential-1password",
+    "cargo-credential-gnome-secret",
+    "cargo-credential-libsecret",
+    "cargo-credential-macos-keychain",
+    "cargo-credential-wincred",
+    "cargo-platform",
+    "cargo-test-macro",
+    "cargo-test-support",
+    "cargo-util",
+    "cargo-util-schemas",
+    "cargo-util-terminal",
+    "crates-io",
+    "home",
+    "rustfix",
+]
+publish-workflow = "release.yml"
+publish-environment = "release"
+
 [environments.github-pages]
 
 [environments.release]


### PR DESCRIPTION
Those should be the crates that use `rust-lang/cargo` as their repository, unless I missed some.

Marking as draft, because we first need to make trusted publishing work for them (https://github.com/rust-lang/cargo/pull/17426).
