### PR TITLE
Set compiler team as co-owners of `annotate-snippets`

### DIFF
--- a/repos/rust-lang/annotate-snippets-rs.toml
+++ b/repos/rust-lang/annotate-snippets-rs.toml
@@ -5,6 +5,7 @@ bots = ["renovate"]
 
 [access.teams]
 cargo = "write"
+compiler = "write"
 wg-diagnostics = "write"
 
 [[rulesets]]
@@ -16,6 +17,6 @@ required-approvals = 0
 crates = ["annotate-snippets"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
-teams = ["cargo"]
+teams = ["cargo", "compiler"]
 
 [environments.publish]


### PR DESCRIPTION
Per the discussion in https://github.com/rust-lang/team/pull/2742#discussion_r3976262097.

CC @Muscraft