### PR TITLE
Force team ownership of crates

### DIFF
--- a/rust_team_data/src/v1.rs
+++ b/rust_team_data/src/v1.rs
@@ -280,9 +280,14 @@ pub struct CrateTeamOwner {
 pub struct Crate {
     pub name: String,
     pub crates_io_publishing: Option<CratesIoPublishing>,
+    #[serde(default = "default_true")]
     pub trusted_publishing_only: bool,
     /// GitHub teams that have access to this crate on crates.io
     pub teams: Vec<CrateTeamOwner>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1082,9 +1082,6 @@ pub(crate) struct CratesIoConfiguration {
     pub workflow_filename: String,
     #[serde(rename = "publish-environment")]
     pub environment: String,
-    #[serde(default = "default_true")]
-    pub disable_other_publish_methods: bool,
-    #[serde(default)]
     pub teams: Vec<String>,
 }
 

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -197,7 +197,7 @@ impl<'a> Generator<'a> {
                                         workflow_file: p.workflow_filename.clone(),
                                         environment: p.environment.clone(),
                                     }),
-                                    trusted_publishing_only: p.disable_other_publish_methods,
+                                    trusted_publishing_only: true,
                                     teams: team_owners,
                                 })
                             })

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1421,12 +1421,13 @@ fn validate_trusted_publishing(data: &Data, errors: &mut Vec<String>) {
                 }
             }
 
-            if !publishing.teams.is_empty() && !publishing.disable_other_publish_methods {
+            if publishing.teams.is_empty() {
                 return Err(anyhow::anyhow!(
-                    "Repository `{repo_name}` configures crates.io access for team(s) `{}` while setting `disable-other-publish-methods = false`. Either remove the team access or set it to `true`.",
-                    publishing.teams.join(", ")
+                    "Repository `{repo_name}` has no owner teams for crates `{}`. Each crate must be owned at least by a single team.",
+                    publishing.crates.join(", ")
                 ));
             }
+
             for team in &publishing.teams {
                 let Some(team) = data.team(team) else {
                     return Err(anyhow::anyhow!(


### PR DESCRIPTION
This PR makes team ownership of each tracked crate mandatory, and also makes trusted publishing mandatory for tracked crates (all currently tracked crates had it mandatory anyway).

This allows us to ensure that every crate we track is owned only by `rust-lang-owner` on crates.io, but also has some Rust team that can do yanking/unyanking on Zulip. It also ensures that everything we track is published from CI using trusted publishing.
Over time we can backport the existing crates, until we have all of them in the `team` DB.

I made the trusted publishing field in the v1 data scheme optional, in preparation for removing it later.