### PR TITLE
enable crabwatch on all repositories except rust

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,11 @@ independent-github-orgs = [
     "rust-embedded",
 ]
 
+# Crabwatch is enabled for all non-archived repositories except those listed here.
+crabwatch-deny-list = [
+    "rust-lang/rust",
+]
+
 permissions-bors-repos = [
     "bors-kindergarten",
     "rust",

--- a/docs/toml-schema.md
+++ b/docs/toml-schema.md
@@ -584,12 +584,17 @@ String, boolean, and string array values are supported.
 # Repository custom properties (optional)
 [custom-properties]
 # Set a property name to a boolean value
-crabwatch = true
+example-flag = true
 # Or set a text-type property to a string value
 status = "active"
 # Or set a multi-select property to a list of string values
 colors = ["red", "green"]
 ```
+
+By default, `team` sets the `crabwatch` custom property to `true` for all non-archived repositories in the `rust-lang` organization.
+This enables the [Crabwatch](https://github.com/rust-lang/crabwatch) GitHub Action.
+
+If you want to disable Crabwatch in a repository, add it to the `crabwatch-deny-list` in the root `config.toml`.
 
 Properties set on GitHub but not declared here are removed.
 

--- a/repos/rust-lang/aws-runners-test.toml
+++ b/repos/rust-lang/aws-runners-test.toml
@@ -6,6 +6,3 @@ bots = []
 [access.teams]
 infra = "write"
 infra-admins = "maintain"
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/bors.toml
+++ b/repos/rust-lang/bors.toml
@@ -22,6 +22,3 @@ branches = ["main"]
 
 [environments.staging]
 branches = ["main"]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/calendar-generation.toml
+++ b/repos/rust-lang/calendar-generation.toml
@@ -17,6 +17,3 @@ wg-async = "write"
 
 [[rulesets]]
 pattern = "main"
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/calendar.toml
+++ b/repos/rust-lang/calendar.toml
@@ -25,6 +25,3 @@ pr-required = false
 
 [environments.github-pages]
 branches = ["main"]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/ci-mirrors.toml
+++ b/repos/rust-lang/ci-mirrors.toml
@@ -14,6 +14,3 @@ dismiss-stale-review = true
 merge-queue = { enabled = true, max-entries-to-build = 1, min-entries-to-merge-wait-minutes = 1, max-entries-to-merge = 15 }
 
 [environments.upload]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/crabwatch.toml
+++ b/repos/rust-lang/crabwatch.toml
@@ -10,6 +10,3 @@ infra = "write"
 pattern = "main"
 ci-checks = ["CI"]
 required-approvals = 0
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/crater.toml
+++ b/repos/rust-lang/crater.toml
@@ -12,6 +12,3 @@ pattern = "master"
 ci-checks = ["conclusion"]
 required-approvals = 0
 merge-queue = { enabled = true }
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/crates-build-env.toml
+++ b/repos/rust-lang/crates-build-env.toml
@@ -10,6 +10,3 @@ infra = "write"
 [[rulesets]]
 pattern = 'master'
 required-approvals = 0
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/crates-io-auth-action.toml
+++ b/repos/rust-lang/crates-io-auth-action.toml
@@ -13,6 +13,3 @@ pattern = "main"
 ci-checks = ["Conclusion"]
 required-approvals = 0
 merge-queue = { enabled = true }
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/crates-io-heroku-metrics.toml
+++ b/repos/rust-lang/crates-io-heroku-metrics.toml
@@ -5,6 +5,3 @@ bots = []
 
 [access.teams]
 infra = "write"
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/gha-self-hosted.toml
+++ b/repos/rust-lang/gha-self-hosted.toml
@@ -12,6 +12,3 @@ ci-checks = ["CI finished"]
 merge-queue = { enabled = true, max-entries-to-build = 1, min-entries-to-merge-wait-minutes = 1, max-entries-to-merge = 1 }
 
 [environments.upload]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/infra-smoke-tests.toml
+++ b/repos/rust-lang/infra-smoke-tests.toml
@@ -20,6 +20,3 @@ ci-checks = [
     "Lint YAML files",
     "Run tests",
 ]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/infra-team.toml
+++ b/repos/rust-lang/infra-team.toml
@@ -6,6 +6,3 @@ bots = []
 
 [access.teams]
 infra = "write"
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/josh-sync.toml
+++ b/repos/rust-lang/josh-sync.toml
@@ -11,6 +11,3 @@ infra = "write"
 pattern = "main"
 ci-checks = ["Test"]
 required-approvals = 0
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/monitorbot.toml
+++ b/repos/rust-lang/monitorbot.toml
@@ -5,6 +5,3 @@ bots = []
 
 [access.teams]
 infra = "write"
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/pontoon.toml
+++ b/repos/rust-lang/pontoon.toml
@@ -7,6 +7,3 @@ bots = []
 infra = "write"
 
 [environments.rust-pontoon]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/promote-release.toml
+++ b/repos/rust-lang/promote-release.toml
@@ -18,6 +18,3 @@ ci-checks = [
 ]
 required-approvals = 0
 require-conversation-resolution = true
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/renovate.toml
+++ b/repos/rust-lang/renovate.toml
@@ -11,6 +11,3 @@ pattern = "main"
 ci-checks = ["Conclusion"]
 required-approvals = 0
 merge-queue = { enabled = true }
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/rust-forge.toml
+++ b/repos/rust-lang/rust-forge.toml
@@ -33,6 +33,3 @@ ci-checks = ["test"]
 
 [environments.github-pages]
 branches = ["main"]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/rust-log-analyzer.toml
+++ b/repos/rust-lang/rust-log-analyzer.toml
@@ -12,6 +12,3 @@ ci-checks = ["CI"]
 required-approvals = 0
 
 [environments.github-pages]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/rust-playground.toml
+++ b/repos/rust-lang/rust-playground.toml
@@ -11,6 +11,3 @@ infra = "maintain"
 pattern = "main"
 ci-checks = []
 required-approvals = 0
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/rust-repos.toml
+++ b/repos/rust-lang/rust-repos.toml
@@ -5,6 +5,3 @@ bots = ["highfive"]
 
 [access.teams]
 infra = "write"
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/rustc-dev-guide.toml
+++ b/repos/rust-lang/rustc-dev-guide.toml
@@ -34,6 +34,3 @@ pattern = "master-old"
 prevent-update = true
 
 [environments.github-pages]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/rustup-components-history.toml
+++ b/repos/rust-lang/rustup-components-history.toml
@@ -13,6 +13,3 @@ path = "/"
 infra = "write"
 
 [environments.github-pages]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/rustwide.toml
+++ b/repos/rust-lang/rustwide.toml
@@ -16,6 +16,3 @@ crates = ["rustwide"]
 publish-workflow = "release.yml"
 publish-environment = "publish"
 teams = ["infra", "docs-rs"]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/simpleinfra.toml
+++ b/repos/rust-lang/simpleinfra.toml
@@ -10,6 +10,3 @@ infra = "write"
 pattern = "master"
 ci-checks = ["CI"]
 required-approvals = 0
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/thanks.toml
+++ b/repos/rust-lang/thanks.toml
@@ -18,6 +18,3 @@ required-approvals = 0
 
 [environments.github-pages]
 branches = ["main"]
-
-[custom-properties]
-crabwatch = true

--- a/repos/rust-lang/triagebot.toml
+++ b/repos/rust-lang/triagebot.toml
@@ -12,6 +12,3 @@ triagebot = "maintain"
 pattern = "main"
 ci-checks = ["ci"]
 merge-queue = { enabled = true }
-
-[custom-properties]
-crabwatch = true

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -11,6 +11,7 @@ pub(crate) struct Config {
     allowed_mailing_lists_domains: HashSet<String>,
     allowed_github_orgs: HashSet<String>,
     independent_github_orgs: BTreeSet<String>,
+    crabwatch_deny_list: HashSet<String>,
     permissions_bors_repos: HashSet<String>,
     permissions_bools: HashSet<String>,
     // Use a BTreeSet for consistent ordering in tests
@@ -37,6 +38,10 @@ impl Config {
 
     pub(crate) fn independent_github_orgs(&self) -> &BTreeSet<String> {
         &self.independent_github_orgs
+    }
+
+    pub(crate) fn crabwatch_deny_list(&self) -> &HashSet<String> {
+        &self.crabwatch_deny_list
     }
 
     pub(crate) fn special_org_members(&self) -> &BTreeSet<String> {

--- a/src/static_api.rs
+++ b/src/static_api.rs
@@ -224,11 +224,22 @@ impl<'a> Generator<'a> {
                 pages: convert_pages(r)?,
                 archived,
                 auto_merge_enabled: !managed_by_bors,
-                custom_properties: r
-                    .custom_properties
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect(),
+                custom_properties: {
+                    let mut properties = r.custom_properties.clone();
+                    if r.org != "rust-lang"
+                        || archived
+                        || self
+                            .data
+                            .config()
+                            .crabwatch_deny_list()
+                            .contains(&format!("{}/{}", r.org, r.name))
+                    {
+                        properties.remove("crabwatch");
+                    } else {
+                        properties.insert("crabwatch".to_string(), true.into());
+                    }
+                    properties.into_iter().collect()
+                },
             };
 
             self.add(&format!("v1/repos/{}.json", r.name), &repo)?;

--- a/tests/static-api/_expected/v1/repos.json
+++ b/tests/static-api/_expected/v1/repos.json
@@ -147,7 +147,6 @@
           "red",
           "green"
         ],
-        "crabwatch": true,
         "status": "active"
       }
     }

--- a/tests/static-api/_expected/v1/repos/some_repo.json
+++ b/tests/static-api/_expected/v1/repos/some_repo.json
@@ -105,7 +105,6 @@
       "red",
       "green"
     ],
-    "crabwatch": true,
     "status": "active"
   }
 }

--- a/tests/static-api/config.toml
+++ b/tests/static-api/config.toml
@@ -10,6 +10,10 @@ independent-github-orgs = [
     "org-independent",
 ]
 
+crabwatch-deny-list = [
+    "test-org/some_repo",
+]
+
 permissions-bors-repos = [
     "crates-io",
     "crater",

--- a/tests/static-api/repos/test-org/some_repo.toml
+++ b/tests/static-api/repos/test-org/some_repo.toml
@@ -21,7 +21,6 @@ bypass-apps = ["promote-release"]
 branches = ["main"]
 
 [custom-properties]
-crabwatch = true
 status = "active"
 colors = ["red", "green"]
 


### PR DESCRIPTION
As discussed in [#t-infra > crabwatch on infra repos](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/crabwatch.20on.20infra.20repos/with/620361183), crabwatch seems to work well, so now we want to enable it for more repositories.

before merging:
- [x] announce this change in `t-infra/announcements` because people might need to trigger CI by pushing a commit in order to get this job running (and therefore their PR can be merged).
- [x] verify `GITHUB_TOKEN=$(gh auth token) cargo run -- analyze --org rust-lang` works without errors in the crabwatch repo.

## Alternative

Another approach is to:
* run crabwatch on all repositories (i.e. with `crabwatch = true` or where `crabwatch` is undefined)
* don't run crabwatch in repositories where `crabwatch = false`.

This approach has the pro that we don't set the crabwatch repository everywhere.
I guess it doesn't change much, but if the reviewer has a preference we can change the ruleset rule.

## AI disclosure

I used GPT6-Astra with the codex harness to generate this change.