### PR TITLE
make marco infra team leader

### DIFF
--- a/teams/infra.toml
+++ b/teams/infra.toml
@@ -2,7 +2,7 @@ name = "infra"
 top-level = true
 
 [people]
-leads = ["shepmaster", "jdno"]
+leads = ["shepmaster", "marcoieni"]
 members = [
     "Mark-Simulacrum",
     "emilyalbini",


### PR DESCRIPTION
According to the infra team [team-lead policy](https://github.com/rust-lang/infra-team/blob/main/about/team-leads.md), one of the two team leaders should be a Rust Foundation employee.

JD said he would like to step down as leader in zulip ([#t-infra > Team lead refresh @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Team.20lead.20refresh/near/622282383)).

Me and @ubiratansoares are the only Rust Foundation employee in the infrastructure team.

I would like to propose myself as the next infra team leader. I talked with Ubi and he supports my nomination.