### PR TITLE
nominate matthewhughes934 to join rustfmt-contributors

### DIFF
--- a/people/matthewhughes934.toml
+++ b/people/matthewhughes934.toml
@@ -1,0 +1,5 @@
+name = "Matthew Hughes"
+github = "matthewhughes934"
+github-id = 34972397
+email = 'matthewhughes934@gmail.com'
+zulip-id = 937278

--- a/teams/rustfmt-contributors.toml
+++ b/teams/rustfmt-contributors.toml
@@ -9,6 +9,7 @@ members = [
     "camsteffen",
     "jieyouxu",
     "estebank",
+    "matthewhughes934",
 ]
 alumni = []
 


### PR DESCRIPTION
@matthewhughes934 has been getting involved and helping out on rustfmt a lot recently so I'm happy to invite them to join the @rust-lang/rustfmt-contributors team.

Welcome! 🎉