### PR TITLE
Point the `funding@rust-lang.org` e-mail list to the funding team

### DIFF
--- a/teams/funding.toml
+++ b/teams/funding.toml
@@ -43,10 +43,6 @@ extra-people = [
 
 [[lists]]
 address = "funding@rust-lang.org"
-extra-teams = ["funding-advisors"]
-
-[[lists]]
-address = "funding-private@rust-lang.org"
 
 [[lists]]
 address = "hiring@rust-lang.org"


### PR DESCRIPTION
CC @rust-lang/funding