### PR TITLE
archive the chalk repository

### DIFF
--- a/repos/archive/rust-lang/chalk.toml
+++ b/repos/archive/rust-lang/chalk.toml
@@ -10,6 +10,5 @@ branch = "gh-pages"
 path = "/"
 
 [access.teams]
-types = "write"
 
 [environments.github-pages]


### PR DESCRIPTION
The readme of this repository says:

> The Chalk project has been sunset in favor of the newer next-generation trait solver

Can we archive it?
So that we don't have to worry about CI security. E.g. see https://github.com/rust-lang/chalk/pull/834


I asked the types team in [#t-types > archive chalk](https://rust-lang.zulipchat.com/#narrow/channel/144729-t-types/topic/archive.20chalk/with/623621965).