### PR TITLE
Remove `jieyouxu` from the `rustfmt-contributors` subteam

### DIFF
--- a/teams/rustfmt-contributors.toml
+++ b/teams/rustfmt-contributors.toml
@@ -7,7 +7,6 @@ members = [
     "Manishearth",
     "fee1-dead",
     "camsteffen",
-    "jieyouxu",
     "estebank",
     "matthewhughes934",
 ]


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/team/pull/2739, I completely forgot about the contributors subteam split after compiler/libs got rid of `-contributors` subteams lol.

cc @ytmimi 