### PR TITLE
rustc_apfloat: Enable rulesets for `main`

### DIFF
--- a/repos/rust-lang/rustc_apfloat.toml
+++ b/repos/rust-lang/rustc_apfloat.toml
@@ -10,5 +10,6 @@ bots = ["rustbot", "rfcbot"]
 [access.teams]
 compiler = 'maintain'
 
-# Likewise, eventually we may want a branch protections section, but we will
-# tackle that later.
+[[rulesets]]
+pattern = "main"
+pr-required = false


### PR DESCRIPTION
Add a basic setup that that prevents destructive operations (force pushes and branch deletion).