### PR TITLE
assign on-call team to the right crates-io-admins team

### DIFF
--- a/teams/crates-io-admins.toml
+++ b/teams/crates-io-admins.toml
@@ -7,4 +7,4 @@ kind = "marker-team"
 [people]
 leads = []
 members = []
-included-teams = ["crates-io"]
+included-teams = ["crates-io", "crates-io-on-call"]

--- a/teams/crates-io-infra-admins.toml
+++ b/teams/crates-io-infra-admins.toml
@@ -12,7 +12,6 @@ members = [
     "Turbo87",
     "LawnGnome",
 ]
-included-teams = ["crates-io-on-call"]
 
 [[github]]
 orgs = ["rust-lang"]


### PR DESCRIPTION
https://github.com/rust-lang/team/pull/2718#issuecomment-5517608921