### PR TITLE
Assign owner teams to crates.io crates

### DIFF
--- a/repos/rust-lang/annotate-snippets-rs.toml
+++ b/repos/rust-lang/annotate-snippets-rs.toml
@@ -16,5 +16,6 @@ required-approvals = 0
 crates = ["annotate-snippets"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
+teams = ["cargo"]
 
 [environments.publish]

--- a/repos/rust-lang/ar_archive_writer.toml
+++ b/repos/rust-lang/ar_archive_writer.toml
@@ -14,3 +14,4 @@ tags = ["*"]
 crates = ["ar_archive_writer"]
 publish-workflow = "publish.yml"
 publish-environment = "publish"
+teams = ["compiler"]

--- a/repos/rust-lang/cc-rs.toml
+++ b/repos/rust-lang/cc-rs.toml
@@ -16,9 +16,9 @@ ci-checks = ['Tests pass']
 crates = ["cc", "find-msvc-tools"]
 publish-workflow = "publish.yml"
 publish-environment = "publish"
+teams = ["crate-maintainers"]
 
 [environments.github-pages]
 
 [environments.publish]
 branches = ["main"]
-

--- a/repos/rust-lang/compiler-builtins.toml
+++ b/repos/rust-lang/compiler-builtins.toml
@@ -21,3 +21,4 @@ branches = ["main"]
 crates = ["libm"]
 publish-workflow = "publish.yaml"
 publish-environment = "publish"
+teams = ["crate-maintainers"]

--- a/repos/rust-lang/crates_io_og_image.toml
+++ b/repos/rust-lang/crates_io_og_image.toml
@@ -18,3 +18,4 @@ pr-required = false
 crates = ["crates_io_og_image"]
 publish-workflow = "release.yml"
 publish-environment = "release"
+teams = ["crates-io"]

--- a/repos/rust-lang/docs.rs.toml
+++ b/repos/rust-lang/docs.rs.toml
@@ -33,6 +33,7 @@ crates = [
 ]
 publish-workflow = "release.yml"
 publish-environment = "publish"
+teams = ["docs-rs"]
 
 [pages]
 build-type = "workflow"

--- a/repos/rust-lang/libc.toml
+++ b/repos/rust-lang/libc.toml
@@ -33,6 +33,7 @@ require-linear-history = true
 crates = ["libc", "ctest"]
 publish-workflow = "release.yaml"
 publish-environment = "release"
+teams = ["crate-maintainers"]
 
 [environments.github-pages]
 branches = ["gh-pages", "main", "master"]

--- a/repos/rust-lang/mdBook.toml
+++ b/repos/rust-lang/mdBook.toml
@@ -31,6 +31,7 @@ crates = [
 ]
 publish-workflow = "publish-crates-io.yml"
 publish-environment = "publish"
+teams = ["mdbook"]
 
 [environments.github-pages]
 

--- a/repos/rust-lang/measureme.toml
+++ b/repos/rust-lang/measureme.toml
@@ -19,6 +19,7 @@ ci-checks = ["success"]
 crates = ["analyzeme", "decodeme", "measureme"]
 publish-workflow = "publish.yml"
 publish-environment = "publish"
+teams = ["compiler"]
 
 [environments.publish]
 branches = ["master"]

--- a/repos/rust-lang/rustdoc-types.toml
+++ b/repos/rust-lang/rustdoc-types.toml
@@ -15,3 +15,4 @@ tags = ["v*"]
 crates = ["rustdoc-types"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
+teams = ["rustdoc"]

--- a/repos/rust-lang/rustwide.toml
+++ b/repos/rust-lang/rustwide.toml
@@ -15,6 +15,7 @@ tags = ["*"]
 crates = ["rustwide"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
+teams = ["infra", "docs-rs"]
 
 [custom-properties]
 crabwatch = true


### PR DESCRIPTION
In preparation for https://github.com/rust-lang/team/pull/2726, this PR assigns owner teams to all crates.io crates currently recorded in the `team` DB. I assigned mostly the teams that had access to the repo from where the crate is published.